### PR TITLE
fix(promote): git-tag existence check misread 422 as an existing tag

### DIFF
--- a/.github/workflows/promote-docker.yml
+++ b/.github/workflows/promote-docker.yml
@@ -360,9 +360,9 @@ jobs:
             exit 0
           fi
 
-          # Idempotent + never-move: resolve any existing tag to its commit.
-          CUR=$(gh api "repos/$REPO/commits/$TAG" --jq '.sha' 2>/dev/null || true)
-          if [ -n "$CUR" ]; then
+          # Idempotent + never-move
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            CUR=$(gh api "repos/$REPO/commits/$TAG" --jq '.sha')
             if [ "$CUR" = "$COMMIT" ]; then
               echo "Tag $TAG already points at $COMMIT — nothing to do."
               exit 0


### PR DESCRIPTION
## Fix

Use the refs API (`git/ref/tags/$TAG`) for a clean existence check (real 404 when missing), and only resolve the commit when the tag actually exists. Create-only / never-move / idempotent semantics are unchanged.
