### PR TITLE
chore(release): v1.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,7 +2288,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chaos-framework"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap",
  "const-hex",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "consensus-metrics"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "axum 0.8.8",
  "futures",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "clap",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-batch-builder"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -7750,7 +7750,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-batch-validator"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7767,7 +7767,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-network"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7794,7 +7794,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-primary"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7825,7 +7825,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-primary-metrics"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "consensus-metrics",
  "prometheus",
@@ -7834,7 +7834,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-state-sync"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "consensus-metrics",
  "eyre",
@@ -7851,7 +7851,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-worker"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7879,7 +7879,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-evm"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -7950,7 +7950,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-faucet"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "clap",
@@ -7984,7 +7984,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-metrics"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "eyre",
  "rayls-infrastructure-types",
@@ -7999,7 +7999,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-rpc"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -8012,7 +8012,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-config"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm-siv",
  "backoff",
@@ -8036,7 +8036,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-network-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "async-trait",
  "eyre",
@@ -8049,7 +8049,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-storage"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "eyre",
  "ouroboros",
@@ -8067,7 +8067,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-types"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-utils"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "futures",
  "parking_lot",
@@ -8114,7 +8114,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-bridge"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "consensus-metrics",
  "eyre",
@@ -8135,7 +8135,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-orchestrator"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "consensus-metrics",
@@ -8173,7 +8173,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-processor"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "assert_matches",
  "eyre",
@@ -8199,7 +8199,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-rewards"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "eyre",
  "indexmap 2.13.0",
@@ -8215,7 +8215,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-network"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap",
  "rayls-execution-faucet",
@@ -8227,7 +8227,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-network-cli"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "bs58",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-replay"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap",
  "eyre",
@@ -8275,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-testing-test-utils"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap",
  "eyre",
@@ -8292,7 +8292,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-testing-test-utils-committee"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "rand 0.9.3",
  "rayls-execution-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ exclude = ["crates/testing/fuzz-targets"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 # Remember to update:
 # - .clippy.toml


### PR DESCRIPTION
Automated version bump `1.2.1` → `1.2.2` (level: `patch`).

Opened manually because the dispatch run (#28940558086) pushed the branch but failed at `gh pr create` — the repo's "Allow GitHub Actions to create and approve pull requests" setting is off, so the Actions `GITHUB_TOKEN` is refused.

Merging this PR creates tag `v1.2.2` and builds the `devnet-v1.2.2` image (via `tag-on-release.yml`).