### PR TITLE
ci: use ubuntu-latest instead of ubuntu-latest-m

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,7 +51,7 @@ jobs:
   # ===========================================================================
   build-and-push:
     name: Build and Push to ECR
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
@@ -146,7 +146,7 @@ jobs:
   # ===========================================================================
   security-scan:
     name: Security Scan
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: build-and-push
     permissions:
       contents: read

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   bench:
     name: EVM benchmarks
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   chaos:
     name: Chaos scenarios
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - name: Checkout repository

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -32,7 +32,7 @@ jobs:
   e2e-default:
     name: E2E (default)
     if: github.event_name == 'schedule' || inputs.suite == 'all' || inputs.suite == 'default'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Checkout repository
@@ -59,7 +59,7 @@ jobs:
   e2e-isolated:
     name: E2E (${{ matrix.test }})
     if: github.event_name == 'schedule' || inputs.suite == 'all' || inputs.suite == 'isolated'
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   fuzz:
     name: fuzz ${{ matrix.target }}
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,7 +52,7 @@ jobs:
   # ===========================================================================
   tests:
     name: Tests
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     steps:
       # exit immediately for drafts
       # - name: Check if draft PR
@@ -92,7 +92,7 @@ jobs:
   # ===========================================================================
   security-scan:
     name: Security Scan
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Self-hosted larger runners aren't set up yet, so switch CI workflows back to regular GitHub-hosted `ubuntu-latest` runners in the meantime.

## Test plan
- [x] CI passes on this PR using `ubuntu-latest`