### PR TITLE
fix: stop intermittent empty `0x` reads at `latest` (keep canonical head in memory)

### DIFF
--- a/crates/execution/evm/src/reth_env/persistence.rs
+++ b/crates/execution/evm/src/reth_env/persistence.rs
@@ -35,9 +35,12 @@ impl RethEnv {
         // persist when canonical head is far enough ahead of last persisted block
         // and no persistence is already in-flight (matching reth's advance_persistence)
         if !state.in_progress() && state.should_persist(header.number) {
+            // Keep `persistence_threshold` (>=1) blocks resident in CIM so the
+            // canonical head is always served from memory, not a racing MDBX read.
             let blocks = Self::get_canonical_blocks_to_persist(
                 &self.canonical_in_memory_state(),
                 state.last_persisted_block.number,
+                state.persistence_threshold.max(1),
             );
             if !blocks.is_empty() {
                 let count = blocks.len();
@@ -105,19 +108,35 @@ impl RethEnv {
 
     /// Extract canonical blocks from in-memory state that need to be persisted.
     ///
-    /// Iterates by block number from `last_persisted + 1` to the canonical
-    /// head, using `state_by_number()` to look up each block. Blocks
-    /// inserted via batch `update_chain()` DO have parent links, but we
+    /// Iterates by block number from `last_persisted + 1` up to
+    /// `canonical_head - keep_in_memory`, using `state_by_number()` to look up
+    /// each block. The top `keep_in_memory` blocks (the head and its most recent
+    /// ancestors) are deliberately left resident in [`CanonicalInMemoryState`]
+    /// and never persisted here — so they are never evicted by the subsequent
+    /// `remove_persisted_blocks`, and a `latest` RPC read is always served from
+    /// the in-memory overlay rather than racing a not-yet-visible MDBX commit
+    /// (the source of intermittent empty `eth_call` results at the tip). Pass
+    /// `0` to persist everything up to the head (e.g. epoch-boundary flush).
+    ///
+    /// Blocks inserted via batch `update_chain()` DO have parent links, but we
     /// iterate by number for consistency with the persistence range.
     fn get_canonical_blocks_to_persist(
         canonical_in_memory_state: &CanonicalInMemoryState,
         last_persisted_block_number: u64,
+        keep_in_memory: u64,
     ) -> Vec<ExecutedBlock> {
         let canonical_head = canonical_in_memory_state.get_canonical_block_number();
-        let count = canonical_head.saturating_sub(last_persisted_block_number) as usize;
+        // Persist only up to `head - keep_in_memory`; the head + `keep_in_memory`
+        // ancestors must stay in CIM to serve `latest` without hitting the MDBX
+        // commit-visibility gap. Nothing to do if that leaves no new blocks.
+        let persist_target = canonical_head.saturating_sub(keep_in_memory);
+        if persist_target <= last_persisted_block_number {
+            return Vec::new();
+        }
+        let count = persist_target.saturating_sub(last_persisted_block_number) as usize;
         let mut blocks_to_persist = Vec::with_capacity(count);
 
-        for number in (last_persisted_block_number + 1)..=canonical_head {
+        for number in (last_persisted_block_number + 1)..=persist_target {
             if let Some(block_state) = canonical_in_memory_state.state_by_number(number) {
                 blocks_to_persist.push(block_state.block());
             } else {
@@ -134,6 +153,8 @@ impl RethEnv {
             count = blocks_to_persist.len(),
             last_persisted_block_number,
             canonical_head,
+            persist_target,
+            keep_in_memory,
             "extracted blocks to persist from canonical in-memory state",
         );
         blocks_to_persist.sort_unstable_by_key(|b| b.recovered_block.number());
@@ -284,9 +305,12 @@ impl RethEnv {
                 state.pending_started_at = None;
             }
 
+            // Epoch-boundary flush must persist everything up to the head before the
+            // consensus DB is cleared, so keep no buffer here.
             let blocks = RethEnv::get_canonical_blocks_to_persist(
                 &canonical_in_memory_state,
                 state.last_persisted_block.number,
+                0,
             );
 
             let total_blocks_to_persist = blocks.len();


### PR DESCRIPTION
## Problem

An `eth_call` at block tag `latest` intermittently returned empty `0x`
instead of the correct value — most visibly `getValidators` on the
ConsensusRegistry proxy at `0x07e1…e1`. The same call at a fixed
historic block always worked; only `latest` flipped between correct and
empty.

Root cause is a read/eviction race on `CanonicalInMemoryState` (CIM):

- The periodic persistence loop persisted blocks up to **and including**
  the canonical head, then `remove_persisted_blocks` evicted them from
  CIM — leaving the head's state only in MDBX.
- A concurrent RPC `latest()` reads head + CIM map + MDBX non-atomically.
  If it resolved head = N while N was being evicted from CIM and its own
  MDBX read txn predated the persist commit, it fell through to a state
  view with no code at the target account → the proxy `delegatecall`s
  into nothing → empty `0x`.
- `EmptyOutputBlock` mints a block every consensus round even when idle,
  so this persist→evict cycle ran constantly and the race fired often.

Historic blocks were always fine because they read a stable, committed
MDBX state below `last_persisted`.

## What's changed

`crates/execution/evm/src/reth_env/persistence.rs`:

- Added a `keep_in_memory: u64` parameter to
  `get_canonical_blocks_to_persist`; it now persists only up to
  `head - keep_in_memory` instead of up to `head`.
- **Periodic path** (`finalize_block`) passes `persistence_threshold.max(1)`,
  so the head + recent ancestors always stay resident in the CIM overlay
  and `latest` is served from memory — never racing an MDBX commit.
- **Flush path** (`flush_persistence`, epoch boundary) passes `0`, so it
  still persists everything up to the head before the consensus DB is
  cleared. Contract unchanged.

This restores reth's invariant that persistence lags the head by a
buffer (using the existing `persistence_threshold` knob — no new config).

## Verification

- `cargo check` / build clean.
- `reth_env` tests pass (7/7), including `test_rpc_validator` and
  `test_close_epochs` (the flush path).
- Unit tests confirm no regression but are single-threaded and don't
  reproduce the concurrency race; validated against a live node by
  hammering `getValidators @ latest` under idle load — no more `0x`.
