### PR TITLE
ci: authenticate Claude to GitHub via GITHUB_TOKEN

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,6 +46,11 @@ jobs:
         uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's GITHUB_TOKEN directly instead of the Claude
+          # GitHub App: the OIDC->app-token exchange 401s unless the app is
+          # installed on the org. The job already grants pull-requests: write,
+          # so this token can post review comments (as github-actions[bot]).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           track_progress: true
           exclude_comments_by_actor: 'github-actions[bot]'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,11 @@ jobs:
         uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1 
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's GITHUB_TOKEN directly instead of the Claude
+          # GitHub App: the OIDC->app-token exchange 401s unless the app is
+          # installed on the org. The job already grants pull-requests/issues:
+          # write, so this token posts comments (as github-actions[bot]).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Problem
After #11 merged, "Claude Code Review" gets far enough to obtain an OIDC token, then fails:

```
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Operation failed after 3 attempts
```

The action authenticates in two places: to **Anthropic** (via `CLAUDE_CODE_OAUTH_TOKEN`, which works) and to **GitHub** (to post comments). Since neither workflow passed a `github_token`, the action defaulted to the **Claude GitHub App** flow — exchanging the workflow's OIDC token for an app installation token at Anthropic's endpoint. That exchange 401s because the Claude GitHub App isn't installed/approved on the `raylsnetwork` org (an org-owner action; re-running `/install-github-app` locally can't fix it).

## Fix
Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` to both `claude.yml` and `claude-code-review.yml`. The action then uses the workflow token directly and skips the app-token exchange. Both jobs already declare `pull-requests`/`issues: write`, so the token can post comments — authored by **`github-actions[bot]`** instead of `claude[bot]`.

## Reverting later
If someone installs the Claude GitHub App on the org (for `claude[bot]` attribution), just drop these two `github_token` lines.