### PR TITLE
ci: let Claude review fork PRs from trusted authors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,13 @@
 name: Claude Code Review
 
+# Uses pull_request_target (not pull_request) so the job runs in the BASE repo
+# context and can access secrets + id-token on PRs from forks. Because that
+# grants secrets to a workflow that checks out untrusted fork code, the job is
+# gated (see `if:` below) to authors we trust, and only ever runs read-only
+# review tools. Fork PRs from anyone else fall back to the `@claude` mention
+# flow in claude.yml, which a maintainer triggers after eyeballing the diff.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -12,10 +18,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
+    # Only auto-review same-repo PRs, or fork PRs from trusted authors (org
+    # members / collaborators). Everyone else uses the @claude mention flow.
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
 
     runs-on: ubuntu-latest
     permissions:
@@ -29,6 +36,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          # pull_request_target checks out the base by default; the `if:` gate
+          # above restricts this to trusted authors' PRs.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review


### PR DESCRIPTION
## Problem
The Claude Code Review workflow triggers on `pull_request`. GitHub withholds repository secrets **and** refuses to grant `id-token: write` on PRs from forks (e.g. #9 from `procdump/axyl`). So the action gets an empty `CLAUDE_CODE_OAUTH_TOKEN`, falls back to OIDC, and OIDC is blocked too — failing with `Could not fetch an OIDC token. Did you remember to add id-token: write` on every fork PR. The workflow already had `id-token: write`; the permission simply can't be granted for fork `pull_request` runs.

## Fix
- Switch the trigger to `pull_request_target`, which runs in the **base-repo** context where secrets and `id-token` are available.
- Because that grants secrets to a workflow that checks out untrusted fork code, **gate the job**: it only runs for same-repo PRs, or fork PRs whose `author_association` is `OWNER` / `MEMBER` / `COLLABORATOR`. Any other fork PR skips silently (no failing check) and uses the `@claude` mention flow in `claude.yml`, which a maintainer triggers after eyeballing the diff.
- Pin the checkout to `github.event.pull_request.head.sha` — `pull_request_target` checks out the base branch by default, so without this Claude would review the wrong code.

## Notes
- `pull_request_target` always uses the workflow definition from the **default branch**, so this only takes effect once merged to `main` (can't be exercised from this PR branch).
- Existing open fork PRs won't retroactively re-run; they need a fresh event (new commit, or close/reopen) after merge.