### PR TITLE
fix: epoch-close wait hangs when boundary output drains a parked batch

### DIFF
--- a/crates/middleware/orchestrator/src/epoch_manager/core.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/core.rs
@@ -1157,11 +1157,13 @@ where
         Err(eyre::eyre!("consensus output channel closed before epoch boundary"))
     }
 
-    /// Wait for the engine to execute the epoch-closing block.
+    /// Wait for the engine to execute the epoch-closing boundary output.
     ///
-    /// This sends the boundary output to the engine and waits for the execution
-    /// result identified by `target_hash` in the block's `parent_beacon_block_root`.
-    /// Consensus shutdown must already be complete before calling this.
+    /// Sends the boundary output to the engine, then subscribes to the `executed_anchor` watch and
+    /// waits until `anchor.number >= boundary_output.number` — a monotonic, drop-free completion
+    /// signal, immune to which block ends up the canonical tip (e.g. a drained parked batch, whose
+    /// block anchors to a previous output). `target_hash` is used only for diagnostics, not
+    /// matching. Consensus shutdown must already be complete before calling this.
     pub(super) async fn await_epoch_execution(
         &self,
         engine: &ExecutionNode,

--- a/crates/middleware/orchestrator/src/epoch_manager/core.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/core.rs
@@ -24,10 +24,10 @@ use rayls_execution_evm::{reth_env::RethEnv, system_calls::EpochState};
 use rayls_infrastructure_config::{KeyConfig, LibP2pConfig, NetworkConfig, RaylsDirs};
 use rayls_infrastructure_storage::{tables::ConsensusBlocks, EpochStore as _};
 use rayls_infrastructure_types::{
-    error::HeaderError, gas_accumulator::GasAccumulator, BlockNumHash, BlsAggregateSignature,
-    BlsPublicKey, BlsSignature, CameFrom, ConsensusOutput, Database as ReDatabase, Epoch,
-    EpochCertificate, EpochRecord, EpochVote, Noticer, Notifier, RaylsReceiver, RaylsSender,
-    TaskJoinError, TaskKind, TaskManager, VotesAggregator, B256,
+    error::HeaderError, gas_accumulator::GasAccumulator, BlsAggregateSignature, BlsPublicKey,
+    BlsSignature, CameFrom, ConsensusOutput, Database as ReDatabase, Epoch, EpochCertificate,
+    EpochRecord, EpochVote, Noticer, Notifier, RaylsReceiver, RaylsSender, TaskJoinError, TaskKind,
+    TaskManager, VotesAggregator, B256,
 };
 use rayls_middleware_processor::{batch::BatchOrdering, reconstruct_batch_digests};
 use std::{
@@ -36,7 +36,6 @@ use std::{
     time::Duration,
 };
 use tokio::sync::{mpsc, oneshot, watch};
-use tokio_stream::StreamExt;
 use tracing::{debug, error, info, warn};
 
 /// Number of recent EVM blocks scanned to recover the restart execution anchor.
@@ -1170,61 +1169,52 @@ where
         boundary_output: ConsensusOutput,
         gas_accumulator: &GasAccumulator,
         target_hash: B256,
-    ) -> eyre::Result<BlockNumHash> {
-        // subscribe to engine blocks to confirm epoch closed on-chain
-        let mut executed_output = engine.canonical_block_stream().await;
+    ) -> eyre::Result<()> {
+        // Anchor on execution PROGRESS (the boundary output's number), NOT on a block's
+        // `parent_beacon_block_root`. The engine advances `executed_anchor` to each output's own
+        // consensus header as it finishes executing it, so `anchor.number >= boundary.number` is an
+        // unambiguous, monotonic completion signal. Matching a block's beacon instead fails when
+        // the boundary output drains a previously-parked batch: that block lands as the
+        // canonical tip but anchors to its ORIGIN output, so the tip's beacon never equals
+        // `target_hash` and the old loop timed out (network-wide) even though the output
+        // HAD executed. `executed_anchor` is a `watch`, so it also can't silently drop like
+        // the canonical broadcast stream.
+        let boundary_number = boundary_output.number;
+
+        // Subscribe BEFORE sending so we cannot miss the anchor update for the boundary output.
+        let mut anchor_rx = self.consensus_bus.executed_anchor().subscribe();
 
         // send the boundary output to the engine for execution
         to_engine.send((CameFrom::AwaitEpochExecution, boundary_output)).await?;
 
-        let latest = self.consensus_bus.recent_blocks().borrow().latest_block();
-        // DIAGNOSTIC: what did the one-shot fast-path see, and does it match target_hash?
-        info!(
-            target: "epoch-manager",
-            latest_number = latest.number,
-            latest_parent_beacon = ?latest.parent_beacon_block_root,
-            ?target_hash,
-            matched = latest.parent_beacon_block_root == Some(target_hash),
-            "await_epoch_execution: initial latest check"
-        );
-        // If we have already caught up execution then we are good, skip below loop.
-        if latest.parent_beacon_block_root == Some(target_hash) {
-            self.adjust_base_fees(gas_accumulator, latest.number);
-            gas_accumulator.clear();
-            return Ok(latest.num_hash());
-        }
-
-        // wait for execution result before proceeding
-        while let Some(output) = executed_output.next().await {
-            // DIAGNOSTIC: log every canon notification this subscription receives, so a stall
-            // (no log before the 180s timeout) is distinguishable from a mis-match (logged but
-            // parent_beacon != target_hash / tip is not the boundary block).
-            let tip_hdr = output.tip().sealed_header();
+        loop {
+            let anchor_number = anchor_rx.borrow_and_update().number;
             info!(
                 target: "epoch-manager",
-                tip = ?output.tip().num_hash(),
-                tip_parent_beacon = ?tip_hdr.parent_beacon_block_root,
+                anchor_number,
+                boundary_number,
                 ?target_hash,
-                matched = tip_hdr.parent_beacon_block_root == Some(target_hash),
-                "await_epoch_execution: received canon notification"
+                reached = anchor_number >= boundary_number,
+                "await_epoch_execution: executed-anchor check"
             );
-            if output.tip().sealed_header().parent_beacon_block_root == Some(target_hash) {
-                // Ensure recent_blocks reflects the epoch-closing block.
-                let tip_number = output.tip().sealed_header().number;
-                self.consensus_bus
-                    .recent_blocks()
-                    .send_modify(|blocks| blocks.push_latest(output.tip().clone_sealed_header()));
+            // Boundary output (and everything before it) has executed.
+            if anchor_number >= boundary_number {
+                // adjust base fees against the resulting EVM tip, then clear the accumulator.
+                let tip_number = engine.get_reth_env().await.canonical_tip().number;
                 self.adjust_base_fees(gas_accumulator, tip_number);
                 gas_accumulator.clear();
-                return Ok(output.tip().num_hash());
+                return Ok(());
+            }
+            // Wait for the next anchor advance. An error means the sender was dropped — the engine
+            // task is gone, so execution can never complete.
+            if anchor_rx.changed().await.is_err() {
+                error!(
+                    target: "epoch-manager",
+                    "executed_anchor sender dropped while awaiting engine execution for closing epoch",
+                );
+                return Err(eyre!("engine failed to report execution for closing epoch"));
             }
         }
-
-        error!(
-            target: "epoch-manager",
-            "canon state notifications dropped while awaiting engine execution for closing epoch",
-        );
-        Err(eyre!("engine failed to report output for closing epoch"))
     }
 }
 

--- a/crates/middleware/orchestrator/src/epoch_manager/state.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/state.rs
@@ -145,9 +145,12 @@ where
             }
             prev.digest()
         };
