### PR TITLE
fix: exempt consensus recovery reads from the 30s MDBX read-txn timeout

### DIFF
--- a/crates/consensus/primary/src/consensus/state.rs
+++ b/crates/consensus/primary/src/consensus/state.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use consensus_metrics::monitored_future;
 use rayls_infrastructure_config::ConsensusConfig;
-use rayls_infrastructure_storage::{CertificateStore, ConsensusStore};
+use rayls_infrastructure_storage::{CertificateStore, ConsensusStore, ReadTimeout};
 use rayls_infrastructure_types::{
     AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, Committee, Database,
     Epoch, Hash as _, Noticer, RaylsReceiver, RaylsSender, Round, TaskManager, Timestamp,
@@ -104,7 +104,10 @@ impl ConsensusState {
 
         // Ascending round order + check_parents=true makes orphans self-reject
         // at insert time, yielding a sound-by-construction DAG.
-        let mut certificates = cert_store.after_round(gc_round + 1).expect("database available");
+        // Exempt from the read-txn timeout: a transient I/O stall must not turn this bounded
+        // recovery scan into a panic (which would kill the node mid-write and risk DB corruption).
+        let mut certificates =
+            cert_store.after_round(gc_round + 1, ReadTimeout::Exempt).expect("database available");
         certificates.sort_by_key(|c| c.round());
 
         let mut num_certs = 0;

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -11,7 +11,7 @@ use rayls_infrastructure_storage::{
         CertificateDigestByOrigin, ConsensusBlockNumbersByDigest, ConsensusBlocks,
         ConsensusBlocksCache,
     },
-    CertificateStore, ConsensusStore, ProposerStore,
+    CertificateStore, ConsensusStore, ProposerStore, ReadTimeout,
 };
 use rayls_infrastructure_types::{
     AuthorityIdentifier, Certificate, CertificateDigest, CommittedSubDag, ConsensusHeader,
@@ -379,7 +379,9 @@ async fn test_certificate_store_after_round() {
     // WHEN
     tracing::debug!("Access after round {round_cutoff}, before {total_rounds}");
     let now = Instant::now();
-    let result = store.after_round(round_cutoff).expect("Error returned while reading after_round");
+    let result = store
+        .after_round(round_cutoff, ReadTimeout::Enforced)
+        .expect("Error returned while reading after_round");
 
     tracing::debug!("Total time: {} seconds", now.elapsed().as_secs_f32());
 

--- a/crates/consensus/state-sync/src/lib.rs
+++ b/crates/consensus/state-sync/src/lib.rs
@@ -11,7 +11,7 @@ use rayls_consensus_primary::{
 use rayls_infrastructure_config::ConsensusConfig;
 use rayls_infrastructure_storage::{
     tables::{Batches, ConsensusBlockNumbersByDigest, ConsensusBlocks, ConsensusBlocksCache},
-    CertificateStore, CheckpointStore, ConsensusStore, EpochStore,
+    CertificateStore, CheckpointStore, ConsensusStore, EpochStore, ReadTimeout,
 };
 use rayls_infrastructure_types::{
     AuthorityIdentifier, ConsensusHeader, ConsensusOutput, Database, DbTx, DbTxMut, Epoch,
@@ -88,7 +88,7 @@ pub fn prime_consensus<DB: Database>(consensus_bus: &ConsensusBus, config: &Cons
     // rejoin gate and cert_manager's threshold see a consistent view.
     let gc_round = committed_round.saturating_sub(gc_depth);
     let (cert_store_max, cert_count) =
-        match config.node_storage().after_round(gc_round.saturating_add(1)) {
+        match config.node_storage().after_round(gc_round.saturating_add(1), ReadTimeout::Exempt) {
             Ok(certs) => {
                 let count = certs.len();
                 let max = certs.iter().map(|c| c.round()).max();

--- a/crates/infrastructure/storage/src/lib.rs
+++ b/crates/infrastructure/storage/src/lib.rs
@@ -24,7 +24,7 @@ pub mod mdbx;
 pub mod mem_db;
 pub mod redb;
 
-pub use rayls_infrastructure_types::error::StoreError;
+pub use rayls_infrastructure_types::{error::StoreError, ReadTimeout};
 
 use crate::mdbx::MdbxConfig;
 

--- a/crates/infrastructure/storage/src/stores/certificate_store.rs
+++ b/crates/infrastructure/storage/src/stores/certificate_store.rs
@@ -7,28 +7,13 @@ use crate::{
     StoreResult,
 };
 use rayls_infrastructure_types::{
-    AuthorityIdentifier, Certificate, CertificateDigest, Database, DbTx, DbTxMut, Hash, Round,
+    AuthorityIdentifier, Certificate, CertificateDigest, Database, DbTx, DbTxMut, Hash,
+    ReadTimeout, Round,
 };
 use rayls_infrastructure_utils::NotifyRead;
 
 static NOTIFY_SUBSCRIBERS: LazyLock<NotifyRead<CertificateDigest, Certificate>> =
     LazyLock::new(NotifyRead::new);
-
-/// Whether a read may opt out of the MDBX read-transaction timeout
-/// (`max_read_transaction_duration`, default 30s).
-///
-/// The timeout exists to stop leaked or hung readers from pinning the MVCC free-list and
-/// starving the writer. A bounded one-shot recovery scan (`prime_consensus`, DAG rebuild) can
-/// legitimately outlast it under I/O pressure — and being force-reset mid-recovery turns a
-/// transient storage stall into a hard failure. Such reads pass `Exempt` to run to completion;
-/// everything on a latency-sensitive path stays `Enforced`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ReadTimeout {
-    /// Subject to the configured read-transaction timeout.
-    Enforced,
-    /// Opt out of the timeout for a bounded, latency-insensitive scan.
-    Exempt,
-}
 
 /// Certificate persistence with round-based indexing and pub/sub on writes.
 ///

--- a/crates/infrastructure/storage/src/stores/certificate_store.rs
+++ b/crates/infrastructure/storage/src/stores/certificate_store.rs
@@ -14,6 +14,22 @@ use rayls_infrastructure_utils::NotifyRead;
 static NOTIFY_SUBSCRIBERS: LazyLock<NotifyRead<CertificateDigest, Certificate>> =
     LazyLock::new(NotifyRead::new);
 
+/// Whether a read may opt out of the MDBX read-transaction timeout
+/// (`max_read_transaction_duration`, default 30s).
+///
+/// The timeout exists to stop leaked or hung readers from pinning the MVCC free-list and
+/// starving the writer. A bounded one-shot recovery scan (`prime_consensus`, DAG rebuild) can
+/// legitimately outlast it under I/O pressure — and being force-reset mid-recovery turns a
+/// transient storage stall into a hard failure. Such reads pass `Exempt` to run to completion;
+/// everything on a latency-sensitive path stays `Enforced`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadTimeout {
+    /// Subject to the configured read-transaction timeout.
+    Enforced,
+    /// Opt out of the timeout for a bounded, latency-insensitive scan.
+    Exempt,
+}
+
 /// Certificate persistence with round-based indexing and pub/sub on writes.
 ///
 /// Cert store growth is bounded by epoch length; all tables are cleared
@@ -73,8 +89,11 @@ pub trait CertificateStore {
     fn delete(&self, id: CertificateDigest) -> StoreResult<()>;
 
     /// Retrieves all the certificates with round >= the provided round.
-    /// The result is returned with certificates sorted in round asc order
-    fn after_round(&self, round: Round) -> StoreResult<Vec<Certificate>>;
+    /// The result is returned with certificates sorted in round asc order.
+    ///
+    /// `timeout` controls whether this (potentially large) scan is subject to the read-transaction
+    /// timeout; recovery-path callers pass [`ReadTimeout::Exempt`].
+    fn after_round(&self, round: Round, timeout: ReadTimeout) -> StoreResult<Vec<Certificate>>;
 
     /// Retrieves origins with certificates in each round >= the provided round.
     fn origins_after_round(
@@ -237,10 +256,15 @@ impl<DB: Database> CertificateStore for DB {
 
     /// Retrieves all the certificates with round >= the provided round.
     /// The result is returned with certificates sorted in round asc order
-    fn after_round(&self, round: Round) -> StoreResult<Vec<Certificate>> {
+    fn after_round(&self, round: Round, timeout: ReadTimeout) -> StoreResult<Vec<Certificate>> {
         // Collect digests within a properly scoped read transaction
         // to ensure MDBX can reclaim dirty pages after the iterator completes
         self.with_read_txn(|txn| {
+            if timeout == ReadTimeout::Exempt {
+                // Bounded one-shot recovery scan: opt out of the read-txn cap so a transient I/O
+                // stall can't force-reset the txn mid-recovery and fail the caller.
+                txn.disable_long_read_safety();
+            }
             let iter = if round > 0 {
                 txn.skip_to::<CertificateDigestByRound>(
                     &(round - 1, AuthorityIdentifier::default()),

--- a/crates/infrastructure/types/src/database_traits.rs
+++ b/crates/infrastructure/types/src/database_traits.rs
@@ -24,6 +24,22 @@ pub trait Table: Send + Sync + Debug + 'static {
     const NAME: &'static str;
 }
 
+/// Whether a read may opt out of the MDBX read-transaction timeout
+/// (`max_read_transaction_duration`, default 30s).
+///
+/// The timeout exists to stop leaked or hung readers from pinning the MVCC free-list and
+/// starving the writer. A bounded one-shot recovery scan (`prime_consensus`, DAG rebuild) can
+/// legitimately outlast it under I/O pressure — and being force-reset mid-recovery turns a
+/// transient storage stall into a hard failure. Such reads pass `Exempt` to run to completion;
+/// everything on a latency-sensitive path stays `Enforced`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadTimeout {
+    /// Subject to the configured read-transaction timeout.
+    Enforced,
+    /// Opt out of the timeout for a bounded, latency-insensitive scan.
+    Exempt,
+}
+
 /// Interface to a DB read transaction.
 pub trait DbTx {
     /// Returns the value for the given key from the map, if it exists.


### PR DESCRIPTION
## Problem

A validator crash-looped into an unrecoverable "database is corrupted" state.
Root cause was a transient storage stall, not a logic bug.

Timeline from the incident logs:
- `~15:10:38` — the node's storage stalls; execution freezes (block stuck at
  4776429 for ~78s while consensus rounds keep advancing).
- `15:11:08 / 15:11:24 / 15:11:56` — three separate read transactions each hit
  the 30s `max_read_transaction_duration` cap ("Long-lived read transaction has
  been timed out"). Multiple unrelated readers timing out at once is an I/O
  stall signature, not a slow query.
- `15:11:56` — the DAG-rebuild read in `construct_dag_from_cert_store`
  (`after_round`) is one of them. Its `.expect("database available")` turns the
  timeout into a **panic**, killing the process mid-write.
- `15:11:57` onward — on restart MDBX `open()` returns `MDBX_CORRUPTED` (write
  map + `SafeNoSync`, killed mid-writeback during the stall). Crash loop with
  exponential backoff, never recovers.

The scan that panicked was tiny (~600 rounds; a healthy rebuild does 500 rounds
in ~76ms), which rules out "large scan" and confirms the stall.

## Fix

The read-txn timeout exists to stop leaked/hung readers from pinning the MVCC
free-list and starving the writer — worth keeping. But it should not guillotine
a **bounded, one-shot recovery scan** that legitimately runs long under I/O
pressure. The repo already has `disable_long_read_safety()` for exactly this
(used by the epoch-manager tally walk); `after_round` just never opted in.

- Add a self-documenting `ReadTimeout { Enforced, Exempt }` param to
  `after_round`.
- Both recovery callers pass `Exempt`:
  - `construct_dag_from_cert_store` (the crash path) — keeps its `.expect`,
    which now only fires on a *real* DB fault (panic-at-boot is correct there).
  - `prime_consensus` — now returns the correct `cert_store_round` instead of
    degrading to a stale value on timeout.
- The 30s cap still guards every other reader in the system.

