### PR TITLE
ci: harden pr.yaml + chaos workflow

### DIFF
--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -64,7 +64,11 @@ jobs:
       # their own), so the test process itself must be root. `rustup which cargo`
       # resolves the toolchain binary as the runner user; sudo -E then runs it
       # as root with the environment (PATH, HOME, CARGO_HOME) preserved.
+      # Pass the dispatch input via env (not templated into the script) so it's
+      # treated as data, not shell code. Left unquoted so empty = run all.
       - name: Run chaos scenarios
+        env:
+          TEST: ${{ github.event.inputs.test }}
         run: |
           sudo -E "$(rustup which cargo)" test -p chaos-framework --test chaos_scenarios \
-            -- --ignored --exact --test-threads 1 ${{ github.event.inputs.test }}
+            -- --ignored --exact --test-threads 1 $TEST

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,17 @@ on:
     branches:
       - main
 
+# Least privilege by default; the jobs that post PR comments re-grant
+# pull-requests: write in their own permissions block.
+permissions:
+  contents: read
+
+# Supersede in-flight runs when a PR is pushed/rebased instead of stacking
+# full build+test runs (the "require up-to-date branch" rule causes churn).
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0 # disable incremental compilation
   RUSTFLAGS: ""
@@ -120,7 +131,8 @@ jobs:
         run: |
           if [ -f trivy-results.txt ]; then
             echo "results<<EOF" >> $GITHUB_OUTPUT
-            cat trivy-results.txt >> $GITHUB_OUTPUT
+            # cap output so the sticky comment stays under GitHub's 65536-char limit
+            tail -c 60000 trivy-results.txt >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "results=No scan results available" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Findings from a full workflow audit (actionlint 1.7.12 reports the whole `.github/workflows` tree clean; these are hardening/correctness gaps it doesn't flag).

## Fixes in this PR

**1. `pr.yaml`: cap the Trivy comment output** — latent failure
The forge path caps its comment at `tail -c 60000` (GitHub's 65536-char comment-body limit), but the Trivy path did a raw `cat trivy-results.txt >> $GITHUB_OUTPUT`. A PR with many HIGH/CRITICAL findings produces a table over the limit → the sticky-comment POST 422s and the step fails. Now capped the same way.

**2. `pr.yaml`: add top-level `permissions: contents: read`**
The `fmt` and `tests` jobs declared no permissions and inherited the repo-default `GITHUB_TOKEN` scope. Every other workflow already pins least privilege. The two commenting jobs keep their own `pull-requests: write` override.

**3. `pr.yaml`: add `concurrency` with `cancel-in-progress`**
No cancellation meant every push/rebase stacked another full build+test run — amplified by the "require branch up-to-date" rule. Now a new push supersedes the in-flight run. (CodeQL already does this; the push/tag build workflows intentionally don't.)

**4. `nightly-chaos.yml`: route the dispatch input through `env:`**
`... --test-threads 1 ${{ github.event.inputs.test }}` templated a user input straight into the shell — a script-injection surface (low severity: dispatch requires write access, and it's the only workflow doing this vs the env-var pattern build-docker/promote-docker use). Now passed as `env: TEST` and referenced as `$TEST` (data, not code). Left unquoted so empty still means "run all scenarios".

## Deliberately not changed (per review decision)
- Clippy is installed in 5 jobs but never run — left as-is.
- `promote-docker.yml`'s "fail if target tag exists" guard stays commented (overwrite-on-re-promote kept).
- Draft-PR skip stays commented (full CI runs on drafts).