### PR TITLE
ci: tune CodeQL — main+schedule trigger, security-extended, exclude tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,10 +14,12 @@ name: CodeQL
 permissions:
   contents: read
 
+# Runs on push to main + weekly, not on every PR: a full Rust extraction takes
+# ~40 min, CodeQL isn't a required check, and the Security > Code Scanning tab
+# is populated from main analyses (PR runs only add inline diff annotations).
+# Newly introduced issues are caught on merge to main + the weekly scan.
 on:
   push:
-    branches: [main]
-  pull_request:
     branches: [main]
   schedule:
     - cron: '0 6 * * 1' # 06:00 UTC every Monday

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,6 +67,18 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          # Broader security coverage (default suite + extra security queries).
+          queries: security-extended
+          # Keep alerts on shipped code: drop test harnesses and fixtures.
+          # Note: inline #[cfg(test)] modules can't be path-excluded, but under
+          # build-mode: none the `test` cfg isn't enabled, so they aren't
+          # analyzed anyway — this targets the separate test dirs/crates.
+          config: |
+            paths-ignore:
+              - '**/tests/**'
+              - '**/benches/**'
+              - '**/examples/**'
+              - 'crates/testing/**'
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
Tunes the CodeQL workflow in three related ways.

## 1. Run on main + schedule, not every PR
A full Rust CodeQL run takes **~40 min** (`build-mode: none` resolves the whole Cargo graph via rust-analyzer) and fired on every PR *and* every rebase, for little value:
- **CodeQL is not a required status check** (rulesets require only `Format`), so on PRs it never gated a merge.
- The **Security → Code Scanning tab is fed by `main` (default-branch) analyses**; PR runs only add inline diff annotations.

Removes the `pull_request` trigger. CodeQL still runs on `push` to `main`, the weekly `schedule` (Mon 06:00 UTC), and `workflow_dispatch`.

## 2. security-extended query suite
Extend from the default suite to `security-extended` for broader security coverage. Cheap here because extraction (~29 min) dominates runtime — more queries only lengthen the ~10-min eval phase slightly, and it's off the PR path now.

## 3. Exclude test code
`paths-ignore` for `**/tests/**`, `**/benches/**`, `**/examples/**`, and `crates/testing/**`, so the extra `security-extended` alerts stay focused on shipped code and don't flag intentionally insecure test harnesses (chaos-framework, e2e-tests, test-utils). Inline `#[cfg(test)]` modules can't be path-excluded, but under `build-mode: none` the `test` cfg isn't enabled, so they aren't analyzed anyway.

## Trade-off
Lose pre-merge (PR-diff) annotations. Given the analysis is non-blocking, catching issues on merge + weekly is a reasonable posture. To restore pre-merge scanning later, re-add `pull_request` with `paths` filters (Rust/Cargo only) + a draft skip.