### PR TITLE
fix(replay): repair genesis history for v2 (StorageV2) archives

### DIFF
--- a/bin/rayls-replay/src/main.rs
+++ b/bin/rayls-replay/src/main.rs
@@ -93,7 +93,7 @@ struct Cli {
     /// 2. AccountsHistory seed: IndexAccountHistoryStage clears AccountsHistory on first sync and
     ///    never re-inserts accounts whose code/nonce/balance never change after genesis (immutable
     ///    system contracts). Historical `eth_call` returns empty contract code for those accounts.
-    #[arg(long)]
+    #[arg(long = "fix-genesis-history")]
     fix_genesis_history: bool,
 
     /// Verify state root after every block (slow). Default: epoch boundaries only.
@@ -280,7 +280,7 @@ async fn run(cli: Cli) -> eyre::Result<()> {
     }
 
     // archive is complete: repair the two genesis-history issues so it boots
-    // correct without a separate --fix_genesis_history pass. The re-key/seed
+    // correct without a separate --fix-genesis-history pass. The re-key/seed
     // read-merge with existing history, so running here (after replay) preserves
     // every post-genesis change; a no-op on v1 archives and on any slot/account
     // already carrying the genesis block. Only on normal completion — the

--- a/bin/rayls-replay/src/main.rs
+++ b/bin/rayls-replay/src/main.rs
@@ -80,6 +80,22 @@ struct Cli {
     #[arg(long, value_name = "BLOCK")]
     unwind_to: Option<u64>,
 
+    /// Repair genesis history indices on an existing archive, then exit (no
+    /// replay). Idempotent; run with the node stopped. Freshly built archives
+    /// are repaired automatically at the end of a normal replay, so this flag is
+    /// only for archives built before that behaviour existed (e.g. mainnet).
+    /// Fixes two v2 archive issues:
+    ///
+    /// 1. StoragesHistory re-key: reth writes genesis StoragesHistory under plain slots while the
+    ///    v2 read looks up by keccak256(slot), so genesis-seeded storage (e.g. the validator set)
+    ///    returns 0x0 at historical blocks.
+    ///
+    /// 2. AccountsHistory seed: IndexAccountHistoryStage clears AccountsHistory on first sync and
+    ///    never re-inserts accounts whose code/nonce/balance never change after genesis (immutable
+    ///    system contracts). Historical `eth_call` returns empty contract code for those accounts.
+    #[arg(long)]
+    fix_genesis_history: bool,
+
     /// Verify state root after every block (slow). Default: epoch boundaries only.
     #[arg(long)]
     verify_every_block: bool,
@@ -150,8 +166,6 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         "loaded network configuration"
     );
 
-    let consensus_store = open_db(&consensus_db);
-
     // archive blocks build with the snapshot's committed close-epoch tally,
     // staged into `tally_store` per close block; snapshot env never builds.
     let tally_store = SnapshotTallyStore::default();
@@ -174,6 +188,19 @@ async fn run(cli: Cli) -> eyre::Result<()> {
     .await
     .wrap_err("open archive reth env")?;
 
+    // maintenance exit: repair genesis history on an existing archive, then exit
+    // before opening the snapshot env (no replay).
+    if cli.fix_genesis_history {
+        archive_evm.fix_genesis_history()?;
+        archive_evm.fix_genesis_account_history()?;
+        info!(
+            target: "rayls_replay::main",
+            archive_out = %cli.archive_out.display(),
+            "genesis-history fix complete"
+        );
+        return Ok(());
+    }
+
     // unwind exits before opening the snapshot env; only the archive is touched
     if let Some(target) = cli.unwind_to {
         archive_evm
@@ -188,6 +215,12 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         );
         return Ok(());
     }
+
+    // snapshot-only setup: the consensus DB is the replay oracle and is unused by
+    // the fix-genesis and unwind early-return paths above, so open it only once
+    // we know we're actually replaying (avoids touching a dummy/bad path in those
+    // maintenance modes).
+    let consensus_store = open_db(&consensus_db);
 
     let snapshot_evm = RethEnv::new_for_archive_replay(
         Arc::clone(&base_chain),
@@ -245,6 +278,20 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         );
         return Ok(());
     }
