### PR TITLE
ci: skip PR-comment steps on fork PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -127,7 +127,10 @@ jobs:
           fi
 
       - name: Post Trivy results to PR
-        if: always()
+        # Sticky comments need a writable token, which fork PRs don't get
+        # (read-only GITHUB_TOKEN). Skip on forks — results stay in the job log
+        # and the "Fail if vulnerabilities found" gate below still enforces.
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: trivy-code
@@ -228,7 +231,9 @@ jobs:
           fi
 
       - name: Post contracts test results to PR
-        if: steps.changes.outputs.contracts == 'true'
+        # Skip on forks — fork PRs get a read-only token and can't post
+        # comments; the "Fail if contract tests failed" gate below still runs.
+        if: steps.changes.outputs.contracts == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: contracts-tests


### PR DESCRIPTION
## Problem
On PRs from forks, `pr.yaml` fails with `Resource not accessible by integration` (`create-an-issue-comment`). The **Security Scan (Trivy)** and **Contracts Tests** jobs post sticky PR comments via `marocchino/sticky-pull-request-comment`, which requires a writable token — but fork `pull_request` runs get a **read-only** `GITHUB_TOKEN`, so the comment call is rejected and the check goes red.

## Fix
Guard both comment steps with `github.event.pull_request.head.repo.full_name == github.repository` so they only run for same-repo PRs. On forks:
- the scan/test **results still appear in the job log**, and
- the existing `Fail if vulnerabilities found` / `Fail if contract tests failed` gates **still run** — so security and test enforcement is unchanged; only the convenience comment is skipped.

## Why not `pull_request_target` (as in #11)?
Unlike the Claude review workflow, `pr.yaml` **builds and runs the PR's code** (cargo, forge, trivy). Running that under `pull_request_target` would execute untrusted fork code with a writable token and secrets — a secret-exfiltration risk. Keeping `pull_request` (read-only on forks) is the safe choice; we just make the comment steps degrade gracefully.

## Note
If you later want fork contributors to actually *see* these comments, the secure pattern is a separate `workflow_run`-triggered workflow that runs in base context and posts the comment from an uploaded artifact. Out of scope here.