### PR TITLE
fix: silence spurious "sending on a closed channel" error on MDBX shutdown

### DIFF
--- a/crates/infrastructure/storage/src/mdbx/database.rs
+++ b/crates/infrastructure/storage/src/mdbx/database.rs
@@ -6,8 +6,10 @@ use std::{
     marker::PhantomData,
     path::Path,
     sync::{
-        mpsc::{self, SyncSender},
-        Arc, RwLock,
+        // Disabled with the MDBX metrics thread (removed in #54, f243308):
+        // mpsc::{self, SyncSender},
+        Arc,
+        RwLock,
     },
     time::Duration,
 };
@@ -355,21 +357,25 @@ impl DbTxMut for MdbxTxMut {
 pub struct MdbxDatabase {
     /// Libmdbx-sys environment.
     inner: Environment,
-    shutdown_tx: Arc<SyncSender<()>>,
+    // Disabled: metrics-thread shutdown channel, leftover after the thread was removed in #54.
+    // shutdown_tx: Arc<SyncSender<()>>,
     /// Cached MDBX DBIs.
     dbis: DbiCache,
 }
 
 impl Drop for MdbxDatabase {
     fn drop(&mut self) {
-        if Arc::strong_count(&self.shutdown_tx) <= 1 {
-            tracing::info!(target: "rayls::mdbx", "MDBX Dropping, shutting down metrics thread");
-            // shutdown_tx is a sync sender with no buffer so this should block until the thread
-            // reads it and shuts down.
-            if let Err(e) = self.shutdown_tx.send(()) {
-                tracing::error!(target: "rayls::mdbx", "Error while trying to send shutdown to MDBX metrics thread {e}");
-            }
-        }
+        // Disabled: the MDBX metrics thread was removed in #54 (f243308) but its shutdown channel
+        // was left behind. With the channel gone there is nothing to signal; the send below hit an
+        // already-closed channel and logged a spurious "sending on a closed channel" error on every
+        // shutdown. Kept as a no-op Drop. Do NOT re-enable as-is, and do NOT retain the rx to
+        // "fix" it: `sync_channel(0).send()` would then block forever on drop with no reader.
+        // if Arc::strong_count(&self.shutdown_tx) <= 1 {
+        //     tracing::info!(target: "rayls::mdbx", "MDBX Dropping, shutting down metrics thread");
+        //     if let Err(e) = self.shutdown_tx.send(()) {
+        //         tracing::error!(target: "rayls::mdbx", "Error while trying to send shutdown to
+        // MDBX metrics thread {e}");     }
+        // }
     }
 }
 
@@ -547,11 +553,12 @@ impl MdbxDatabase {
             }
         }
 
-        let (shutdown_tx, _rx) = mpsc::sync_channel::<()>(0);
+        // Metrics-thread shutdown channel disabled (thread removed in #54, f243308):
+        // let (shutdown_tx, _rx) = mpsc::sync_channel::<()>(0);
 
         Ok(MdbxDatabase {
             inner: env,
-            shutdown_tx: Arc::new(shutdown_tx),
+            // shutdown_tx: Arc::new(shutdown_tx),
             dbis: Arc::new(RwLock::new(HashMap::new())),
         })
     }


### PR DESCRIPTION
## Problem

Every clean shutdown logged:

level=error target=rayls::mdbx message="Error while trying to send shutdown to MDBX metrics thread sending on a closed channel"

## Root cause

The MDBX metrics thread was removed in #54 (`f243308`), but its shutdown
channel was left behind. `MdbxDatabase::new` still created a `sync_channel(0)`
and dropped the receiver at construction (`_rx`), keeping only `shutdown_tx`.
On `Drop`, `shutdown_tx.send(())` then targeted an already-closed channel — so
it failed and logged an error on every shutdown. Benign (there was no thread to
signal, nothing lost), just noisy and misleading.

## Change

Comment out the leftover channel plumbing — the `mpsc`/`SyncSender` import, the
`shutdown_tx` field, its construction, and the `Drop` body — keeping the `Drop`
impl as a documented no-op. Each site references #54 and warns against the two
wrong "fixes": re-enabling the send (errors as before) or retaining the rx
(`sync_channel(0).send()` would then block forever on drop with no reader).

No behavior change beyond removing the erroneous log line; builds clean with no
unused-import warnings.

Should we want the metrics thread back we can uncomment the channel signalization commented in this PR.