-        // Use deterministic sources: boundary_consensus_hash from the boundary
-        // output (immutable) and recent_blocks (stable after flush).
-        let parent_state = self.consensus_bus.recent_blocks().borrow().latest_block_num_hash();
+        // Use deterministic sources: boundary_consensus_hash from the boundary output (immutable)
+        // and the durable canonical tip. Read the reth canonical head directly rather than the
+        // in-memory recent_blocks (which is fed asynchronously by the engine-update task): the tip
+        // is the epoch-closing block the engine finalized before this runs, so parent_state is
+        // deterministic and race-free — and identical to the value the pre-anchor code committed.
+        let parent_state = engine.get_reth_env().await.canonical_tip().num_hash();
 
         let epoch_rec = EpochRecord {
             epoch,

--- a/crates/middleware/orchestrator/src/epoch_manager/transition.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/transition.rs
@@ -356,19 +356,14 @@ where
             EpochTransitionPhase::BoundaryDetected
             | EpochTransitionPhase::Draining
             | EpochTransitionPhase::ConsensusShutdown => {
-                // For early phases, the engine may or may not have received the
-                // boundary output. Check if execution already completed for the
-                // target hash by inspecting recent_blocks.
-                let latest = self.consensus_bus.recent_blocks().borrow().latest_block();
-                let execution_done =
-                    if latest.parent_beacon_block_root == Some(checkpoint.target_hash) {
-                        true
-                    } else {
-                        // recent_blocks is in-memory and may be stale after a crash.
-                        // Fall back to the persisted execution state as the source of truth.
-                        let tip_state = engine.epoch_state_from_canonical_tip().await?;
-                        tip_state.epoch > epoch
-                    };
+                // For early phases the engine may or may not have executed the boundary output.
+                // Decide from the durable execution state: the boundary output runs concludeEpoch,
+                // so if the closing epoch executed, the canonical tip's epoch state has advanced
+                // past it. (The former recent_blocks/parent_beacon fast-path was dead here —
+                // recent_blocks is empty this early in startup, before any replay — and fragile: a
+                // drained parked batch makes the tip's beacon differ from target_hash.)
+                let tip_state = engine.epoch_state_from_canonical_tip().await?;
+                let execution_done = tip_state.epoch > epoch;
 
                 if execution_done {
                     info!(target: "epoch-manager", "recovery: execution already complete for target hash");

--- a/crates/middleware/orchestrator/src/tests/epoch_transition_tests.rs
+++ b/crates/middleware/orchestrator/src/tests/epoch_transition_tests.rs
@@ -479,49 +479,12 @@ fn test_checkpoint_enables_epoch_record_recovery() {
     assert!(needs_clear, "crash before Cleared requires table clear + epoch record");
 }
 
-// ---------------------------------------------------------------------------
-// RANK 4 (MEDIUM): close_epoch vs spawn_engine_update_task Race
-// ---------------------------------------------------------------------------
-// The engine_update_task is node-scoped and continues after epoch shutdown.
-// If it writes a block from the old epoch after reset_for_epoch() clears
-// recent_blocks, the new epoch sees wrong state. The sequential phase design
-// fixes this by explicitly updating recent_blocks in close_epoch() before
-// the update task can race.
-
-/// RANK 4: Verify sequential phases prevent recent_blocks race.
-///
-/// In the new design, close_epoch() explicitly updates recent_blocks with the
-/// epoch-closing block BEFORE the engine_update_task can interfere. This test
-/// verifies that recent_blocks correctly reflects an explicit update.
-#[tokio::test]
-async fn test_sequential_execution_phase_prevents_recent_blocks_race() {
-    let bus = ConsensusBus::new();
-
-    // Simulate the engine_update_task writing a block.
-    let header1 = rayls_infrastructure_types::SealedHeader::seal_slow(
-        rayls_infrastructure_types::ExecHeader::default(),
-    );
-    bus.recent_blocks().send_modify(|blocks| blocks.push_latest(header1.clone()));
-
-    assert_eq!(bus.recent_blocks().borrow().latest_block_num_hash().number, 0);
-
-    // In the new design, close_epoch() explicitly pushes the closing block.
-    // This happens in the sequential ExecutionComplete phase, BEFORE any
-    // concurrent task can interfere.
-    let closing_header = {
-        let mut h = rayls_infrastructure_types::ExecHeader::default();
-        h.number = 100;
-        rayls_infrastructure_types::SealedHeader::seal_slow(h)
-    };
-    bus.recent_blocks().send_modify(|blocks| blocks.push_latest(closing_header.clone()));
-
-    // Verify the closing block is the latest.
-    assert_eq!(
-        bus.recent_blocks().borrow().latest_block_num_hash().number,
-        100,
-        "recent_blocks must reflect the epoch-closing block after explicit update"
-    );
-}
+// The former RANK 4 test (`test_sequential_execution_phase_prevents_recent_blocks_race`) was
+// removed: it guarded a race where `spawn_engine_update_task` could write a stale block into
+// `recent_blocks` and corrupt the epoch record's `parent_state`. That race no longer exists —
+// `write_epoch_record` now sources `parent_state` from the durable canonical tip
+// (`engine.get_reth_env().canonical_tip()`), not from the async-fed `recent_blocks`, so no
+// explicit push or sequential-phase ordering is needed to keep `parent_state` deterministic.
 
 /// RANK 4: Verify recent_blocks accurate after reset.
 ///


### PR DESCRIPTION
**The problem**

`await_epoch_execution` confirmed the epoch closed by waiting for a canonical block
whose `parent_beacon_block_root == target_hash` (the boundary output's consensus-header
digest). It only ever checked the **canonical tip** (`recent_blocks().latest()` and each
canon notification's `output.tip()`).

But when the boundary output drains a previously-**parked** (out-of-order seq) batch, that
drained batch's block lands *after* the in-order blocks and becomes the tip — and it carries
its **origin** output's beacon, not the boundary output's. So the tip's beacon never equals
`target_hash`, the wait times out after 180s, and the epoch never closes.

It's deterministic and network-wide: in the captured incident (epoch 162) **all 5 nodes**
computed the same `target_hash=0xab8d…`, produced the same tip `43663` (a drained parked
batch) with the same beacon `0xc22e…`, and all timed out → no quorum on epoch close → halt.
The boundary output *had* executed; it just wasn't observable via the tip.

**What's changed**

Anchor the wait on **execution progress**, not on a block's beacon. The engine already
advances the `executed_anchor` watch to each output's own consensus header as it finishes
executing it, so:

- `anchor.number >= boundary_output.number` is an unambiguous, monotonic completion signal;
- it's immune to which block is the canonical tip (parked drains included);
- `executed_anchor` is a `watch`, so it can't silently drop like the `canonical_block_stream`
  broadcast (256-slot, skips `Lagged`).

`target_hash` is kept only for the diagnostic log — matching no longer uses it. The
`EpochRecord`'s `parent_consensus` still comes from `target_hash` computed directly in
`detect_epoch_boundary`, unchanged.

- Consensus is shut down before the wait and `detect_epoch_boundary` never forwards past the
  boundary, so the boundary output is the highest-numbered output the engine executes this
  epoch — `>=` is effectively `==`.
- `executed_anchor` advances once per *whole* output, after all its blocks (in-order +
  withdrawals + drained parked batches) are canonical, so reaching `boundary_number` means the
  entire boundary output executed — nothing is skipped.