+
+    // archive is complete: repair the two genesis-history issues so it boots
+    // correct without a separate --fix_genesis_history pass. The re-key/seed
+    // read-merge with existing history, so running here (after replay) preserves
+    // every post-genesis change; a no-op on v1 archives and on any slot/account
+    // already carrying the genesis block. Only on normal completion — the
+    // graceful-stop path returns above, leaving the archive resumable.
+    archive_evm.fix_genesis_history()?;
+    archive_evm.fix_genesis_account_history()?;
+    info!(
+        target: "rayls_replay::main",
+        archive_out = %cli.archive_out.display(),
+        "genesis-history fix applied to freshly built archive"
+    );
 
     // close the DB envs before the copy so no MDBX handle still maps the files;
     // all three are unused past the flush above

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -484,23 +484,37 @@ impl RethEnv {
     /// left untouched. Only applicable to v2 (RocksDB) archives. Idempotent.
     #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_account_history(&self) -> eyre::Result<()> {
+        Self::fix_genesis_account_history_with(
+            &self.provider_factory,
+            self.node_config.storage_settings().use_hashed_state(),
+        )?;
+        Ok(())
+    }
+
+    /// Testable core of [`Self::fix_genesis_account_history`]. Returns the number
+    /// of accounts seeded.
+    #[cfg(feature = "archive-replay")]
+    pub(crate) fn fix_genesis_account_history_with(
+        provider_factory: &ProviderFactory<RaylsNode>,
+        use_hashed_state: bool,
+    ) -> eyre::Result<usize> {
         use reth_db::{models::ShardedKey, BlockNumberList};
         use reth_provider::RocksDBProviderFactory;
         use std::collections::{HashMap, HashSet};
 
-        if !self.node_config.storage_settings().use_hashed_state() {
+        if !use_hashed_state {
             info!(target: "rayls::reth", "v1 (plain) storage; account history needs no fix");
-            return Ok(());
+            return Ok(0);
         }
 
-        let chain_spec = self.provider_factory.chain_spec();
+        let chain_spec = provider_factory.chain_spec();
         let genesis = chain_spec.genesis();
         let block = chain_spec.genesis_header().number;
 
         // Single pass: collect which addresses already have a block-0 entry
         // (idempotency guard) and how many shards each address has (safety guard).
         let (already_fixed, shard_counts): (HashSet<Address>, HashMap<Address, usize>) = {
-            let rocksdb = self.provider_factory.rocksdb_provider();
+            let rocksdb = provider_factory.rocksdb_provider();
             let mut fixed = HashSet::new();
             let mut counts: HashMap<Address, usize> = HashMap::new();
             for entry in rocksdb.iter::<reth_db::tables::AccountsHistory>()? {
@@ -548,10 +562,10 @@ impl RethEnv {
 
         if to_fix.is_empty() {
             info!(target: "rayls::reth", block, "genesis account history already fully seeded; nothing to do");
-            return Ok(());
+            return Ok(0);
         }
 
-        let rocksdb = self.provider_factory.rocksdb_provider();
+        let rocksdb = provider_factory.rocksdb_provider();
         let mut batch = rocksdb.batch();
         for addr in &to_fix {
             let key = ShardedKey::last(*addr);
@@ -575,7 +589,7 @@ impl RethEnv {
             block,
             "seeded genesis account history for v2 archive"
         );
-        Ok(())
+        Ok(to_fix.len())
     }
 
     /// Re-key the genesis storage history to hashed keys so v2 archive reads
@@ -595,20 +609,34 @@ impl RethEnv {
     /// blocks. Only applicable to v2 (RocksDB) archives. Idempotent.
     #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_history(&self) -> eyre::Result<()> {
+        Self::fix_genesis_history_with(
+            &self.provider_factory,
+            self.node_config.storage_settings().use_hashed_state(),
+        )?;
+        Ok(())
+    }
+
+    /// Testable core of [`Self::fix_genesis_history`]. Returns the number of
+    /// storage slots re-keyed (0 when everything is already correct).
+    #[cfg(feature = "archive-replay")]
+    pub(crate) fn fix_genesis_history_with(
+        provider_factory: &ProviderFactory<RaylsNode>,
+        use_hashed_state: bool,
+    ) -> eyre::Result<usize> {
         use alloy::primitives::keccak256;
         use reth_db::{models::storage_sharded_key::StorageShardedKey, BlockNumberList};
         use reth_provider::RocksDBProviderFactory;
 
-        if !self.node_config.storage_settings().use_hashed_state() {
+        if !use_hashed_state {
             info!(target: "rayls::reth", "v1 (plain) storage; genesis history needs no re-key");
-            return Ok(());
+            return Ok(0);
         }
 
-        let chain_spec = self.provider_factory.chain_spec();
+        let chain_spec = provider_factory.chain_spec();
         let genesis = chain_spec.genesis();
         let block = chain_spec.genesis_header().number;
 
-        let rocksdb = self.provider_factory.rocksdb_provider();
+        let rocksdb = provider_factory.rocksdb_provider();
         let mut batch = rocksdb.batch();
         let (mut fixed, mut already, mut multi_shard) = (0usize, 0usize, 0usize);
 
@@ -659,7 +687,7 @@ impl RethEnv {
 
         if fixed == 0 {
             info!(target: "rayls::reth", block, already, "genesis storage history already re-keyed; nothing to do");
-            return Ok(());
+            return Ok(0);
         }
         batch.commit()?;
 
@@ -671,6 +699,6 @@ impl RethEnv {
             block,
             "re-keyed genesis storage history to hashed keys"
         );
-        Ok(())
+        Ok(fixed)
     }
 }

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -606,7 +606,10 @@ impl RethEnv {
     /// the open (`u64::MAX`) shard. That keeps the post-genesis history of a
     /// genesis slot that was also modified later (e.g. a balance / registry slot)
     /// and places block 0 in the shard the historical read consults for early
-    /// blocks. Only applicable to v2 (RocksDB) archives. Idempotent.
+    /// blocks. When prepending would push the earliest shard past
+    /// `NUM_OF_INDICES_IN_SHARD` (a hot genesis slot with >= that many
+    /// post-genesis changes), the slot's shards are re-chunked so none exceeds
+    /// the limit. Only applicable to v2 (RocksDB) archives. Idempotent.
     #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_history_with(
@@ -624,7 +627,12 @@ impl RethEnv {
         use_hashed_state: bool,
     ) -> eyre::Result<usize> {
         use alloy::primitives::keccak256;
-        use reth_db::{models::storage_sharded_key::StorageShardedKey, BlockNumberList};
+        use reth_db::{
+            models::{
+                sharded_key::NUM_OF_INDICES_IN_SHARD, storage_sharded_key::StorageShardedKey,
+            },
+            BlockNumberList,
+        };
         use reth_provider::RocksDBProviderFactory;
 
         if !use_hashed_state {
@@ -638,7 +646,7 @@ impl RethEnv {
 
         let rocksdb = provider_factory.rocksdb_provider();
         let mut batch = rocksdb.batch();
-        let (mut fixed, mut already, mut multi_shard) = (0usize, 0usize, 0usize);
+        let (mut fixed, mut already, mut rechunked) = (0usize, 0usize, 0usize);
 
         for (addr, account) in genesis.alloc.iter() {
             let Some(storage) = account.storage.as_ref() else { continue };
@@ -664,21 +672,55 @@ impl RethEnv {
                             &BlockNumberList::new([block]).expect("single block always fits"),
                         )?;
                     }
-                    // Prepend the genesis block into the earliest shard, preserving
-                    // its (and every later shard's) post-genesis history. The read
-                    // for an early block consults this shard, so block 0 belongs here.
                     Some((earliest_key, earliest_list)) => {
-                        if shards.len() > 1 {
-                            multi_shard += 1;
+                        // Fast path: a single shard (the open `::last`) with room —
+                        // prepend the genesis block in place. The read for an early
+                        // block consults this shard, so block 0 belongs here.
+                        if shards.len() == 1
+                            && (earliest_list.len() as usize) < NUM_OF_INDICES_IN_SHARD
+                        {
+                            let blocks: Vec<u64> =
+                                core::iter::once(block).chain(earliest_list.iter()).collect();
+                            let merged = BlockNumberList::new(blocks).map_err(|e| {
+                                eyre::eyre!("failed to build block number list: {e}")
+                            })?;
+                            batch.put::<reth_db::tables::StoragesHistory>(
+                                earliest_key.clone(),
+                                &merged,
+                            )?;
+                        } else {
+                            // Prepending would overflow the earliest shard (a hot
+                            // genesis slot with a full first shard). Gather all of the
+                            // slot's blocks, prepend genesis, delete the old shards and
+                            // re-split into <= NUM_OF_INDICES_IN_SHARD chunks so none
+                            // exceeds the limit. `all` is globally sorted: block 0 is
+                            // smaller than every post-genesis change, and both the shard
+                            // order and each shard's list are ascending.
+                            rechunked += 1;
+                            let mut all: Vec<u64> = core::iter::once(block).collect();
+                            for (_, list) in &shards {
+                                all.extend(list.iter());
+                            }
+                            for (key, _) in &shards {
+                                batch.delete::<reth_db::tables::StoragesHistory>(key.clone())?;
+                            }
+                            let mut i = 0;
+                            while i < all.len() {
+                                let end = (i + NUM_OF_INDICES_IN_SHARD).min(all.len());
+                                let chunk = &all[i..end];
+                                let key = if end == all.len() {
+                                    StorageShardedKey::last(*addr, hashed)
+                                } else {
+                                    StorageShardedKey::new(*addr, hashed, chunk[chunk.len() - 1])
+                                };
+                                let list =
+                                    BlockNumberList::new(chunk.iter().copied()).map_err(|e| {
+                                        eyre::eyre!("failed to build block number list: {e}")
+                                    })?;
+                                batch.put::<reth_db::tables::StoragesHistory>(key, &list)?;
+                                i = end;
+                            }
                         }
-                        let blocks: Vec<u64> =
-                            core::iter::once(block).chain(earliest_list.iter()).collect();
-                        let merged = BlockNumberList::new(blocks)
-                            .map_err(|e| eyre::eyre!("failed to build block number list: {e}"))?;
-                        batch.put::<reth_db::tables::StoragesHistory>(
-                            earliest_key.clone(),
-                            &merged,
-                        )?;
                     }
                 }
                 fixed += 1;
@@ -695,7 +737,7 @@ impl RethEnv {
             target: "rayls::reth",
             slots = fixed,
             already,
-            multi_shard,
+            rechunked,
             block,
             "re-keyed genesis storage history to hashed keys"
         );

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -469,4 +469,208 @@ impl RethEnv {
         info!(target: "rayls::reth", target_block, "unwind complete");
         Ok(())
     }
+
+    /// Seed the genesis account history for accounts that produce no changesets.
+    ///
+    /// `IndexAccountHistoryStage` clears `AccountsHistory` on its first run and
+    /// rebuilds from `AccountChangeSets`, so genesis accounts whose
+    /// code/nonce/balance never change again (immutable system contracts) lose
+    /// their block-0 entry entirely — historical `eth_call`/`eth_getCode`
+    /// returns empty for them.
+    ///
+    /// This re-inserts a genesis block-0 entry for every such account via a
+    /// read-merge-write so existing post-genesis shards are preserved. Accounts
+    /// with more than one shard already carry post-genesis changesets and are
+    /// left untouched. Only applicable to v2 (RocksDB) archives. Idempotent.
+    #[cfg(feature = "archive-replay")]
+    pub fn fix_genesis_account_history(&self) -> eyre::Result<()> {
+        use reth_db::{models::ShardedKey, BlockNumberList};
+        use reth_provider::RocksDBProviderFactory;
+        use std::collections::{HashMap, HashSet};
+
+        if !self.node_config.storage_settings().use_hashed_state() {
+            info!(target: "rayls::reth", "v1 (plain) storage; account history needs no fix");
+            return Ok(());
+        }
+
+        let chain_spec = self.provider_factory.chain_spec();
+        let genesis = chain_spec.genesis();
+        let block = chain_spec.genesis_header().number;
+
+        // Single pass: collect which addresses already have a block-0 entry
+        // (idempotency guard) and how many shards each address has (safety guard).
+        let (already_fixed, shard_counts): (HashSet<Address>, HashMap<Address, usize>) = {
+            let rocksdb = self.provider_factory.rocksdb_provider();
+            let mut fixed = HashSet::new();
+            let mut counts: HashMap<Address, usize> = HashMap::new();
+            for entry in rocksdb.iter::<reth_db::tables::AccountsHistory>()? {
+                let (key, value) = entry?;
+                *counts.entry(key.key).or_insert(0) += 1;
+                if value.contains(block) {
+                    fixed.insert(key.key);
+                }
+            }
+            (fixed, counts)
+        };
+
+        if !already_fixed.is_empty() {
+            info!(
+                target: "rayls::reth",
+                already_fixed = already_fixed.len(),
+                "idempotency: skipping accounts already present in AccountsHistory at genesis block"
+            );
+        }
+
+        // Accounts with more than one shard have post-genesis changesets that were
+        // correctly indexed by IndexAccountHistoryStage.
+        let multi_shard_skipped = genesis
+            .alloc
+            .keys()
+            .filter(|addr| shard_counts.get(*addr).copied().unwrap_or(0) > 1)
+            .count();
+
+        if multi_shard_skipped > 0 {
+            info!(
+                target: "rayls::reth",
+                multi_shard_skipped,
+                "skipping genesis accounts with multiple history shards (post-genesis changesets present)"
+            );
+        }
+
+        let to_fix: Vec<Address> = genesis
+            .alloc
+            .keys()
+            .filter(|addr| {
+                !already_fixed.contains(*addr) && shard_counts.get(*addr).copied().unwrap_or(0) <= 1
+            })
+            .copied()
+            .collect();
+
+        if to_fix.is_empty() {
+            info!(target: "rayls::reth", block, "genesis account history already fully seeded; nothing to do");
+            return Ok(());
+        }
+
+        let rocksdb = self.provider_factory.rocksdb_provider();
+        let mut batch = rocksdb.batch();
+        for addr in &to_fix {
+            let key = ShardedKey::last(*addr);
+            let existing = rocksdb.get::<reth_db::tables::AccountsHistory>(key.clone())?;
+            let merged = match existing {
+                Some(existing_list) => {
+                    let blocks: Vec<u64> =
+                        core::iter::once(block).chain(existing_list.iter()).collect();
+                    BlockNumberList::new(blocks)
+                        .map_err(|e| eyre::eyre!("failed to build block number list: {e}"))?
+                }
+                None => BlockNumberList::new([block]).expect("single block always fits"),
+            };
+            batch.put::<reth_db::tables::AccountsHistory>(key, &merged)?;
+        }
+        batch.commit()?;
+
+        info!(
+            target: "rayls::reth",
+            accounts = to_fix.len(),
+            block,
+            "seeded genesis account history for v2 archive"
+        );
+        Ok(())
+    }
+
+    /// Re-key the genesis storage history to hashed keys so v2 archive reads
+    /// reconstruct genesis-seeded storage instead of returning 0x0.
+    ///
+    /// reth's genesis writer (`insert_storage_history`) keys `StoragesHistory`
+    /// by the plain slot, but the v2 read looks it up by `keccak256(slot)`, so
+    /// genesis-seeded storage (e.g. the static validator set) reads as
+    /// `NotYetWritten` -> 0x0. This re-emits the genesis block entry under the
+    /// hashed slot.
+    ///
+    /// The entry is **merged into the earliest existing shard** for each
+    /// `(address, hashed slot)` via a read-merge-write, rather than overwriting
+    /// the open (`u64::MAX`) shard. That keeps the post-genesis history of a
+    /// genesis slot that was also modified later (e.g. a balance / registry slot)
+    /// and places block 0 in the shard the historical read consults for early
+    /// blocks. Only applicable to v2 (RocksDB) archives. Idempotent.
+    #[cfg(feature = "archive-replay")]
+    pub fn fix_genesis_history(&self) -> eyre::Result<()> {
+        use alloy::primitives::keccak256;
+        use reth_db::{models::storage_sharded_key::StorageShardedKey, BlockNumberList};
+        use reth_provider::RocksDBProviderFactory;
+
+        if !self.node_config.storage_settings().use_hashed_state() {
+            info!(target: "rayls::reth", "v1 (plain) storage; genesis history needs no re-key");
+            return Ok(());
+        }
+
+        let chain_spec = self.provider_factory.chain_spec();
+        let genesis = chain_spec.genesis();
+        let block = chain_spec.genesis_header().number;
+
+        let rocksdb = self.provider_factory.rocksdb_provider();
+        let mut batch = rocksdb.batch();
+        let (mut fixed, mut already, mut multi_shard) = (0usize, 0usize, 0usize);
+
+        for (addr, account) in genesis.alloc.iter() {
+            let Some(storage) = account.storage.as_ref() else { continue };
+            for slot in storage.keys() {
+                let hashed = keccak256(slot);
+                // All shards for this (address, hashed slot), ascending by highest
+                // block. A cheap per-slot prefix scan, not an O(N) full-table scan.
+                let shards = rocksdb.storage_history_shards(*addr, hashed)?;
+
+                // Idempotency: a prior run already placed the genesis block.
+                if shards.iter().any(|(_, list)| list.contains(block)) {
+                    already += 1;
+                    continue;
+                }
+
+                match shards.first() {
+                    // No history yet (immutable genesis slot, never touched after
+                    // genesis): open a fresh `::last` shard holding just the block.
+                    None => {
+                        let key = StorageShardedKey::last(*addr, hashed);
+                        batch.put::<reth_db::tables::StoragesHistory>(
+                            key,
+                            &BlockNumberList::new([block]).expect("single block always fits"),
+                        )?;
+                    }
+                    // Prepend the genesis block into the earliest shard, preserving
+                    // its (and every later shard's) post-genesis history. The read
+                    // for an early block consults this shard, so block 0 belongs here.
+                    Some((earliest_key, earliest_list)) => {
+                        if shards.len() > 1 {
+                            multi_shard += 1;
+                        }
+                        let blocks: Vec<u64> =
+                            core::iter::once(block).chain(earliest_list.iter()).collect();
+                        let merged = BlockNumberList::new(blocks)
+                            .map_err(|e| eyre::eyre!("failed to build block number list: {e}"))?;
+                        batch.put::<reth_db::tables::StoragesHistory>(
+                            earliest_key.clone(),
+                            &merged,
+                        )?;
+                    }
+                }
+                fixed += 1;
+            }
+        }
+
+        if fixed == 0 {
+            info!(target: "rayls::reth", block, already, "genesis storage history already re-keyed; nothing to do");
+            return Ok(());
+        }
+        batch.commit()?;
+
+        info!(
+            target: "rayls::reth",
+            slots = fixed,
+            already,
+            multi_shard,
+            block,
+            "re-keyed genesis storage history to hashed keys"
+        );
+        Ok(())
+    }
 }

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -482,6 +482,14 @@ impl RethEnv {
     /// read-merge-write so existing post-genesis shards are preserved. Accounts
     /// with more than one shard already carry post-genesis changesets and are
     /// left untouched. Only applicable to v2 (RocksDB) archives. Idempotent.
+    ///
+    /// Limitation: on an archive whose `AccountsHistory` was cleared and rebuilt
+    /// from `AccountChangeSets` by `IndexAccountHistoryStage` (a normally-synced
+    /// node — not `rayls-replay`), a *multi-shard* genesis account is skipped here
+    /// and genesis has no changeset to rebuild from, so it never regains its
+    /// block-0 entry. This is a non-issue for replay-built archives, where that
+    /// stage never runs; account history is written once by genesis init and only
+    /// appended to.
     #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_account_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_account_history_with(
@@ -610,6 +618,11 @@ impl RethEnv {
     /// `NUM_OF_INDICES_IN_SHARD` (a hot genesis slot with >= that many
     /// post-genesis changes), the slot's shards are re-chunked so none exceeds
     /// the limit. Only applicable to v2 (RocksDB) archives. Idempotent.
+    ///
+    /// This adds the entry under the hashed key; the original plain-slot entry
+    /// written by genesis init is intentionally left in place. It's never read by
+    /// v2 (which looks up the hashed key) and deleting it is avoidable risk for no
+    /// functional gain, so it's kept as harmless dead weight rather than removed.
     #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_history_with(
@@ -701,6 +714,14 @@ impl RethEnv {
                             for (_, list) in &shards {
                                 all.extend(list.iter());
                             }
+                            // `all` must be strictly ascending for BlockNumberList /
+                            // the shard split: genesis block < every post-genesis block,
+                            // storage_history_shards returns shards ascending, and each
+                            // shard's list is ascending. Guard that invariant.
+                            debug_assert!(
+                                all.windows(2).all(|w| w[0] < w[1]),
+                                "re-chunk block list must be strictly ascending"
+                            );
                             for (key, _) in &shards {
                                 batch.delete::<reth_db::tables::StoragesHistory>(key.clone())?;
                             }

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -1026,3 +1026,100 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
 
     Ok(())
 }
+
+/// Full-DB check for `fix_genesis_account_history`. Unlike storage, account
+/// history has no key mismatch (read and write both use the plain address), so
+/// genesis init already seeds it correctly and the fix is a no-op. It only has
+/// work to do after an `IndexAccountHistoryStage` first-sync clear, which this
+/// test simulates — and multi-shard accounts (post-genesis changesets) are left
+/// untouched.
+#[cfg(feature = "archive-replay")]
+#[tokio::test]
+async fn test_fix_genesis_account_history_seeds_after_clear_and_skips_multishard(
+) -> eyre::Result<()> {
+    use crate::{reth_env::RethEnv, traits::RaylsNode};
+    use reth_db::{models::ShardedKey, tables, BlockNumberList};
+    use reth_db_common::init::init_genesis_with_settings;
+    use reth_provider::{
+        providers::{RocksDBBuilder, StaticFileProvider},
+        ProviderFactory, RocksDBProviderFactory, StorageSettings, StorageSettingsCache,
+    };
+
+    let addr = Address::from([0x21u8; 20]); // immutable genesis account
+    let addr2 = Address::from([0x22u8; 20]); // multi-shard (post-genesis changes)
+    let genesis = rayls_infrastructure_types::test_genesis().extend_accounts([
+        (addr, GenesisAccount { balance: U256::from(1u64), ..Default::default() }),
+        (addr2, GenesisAccount { balance: U256::from(2u64), ..Default::default() }),
+    ]);
+
+    let tmp_dir = TempDir::new()?;
+    let datadir = tmp_dir.path().to_path_buf();
+    let db = Arc::new(reth_db::init_db(
+        datadir.join("db"),
+        reth_db::mdbx::DatabaseArguments::default(),
+    )?);
+    let rayls_chain_spec = Arc::new(
+        crate::chainspec::RaylsChainSpec::builder(Arc::new(RethChainSpec::from(genesis))).build(),
+    );
+    let rocksdb_provider =
+        RocksDBBuilder::new(datadir.join("rocksdb")).with_default_tables().build()?;
+    let static_files = StaticFileProvider::read_write(datadir.join("static_files"))?;
+    let runtime = reth_tasks::Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
+    let provider_factory: ProviderFactory<RaylsNode> =
+        ProviderFactory::new(db, rayls_chain_spec, static_files, rocksdb_provider, runtime)?;
+    let settings = StorageSettings::v2();
+    provider_factory.set_storage_settings_cache(settings);
+    init_genesis_with_settings(&provider_factory, settings)?;
+
+    let rocksdb = provider_factory.rocksdb_provider();
+    let last = |a: Address| rocksdb.get::<tables::AccountsHistory>(ShardedKey::last(a));
+
+    // Genesis init already seeds account history correctly (plain address, no
+    // mismatch), so the fix has nothing to do.
+    assert!(
+        last(addr)?.is_some_and(|l| l.contains(0u64)),
+        "genesis init seeds AccountsHistory[addr] = [0]"
+    );
+    assert_eq!(
+        RethEnv::fix_genesis_account_history_with(&provider_factory, true)?,
+        0,
+        "account history already correct at genesis; fix is a no-op"
+    );
+
+    // Simulate IndexAccountHistoryStage's first-sync clear (what a normally-synced
+    // node does), then inject a multi-shard post-genesis account.
+    rocksdb.clear::<tables::AccountsHistory>()?;
+    {
+        let mut batch = rocksdb.batch();
+        batch.put::<tables::AccountsHistory>(
+            ShardedKey::new(addr2, 400u64),
+            &BlockNumberList::new([100u64, 400]).unwrap(),
+        )?;
+        batch.put::<tables::AccountsHistory>(
+            ShardedKey::last(addr2),
+            &BlockNumberList::new([900u64]).unwrap(),
+        )?;
+        batch.commit()?;
+    }
+
+    // The fix restores block 0 for the cleared immutable account...
+    let seeded = RethEnv::fix_genesis_account_history_with(&provider_factory, true)?;
+    assert!(seeded >= 1, "cleared single-shard genesis accounts are re-seeded");
+    assert!(last(addr)?.is_some_and(|l| l.contains(0u64)), "addr re-seeded with block 0");
+
+    // ...but leaves the multi-shard account untouched (assumed correctly indexed).
+    assert_eq!(
+        last(addr2)?.unwrap().iter().collect::<Vec<u64>>(),
+        vec![900],
+        "multi-shard account's open shard is untouched"
+    );
+    assert!(
+        !last(addr2)?.unwrap().contains(0u64),
+        "multi-shard account is not seeded with block 0"
+    );
+
+    // Idempotent.
+    assert_eq!(RethEnv::fix_genesis_account_history_with(&provider_factory, true)?, 0);
+
+    Ok(())
+}

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -988,9 +988,23 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
 
     // Run the fix.
     let fixed = RethEnv::fix_genesis_history_with(&provider_factory, true)?;
-    assert!(fixed >= 3, "expected at least our three slots re-keyed, got {fixed}");
+    assert!(fixed > 0, "fix must re-key at least the injected slots");
 
     let rocksdb = provider_factory.rocksdb_provider();
+
+    // Strong outcome check (not a loose count): every genesis alloc storage slot
+    // now resolves under its hashed key at block 0. Catches any slot the fix
+    // silently missed. Iterates the alloc from the chain spec (genesis was moved).
+    for (a, account) in provider_factory.chain_spec().genesis().alloc.iter() {
+        let Some(s) = account.storage.as_ref() else { continue };
+        for slot in s.keys() {
+            let shards = rocksdb.storage_history_shards(*a, keccak256(*slot))?;
+            assert!(
+                shards.iter().any(|(_, l)| l.contains(0u64)),
+                "genesis slot {slot} on {a} must carry block 0 under its hashed key after the fix"
+            );
+        }
+    }
     let blocks = |shards: &[(StorageShardedKey, BlockNumberList)]| -> Vec<u64> {
         shards.iter().flat_map(|(_, l)| l.iter()).collect()
     };

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -963,7 +963,11 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
     }
 
     // Simulate post-genesis history under the HASHED keys, as replay's indexer
-    // would append: slot_b one open shard [5]; slot_c sealed [100,400] + open [900].
+    // would append:
+    //   slot_b — one open shard [5] (has room → prepend in place)
+    //   slot_c — a FULL sealed shard [1..=2000] + a full open shard [2001..=4000],
+    //            so prepending block 0 (total 4001) must re-chunk into three
+    //            <=2000 shards (the cascade / overflow case).
     {
         let rocksdb = provider_factory.rocksdb_provider();
         let mut batch = rocksdb.batch();
@@ -972,12 +976,12 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
             &BlockNumberList::new([5u64]).unwrap(),
         )?;
         batch.put::<tables::StoragesHistory>(
-            StorageShardedKey::new(addr, hc, 400),
-            &BlockNumberList::new([100u64, 400]).unwrap(),
+            StorageShardedKey::new(addr, hc, 2000),
+            &BlockNumberList::new(1u64..=2000).unwrap(),
         )?;
         batch.put::<tables::StoragesHistory>(
             StorageShardedKey::last(addr, hc),
-            &BlockNumberList::new([900u64]).unwrap(),
+            &BlockNumberList::new(2001u64..=4000).unwrap(),
         )?;
         batch.commit()?;
     }
@@ -1005,17 +1009,24 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
         "block 5 must survive (no clobber)"
     );
 
-    // slot_c (multi-shard) -> earliest shard gets 0 prepended; open shard untouched.
+    // slot_c (full first shard) -> re-chunked so block 0 lands in the earliest
+    // shard, every original block is preserved, and no shard exceeds the limit.
     let c = rocksdb.storage_history_shards(addr, hc)?; // ascending by highest block
+    assert_eq!(c.len(), 3, "4001 blocks re-chunk into three shards, got {}", c.len());
+    assert!(
+        c.iter().all(|(_, l)| (l.len() as usize) <= 2000),
+        "no shard may exceed NUM_OF_INDICES_IN_SHARD (2000)"
+    );
+    assert!(c[0].1.contains(0u64), "genesis block lands in the earliest shard");
     assert_eq!(
-        c[0].1.iter().collect::<Vec<u64>>(),
-        vec![0, 100, 400],
-        "genesis prepended into the earliest shard"
+        c.last().unwrap().0.sharded_key.highest_block_number,
+        u64::MAX,
+        "the last shard is the open (u64::MAX) shard"
     );
     assert_eq!(
-        c.last().unwrap().1.iter().collect::<Vec<u64>>(),
-        vec![900],
-        "the open shard's post-genesis history is preserved"
+        c.iter().flat_map(|(_, l)| l.iter()).collect::<Vec<u64>>(),
+        (0u64..=4000).collect::<Vec<u64>>(),
+        "all blocks preserved, sorted, no duplicates or loss"
     );
 
     // Idempotency: a second run is a no-op.
@@ -1023,6 +1034,11 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
     assert_eq!(again, 0, "second run must re-key nothing");
     assert_eq!(blocks(&rocksdb.storage_history_shards(addr, ha)?), vec![0]);
     assert_eq!(blocks(&rocksdb.storage_history_shards(addr, hb)?), vec![0, 5]);
+    assert_eq!(
+        blocks(&rocksdb.storage_history_shards(addr, hc)?),
+        (0u64..=4000).collect::<Vec<u64>>(),
+        "re-chunked slot is untouched on the second run"
+    );
 
     Ok(())
 }

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -884,3 +884,145 @@ fn test_rpc_validator() {
         }
     };
 }
+
+/// Full-DB check for `fix_genesis_history`: build a v2 storage stack, run
+/// canonical genesis init (which writes genesis storage history under the
+/// buggy plain slot), simulate the post-genesis history a replay would append
+/// under the hashed slot, then re-key and assert every case is correct.
+#[cfg(feature = "archive-replay")]
+#[tokio::test]
+async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::Result<()> {
+    use crate::{reth_env::RethEnv, traits::RaylsNode};
+    use alloy::primitives::keccak256;
+    use reth_db::{models::storage_sharded_key::StorageShardedKey, tables, BlockNumberList};
+    use reth_db_common::init::init_genesis_with_settings;
+    use reth_provider::{
+        providers::{RocksDBBuilder, StaticFileProvider},
+        ChainSpecProvider, ProviderFactory, RocksDBProviderFactory, StorageSettings,
+        StorageSettingsCache,
+    };
+    use std::collections::BTreeMap;
+
+    // genesis with one account holding three storage slots.
+    let addr = Address::from([0x11u8; 20]);
+    let slot_a = B256::from(U256::from(1u64)); // immutable: no post-genesis history
+    let slot_b = B256::from(U256::from(2u64)); // single-shard mutable
+    let slot_c = B256::from(U256::from(3u64)); // multi-shard mutable
+    let storage = BTreeMap::from([
+        (slot_a, B256::from(U256::from(0xAAu64))),
+        (slot_b, B256::from(U256::from(0xBBu64))),
+        (slot_c, B256::from(U256::from(0xCCu64))),
+    ]);
+    let genesis = rayls_infrastructure_types::test_genesis().extend_accounts([(
+        addr,
+        GenesisAccount {
+            balance: U256::from(1_000u64),
+            storage: Some(storage),
+            ..Default::default()
+        },
+    )]);
+
+    // v2 storage stack + canonical genesis init (writes plain-key history).
+    let tmp_dir = TempDir::new()?;
+    let datadir = tmp_dir.path().to_path_buf();
+    let db = Arc::new(reth_db::init_db(
+        datadir.join("db"),
+        reth_db::mdbx::DatabaseArguments::default(),
+    )?);
+    let rayls_chain_spec = Arc::new(
+        crate::chainspec::RaylsChainSpec::builder(Arc::new(RethChainSpec::from(genesis))).build(),
+    );
+    let rocksdb_provider =
+        RocksDBBuilder::new(datadir.join("rocksdb")).with_default_tables().build()?;
+    let static_files = StaticFileProvider::read_write(datadir.join("static_files"))?;
+    let runtime = reth_tasks::Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
+    let provider_factory: ProviderFactory<RaylsNode> =
+        ProviderFactory::new(db, rayls_chain_spec, static_files, rocksdb_provider, runtime)?;
+    let settings = StorageSettings::v2();
+    provider_factory.set_storage_settings_cache(settings);
+    init_genesis_with_settings(&provider_factory, settings)?;
+    let _ = provider_factory.chain_spec();
+
+    let (ha, hb, hc) = (keccak256(slot_a), keccak256(slot_b), keccak256(slot_c));
+
+    // Precondition (the bug): genesis history is keyed by the PLAIN slot, so the
+    // hashed keys the v2 read consults carry no genesis entry yet.
+    {
+        let rocksdb = provider_factory.rocksdb_provider();
+        for h in [ha, hb, hc] {
+            let shards = rocksdb.storage_history_shards(addr, h)?;
+            assert!(
+                shards.iter().all(|(_, l)| !l.contains(0u64)),
+                "hashed slot must lack the genesis entry before the fix"
+            );
+        }
+        assert!(
+            rocksdb.storage_history_shards(addr, slot_a)?.iter().any(|(_, l)| l.contains(0u64)),
+            "genesis writer put the entry under the plain slot (the bug)"
+        );
+    }
+
+    // Simulate post-genesis history under the HASHED keys, as replay's indexer
+    // would append: slot_b one open shard [5]; slot_c sealed [100,400] + open [900].
+    {
+        let rocksdb = provider_factory.rocksdb_provider();
+        let mut batch = rocksdb.batch();
+        batch.put::<tables::StoragesHistory>(
+            StorageShardedKey::last(addr, hb),
+            &BlockNumberList::new([5u64]).unwrap(),
+        )?;
+        batch.put::<tables::StoragesHistory>(
+            StorageShardedKey::new(addr, hc, 400),
+            &BlockNumberList::new([100u64, 400]).unwrap(),
+        )?;
+        batch.put::<tables::StoragesHistory>(
+            StorageShardedKey::last(addr, hc),
+            &BlockNumberList::new([900u64]).unwrap(),
+        )?;
+        batch.commit()?;
+    }
+
+    // Run the fix.
+    let fixed = RethEnv::fix_genesis_history_with(&provider_factory, true)?;
+    assert!(fixed >= 3, "expected at least our three slots re-keyed, got {fixed}");
+
+    let rocksdb = provider_factory.rocksdb_provider();
+    let blocks = |shards: &[(StorageShardedKey, BlockNumberList)]| -> Vec<u64> {
+        shards.iter().flat_map(|(_, l)| l.iter()).collect()
+    };
+
+    // slot_a (immutable) -> a fresh open shard [0].
+    assert_eq!(
+        blocks(&rocksdb.storage_history_shards(addr, ha)?),
+        vec![0],
+        "immutable genesis slot seeded with block 0"
+    );
+
+    // slot_b (single-shard mutable) -> [0, 5]: genesis added, post-genesis kept.
+    assert_eq!(
+        blocks(&rocksdb.storage_history_shards(addr, hb)?),
+        vec![0, 5],
+        "block 5 must survive (no clobber)"
+    );
+
+    // slot_c (multi-shard) -> earliest shard gets 0 prepended; open shard untouched.
+    let c = rocksdb.storage_history_shards(addr, hc)?; // ascending by highest block
+    assert_eq!(
+        c[0].1.iter().collect::<Vec<u64>>(),
+        vec![0, 100, 400],
+        "genesis prepended into the earliest shard"
+    );
+    assert_eq!(
+        c.last().unwrap().1.iter().collect::<Vec<u64>>(),
+        vec![900],
+        "the open shard's post-genesis history is preserved"
+    );
+
+    // Idempotency: a second run is a no-op.
+    let again = RethEnv::fix_genesis_history_with(&provider_factory, true)?;
+    assert_eq!(again, 0, "second run must re-key nothing");
+    assert_eq!(blocks(&rocksdb.storage_history_shards(addr, ha)?), vec![0]);
+    assert_eq!(blocks(&rocksdb.storage_history_shards(addr, hb)?), vec![0, 5]);
+
+    Ok(())
+}

--- a/etc/test-network/.env.example
+++ b/etc/test-network/.env.example
@@ -52,5 +52,11 @@ GASLESS=""
 # Custom block gas limit (in gas units). Leave empty for default (500M).
 GAS_LIMIT=""
 
+# Observer only: run observers as a full archive (drops `--full`, so
+# account/storage history is not pruned) — use when an observer's datadir will
+# seed `rayls-replay`. Left unset so an inline `DISABLE_PRUNING=1 ./local-testnet.sh`
+# is not overwritten when this file is sourced; uncomment to enable via .env.
+# DISABLE_PRUNING=1
+
 
 RL_BLS_PASSPHRASE="local"

--- a/etc/test-network/local-testnet.sh
+++ b/etc/test-network/local-testnet.sh
@@ -269,6 +269,14 @@ fi
 if [[ "$EXPOSE_WS" == "1" ]]; then
     FLAG_WS_API="--ws"
 fi
+# Observers only: `--full` prunes account/storage history to ~10k blocks. Set
+# DISABLE_PRUNING=1 to run observers as full archives (no pruning) so their
+# datadir can seed `rayls-replay`. Validators are unaffected.
+OBSERVER_FULL_FLAG="--full"
+if [[ "$DISABLE_PRUNING" == "1" || "$DISABLE_PRUNING" == "true" ]]; then
+    OBSERVER_FULL_FLAG=""
+    echo "DISABLE_PRUNING set: observers will run as full archives (no --full)"
+fi
 FLAG_TX_POOL_MAX_COUNT="50000"
 FLAG_TX_POOL_MAX_SIZE="1048556000"
 if [[ "$TX_POOL_LARGE_LIMITS" == "1" ]]; then
@@ -467,7 +475,7 @@ if [ "$START" = true ]; then
                 --instance "${OBSERVER_INSTANCE}" \
                 --metrics "${OBSERVER_METRICS}" \
                 --log.stdout.format log-fmt \
-                --full \
+                ${OBSERVER_FULL_FLAG} \
                 --storage.v2 \
                 ${FLAG_DB_GROW} \
                 ${FLAG_CONSENSUS_DB_GROW} \

--- a/etc/test-network/start-local-observer.sh
+++ b/etc/test-network/start-local-observer.sh
@@ -11,6 +11,15 @@ fi
 export RL_BLS_PASSPHRASE="$RL_BLS_PASSPHRASE"
 export RAYLS_NETWORK="$RAYLS_NETWORK"
 
+# `--full` prunes account/storage history to ~10k blocks. Set DISABLE_PRUNING=1
+# (in .env or inline) to run this observer as a full archive so its datadir can
+# seed `rayls-replay` with complete history.
+FULL_FLAG="--full"
+if [[ "$DISABLE_PRUNING" == "1" || "$DISABLE_PRUNING" == "true" ]]; then
+    FULL_FLAG=""
+    echo "DISABLE_PRUNING set: running observer as a full archive (no --full)"
+fi
+
 nodeNum="$1"
 if [[ "$nodeNum" == "" ]]; then
     echo -e "Error: You must specify the validator as 'start-local-observer.sh 1'";
@@ -26,7 +35,7 @@ rm -rf "$logFile"
             --instance "$nodeNum" \
             --metrics "127.0.0.1:910$nodeNum" \
             --log.stdout.format log-fmt \
-            --full \
+            ${FULL_FLAG} \
             --storage.v2 \
             --db.growth-step 1MB \
             --consensus-db.growth-step 1MB \


### PR DESCRIPTION
## Background: what is StorageV2?

reth has two on-disk storage layouts, chosen **per node at datadir init** and recorded in DB metadata (`--storage.v2` / `StorageSettings`), not by any chain hardfork:

- **v1 (legacy):** everything in MDBX, keyed by the plain address/slot.
- **v2 (StorageV2):** hashed state tables are canonical, the history indices (`AccountsHistory`, `StoragesHistory`) live in RocksDB, receipts/changesets in static files. Storage is keyed by `keccak256(slot)`.

StorageV2 doesn't change consensus, block validity, or the state root — only the on-disk layout. Rayls production snapshots (and archives built from them) are v2.

## The problem

On v2 archives, historical reads of **genesis-seeded storage** return `0x0` — e.g. `eth_getStorageAt` at an early block for the static validator set, or `eth_getCode` for immutable system contracts.

Root cause is in reth's v2 genesis init (`init_genesis_with_settings`), which writes genesis state and genesis history through separate paths and keys them inconsistently:

- **Storage history** — `insert_storage_history` keys `StoragesHistory` by the **plain** slot, but the v2 read looks it up by `keccak256(slot)` (`StorageSlotKey::to_hashed`). The read never finds the genesis entry → `NotYetWritten` → `0x0`. Present in **every** v2 genesis. (Genesis *state* is fine: `insert_genesis_hashes` writes `HashedStorages` under `keccak256(slot)` — which is why current-block reads work but historical ones don't.)
- **Account history** — write and read both use the **plain** address, so there's no mismatch; genesis account history is correct. It only breaks via `IndexAccountHistoryStage`'s first-sync clear, which `rayls-replay` never runs.

Genesis has no changeset (it's the initial state, not a change *from* a prior block), so the normal changeset-driven hashed indexing can't reconstruct genesis history — it must be repaired explicitly. This is fundamentally an upstream reth (v1.11.0) defect; we pin reth by tag and can't patch it, so the repair lives in the archive tooling.

## What's changed

**`fix_genesis_history`** (storage re-key — the necessary fix): for each genesis `(address, hashed slot)`, read-merges the genesis block into the **earliest existing shard** (via `storage_history_shards`), never overwriting the open shard. This preserves the post-genesis history of genesis slots that are also mutated later (balances, registry state) and places block 0 where an early-block read looks. When prepending would overflow a full shard (a hot genesis slot with ≥ `NUM_OF_INDICES_IN_SHARD` = 2000 post-genesis changes), the slot's shards are **re-chunked** into ≤2000 pieces (stale keys deleted, cascades handled). Per-slot prefix reads, no full-table scan; idempotent.

**`fix_genesis_account_history`** (account seed — defensive): re-seeds a block-0 entry for `≤1`-shard genesis accounts via read-merge; multi-shard accounts (post-genesis changesets) are left untouched. A no-op on replay-built archives; included as insurance for cleared-history archives.

**Wiring in `rayls-replay`:** both run automatically at the end of a normal replay, so freshly built archives boot correct with no extra step. `--fix_genesis_history` remains for repairing archives built before this (e.g. current mainnet). Both no-op on v1 archives and on already-correct entries. `open_db` is deferred past the maintenance/unwind early-return paths so those modes don't open the consensus DB.

**Test-network tooling:** `DISABLE_PRUNING` env var runs the local observer as a full archive (drops reth's `--full`, which otherwise prunes account/storage history beyond ~10k blocks), so its datadir can seed `rayls-replay`. Validators unaffected.

## Testing

Full-DB unit tests (`cargo test -p rayls-execution-evm --features archive-replay`) build a v2 storage stack, run canonical genesis init, and assert re-keying end to end:

- bug precondition (hashed key lacks the genesis entry, plain key carries it)
- immutable slot → `[0]`
- single-shard mutable slot → `[0, 5]` (post-genesis change not clobbered)
- **full first shard → re-chunk**: 4001 blocks split into three ≤2000 shards, block 0 in the earliest, open shard keyed `u64::MAX`, all blocks preserved
- idempotent second run
- account path: no-op when correct, re-seed after a simulated clear, skip multi-shard

Verified end to end on a local 4-node network: rebuilt an archive via `rayls-replay` and confirmed `eth_getStorageAt(RLS_PROXY, ERC1967_IMPL_SLOT, --block 1)` returns the implementation address, with a negative control (the un-fixed source datadir returns `0x0`).

## Notes for reviewers

- This PR is another approach to #18. Eventually one of the would land.
- The fix is `archive-replay`-gated, so it affects `rayls-replay` only; the live `rayls-network` node is unchanged. Live-synced archive observers are therefore not covered — repair their datadir with `rayls-replay --fix_genesis_history` if needed.
- Open follow-up: confirm the `archive-replay`-gated tests execute under CI's `cargo test --workspace` (feature unification via `bin/rayls-replay` should enable them).
