### PR TITLE
feat(ci): adding build pipeline for replay binary

### DIFF
--- a/.github/workflows/build-docker-replay.yml
+++ b/.github/workflows/build-docker-replay.yml
@@ -1,0 +1,143 @@
+name: Build & Push Replay Docker Image
+
+# Builds the historical-replay image (etc/docker-replay/Dockerfile) and pushes it
+# to the SAME private ECR repository as build-docker.yml, distinguished by a
+# `replay-<tag>` image tag.
+#
+# Manual only: this is an on-demand / debugging build with no automatic triggers.
+# Mirrors build-docker.yml for the ECR login, build-push, and scan steps.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag suffix (image is pushed as replay-<tag>, e.g. latest -> replay-latest)'
+        required: true
+        default: 'latest'
+      ref:
+        description: 'Git ref/branch/SHA to build from (default: this workflow ref)'
+        required: false
+        default: ''
+
+env:
+  IMAGE_NAME: rayls-stack-node-client
+  DOCKERFILE: etc/docker-replay/Dockerfile
+
+jobs:
+  # ===========================================================================
+  # BUILD - Build replay Docker image and push to private ECR
+  # ===========================================================================
+  build-and-push:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image-tag: ${{ steps.meta.outputs.version }}
+      commit: ${{ steps.meta.outputs.sha }}
+    env:
+      ECR_PRIVATE_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION_PRIVATE }}.amazonaws.com
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 1
+
+      - name: Determine image tag
+        id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          # Always prefix with `replay-` so the replay image is unambiguous even
+          # though it shares the ECR repository with the node-client build.
+          TAG="replay-${INPUT_TAG}"
+
+          SHA="$(git rev-parse HEAD)"
+          SHORT="$(git rev-parse --short HEAD)"
+
+          echo "version=$TAG" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT" >> $GITHUB_OUTPUT
+
+          {
+            echo "### Replay Image Build"
+            echo ""
+            echo "**Image tag:** \`$TAG\`"
+            echo "**Built from commit:** \`$SHORT\` ($SHA)"
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION_PRIVATE }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
+
+      - name: Create ECR repository if not exists
+        run: |
+          if ! aws ecr describe-repositories --repository-names "${{ env.IMAGE_NAME }}" 2>/dev/null; then
+            aws ecr create-repository --repository-name "${{ env.IMAGE_NAME }}"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./${{ env.DOCKERFILE }}
+          push: true
+          tags: ${{ env.ECR_PRIVATE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          build-args: |
+            VERGEN_GIT_SHA=${{ steps.meta.outputs.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ steps.meta.outputs.sha }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+          provenance: false
+
+  # ===========================================================================
+  # SECURITY SCAN - Trivy vulnerability scanning on the built image
+  # ===========================================================================
+  security-scan:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      ECR_PRIVATE_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION_PRIVATE }}.amazonaws.com
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION_PRIVATE }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2.1.5
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.ECR_PRIVATE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.image-tag }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          scanners: 'vuln,misconfig'
+          severity: 'HIGH,CRITICAL'
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Replay Docker Image Build" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.ECR_PRIVATE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.image-tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Built from commit:** \`${{ needs.build-and-push.outputs.commit }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Security scan:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

-

Closes #

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

<!-- Does this require a node restart, a network upgrade, a hardfork activation block, a contract migration, a config change, or any client coordination? If yes, describe. If no, write "None". -->

None.

## Test plan

<!-- What did you do to convince yourself this works? Commands, scenarios, or links to CI output. -->

- [ ]
- [ ]
