### PR TITLE
feat: dynamic committee

### DIFF
--- a/crates/execution/evm/src/chainspec.rs
+++ b/crates/execution/evm/src/chainspec.rs
@@ -170,13 +170,13 @@ pub const MAINNET_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 3_569_194;
 pub const LOCAL_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 0;
 
 /// DynamicCommitteeSizing activation block on the Rayls devnet
-pub const DEVNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
+pub const DEVNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = u64::MAX;
 
 /// DynamicCommitteeSizing activation block on the Rayls testnet
-pub const TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
+pub const TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = u64::MAX;
 
 /// DynamicCommitteeSizing activation block on the Rayls mainnet
-pub const MAINNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
+pub const MAINNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = u64::MAX;
 
 /// DynamicCommitteeSizing activation block on the local sandbox network.
 pub const LOCAL_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
@@ -217,7 +217,10 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(DEVNET_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Never),
             (Self::EmptyOutputBlock, ForkCondition::Block(DEVNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
-            (Self::DynamicCommitteeSizing, ForkCondition::Never),
+            (
+                Self::DynamicCommitteeSizing,
+                ForkCondition::Block(DEVNET_DYNAMIC_COMMITTEE_SIZING_BLOCK),
+            ),
         ]
     }
 
@@ -236,7 +239,10 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(TESTNET_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Never),
             (Self::EmptyOutputBlock, ForkCondition::Block(TESTNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
-            (Self::DynamicCommitteeSizing, ForkCondition::Never),
+            (
+                Self::DynamicCommitteeSizing,
+                ForkCondition::Block(TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK),
+            ),
         ]
     }
 
@@ -260,7 +266,10 @@ impl RaylsHardFork {
                 ForkCondition::Block(MAINNET_USDR_SUPPLY_CORRECTION_BLOCK),
             ),
             (Self::EmptyOutputBlock, ForkCondition::Block(MAINNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
-            (Self::DynamicCommitteeSizing, ForkCondition::Never),
+            (
+                Self::DynamicCommitteeSizing,
+                ForkCondition::Block(MAINNET_DYNAMIC_COMMITTEE_SIZING_BLOCK),
+            ),
         ]
     }
 

--- a/crates/execution/evm/src/chainspec.rs
+++ b/crates/execution/evm/src/chainspec.rs
@@ -49,13 +49,16 @@ hardfork!(
         /// Produce a fallback empty block for any consensus output that contributed no block
         /// (no batches, all deduped, or all parked), so every output maps to a block.
         EmptyOutputBlock,
+        /// Size the next epoch's committee based on Active validators (Active + PendingActivation)
+        /// instead of reusing the current epoch's fixed committee size.
+        DynamicCommitteeSizing,
     }
 );
 
 /// EIP-1559 activation block on the Rayls devnet.
 pub const DEVNET_EIP1559_BLOCK: u64 = 50;
 /// EIP-1559 activation block on the Rayls testnet.
-pub const TESTNET_EIP1559_BLOCK: u64 = 281800; // TODO: TBD!
+pub const TESTNET_EIP1559_BLOCK: u64 = 281800;
 /// EIP-1559 activation block on Rayls mainnet.
 pub const MAINNET_EIP1559_BLOCK: u64 = 0;
 /// EIP-1559 activation block on local network.
@@ -64,7 +67,7 @@ pub const LOCAL_EIP1559_BLOCK: u64 = 0;
 /// BatchDigestV2 activation block on Rayls devnet.
 pub const DEVNET_BATCH_DIGEST_V2_BLOCK: u64 = 100;
 /// BatchDigestV2 activation block on Rayls testnet.
-pub const TESTNET_BATCH_DIGEST_V2_BLOCK: u64 = 560539; // TODO: set to actual testnet block before deploy
+pub const TESTNET_BATCH_DIGEST_V2_BLOCK: u64 = 560539;
 /// BatchDigestV2 activation block on Rayls mainnet.
 pub const MAINNET_BATCH_DIGEST_V2_BLOCK: u64 = 0;
 /// BatchDigestV2 activation block on local network.
@@ -73,14 +76,14 @@ pub const LOCAL_BATCH_DIGEST_V2_BLOCK: u64 = 0;
 /// AdminTransfer activation block on Rayls devnet.
 pub const DEVNET_ADMIN_TRANSFER_BLOCK: u64 = 150;
 /// AdminTransfer activation block on Rayls testnet.
-pub const TESTNET_ADMIN_TRANSFER_BLOCK: u64 = 560539; // TODO: set to actual testnet block before deploy
+pub const TESTNET_ADMIN_TRANSFER_BLOCK: u64 = 560539;
 /// AdminTransfer activation block on local network.
 pub const LOCAL_ADMIN_TRANSFER_BLOCK: u64 = 0;
 
 /// PrecompileGasFix activation block on Rayls devnet.
 pub const DEVNET_PRECOMPILE_GAS_FIX_BLOCK: u64 = 150;
 /// PrecompileGasFix activation block on Rayls testnet.
-pub const TESTNET_PRECOMPILE_GAS_FIX_BLOCK: u64 = 900000; // TODO: set to actual testnet block before deploy
+pub const TESTNET_PRECOMPILE_GAS_FIX_BLOCK: u64 = 900000;
 /// PrecompileGasFix activation block on Rayls mainnet.
 pub const MAINNET_PRECOMPILE_GAS_FIX_BLOCK: u64 = 0;
 /// PrecompileGasFix activation block on local network.
@@ -141,6 +144,9 @@ pub const LOCAL_LOAD_BALANCING_BLOCK: u64 = 0;
 // `ForkCondition::Block(<chosen block>)` when ready. See
 // `crates/execution/evm/src/evm/hardforks/usdr_supply_correction.rs`.
 
+/// UsdrSupplyCorrection activation block on the Rayls mainnet.
+pub const MAINNET_USDR_SUPPLY_CORRECTION_BLOCK: u64 = 3_569_194;
+
 /// UsdrSupplyCorrection activation block on the local sandbox network.
 ///
 /// Used for manual end-to-end testing of the hardfork (start chain → mint/burn
@@ -151,9 +157,6 @@ pub const LOCAL_LOAD_BALANCING_BLOCK: u64 = 0;
 /// without a long wait.
 pub const LOCAL_USDR_SUPPLY_CORRECTION_BLOCK: u64 = 100;
 
-/// EmptyOutputBlock activation block on the local sandbox network.
-pub const LOCAL_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 0;
-
 /// EmptyOutputBlock activation block on the Rayls devnet (active from genesis).
 pub const DEVNET_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 0;
 
@@ -163,8 +166,20 @@ pub const TESTNET_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 6_663_630;
 /// EmptyOutputBlock activation block on the Rayls mainnet.
 pub const MAINNET_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 3_569_194;
 
-/// UsdrSupplyCorrection activation block on the Rayls mainnet.
-pub const MAINNET_USDR_SUPPLY_CORRECTION_BLOCK: u64 = 3_569_194;
+/// EmptyOutputBlock activation block on the local sandbox network.
+pub const LOCAL_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 0;
+
+/// DynamicCommitteeSizing activation block on the Rayls devnet
+pub const DEVNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
+
+/// DynamicCommitteeSizing activation block on the Rayls testnet
+pub const TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
+
+/// DynamicCommitteeSizing activation block on the Rayls mainnet
+pub const MAINNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
+
+/// DynamicCommitteeSizing activation block on the local sandbox network.
+pub const LOCAL_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 0;
 
 impl RaylsHardFork {
     /// Return the protocol version byte for this hardfork.
@@ -181,11 +196,12 @@ impl RaylsHardFork {
             Self::TransactionLoadBalancing => 0x09,
             Self::UsdrSupplyCorrection => 0x0a,
             Self::EmptyOutputBlock => 0x0b,
+            Self::DynamicCommitteeSizing => 0x0c,
         }
     }
 
     /// Devnet hardfork schedule.
-    pub const fn devnet() -> [(Self, ForkCondition); 11] {
+    pub const fn devnet() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(DEVNET_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(DEVNET_BATCH_DIGEST_V2_BLOCK)),
@@ -201,11 +217,12 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(DEVNET_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Never),
             (Self::EmptyOutputBlock, ForkCondition::Block(DEVNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::DynamicCommitteeSizing, ForkCondition::Never),
         ]
     }
 
     /// Testnet hardfork schedule.
-    pub const fn testnet() -> [(Self, ForkCondition); 11] {
+    pub const fn testnet() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(TESTNET_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(TESTNET_BATCH_DIGEST_V2_BLOCK)),
@@ -219,11 +236,12 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(TESTNET_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Never),
             (Self::EmptyOutputBlock, ForkCondition::Block(TESTNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::DynamicCommitteeSizing, ForkCondition::Never),
         ]
     }
 
     /// Mainnet hardfork schedule.
-    pub const fn mainnet() -> [(Self, ForkCondition); 11] {
+    pub const fn mainnet() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(MAINNET_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(MAINNET_BATCH_DIGEST_V2_BLOCK)),
@@ -242,11 +260,12 @@ impl RaylsHardFork {
                 ForkCondition::Block(MAINNET_USDR_SUPPLY_CORRECTION_BLOCK),
             ),
             (Self::EmptyOutputBlock, ForkCondition::Block(MAINNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::DynamicCommitteeSizing, ForkCondition::Never),
         ]
     }
 
     /// Local network hardfork schedule (first four hardforks active at genesis).
-    pub const fn local() -> [(Self, ForkCondition); 11] {
+    pub const fn local() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(LOCAL_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(LOCAL_BATCH_DIGEST_V2_BLOCK)),
@@ -262,11 +281,15 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(LOCAL_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Block(LOCAL_USDR_SUPPLY_CORRECTION_BLOCK)),
             (Self::EmptyOutputBlock, ForkCondition::Block(LOCAL_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (
+                Self::DynamicCommitteeSizing,
+                ForkCondition::Block(LOCAL_DYNAMIC_COMMITTEE_SIZING_BLOCK),
+            ),
         ]
     }
 
     /// Return the hardfork schedule for the given network.
-    pub const fn for_network(network: RaylsNetwork) -> [(Self, ForkCondition); 11] {
+    pub const fn for_network(network: RaylsNetwork) -> [(Self, ForkCondition); 12] {
         match network {
             RaylsNetwork::Devnet => Self::devnet(),
             RaylsNetwork::Testnet => Self::testnet(),
@@ -389,6 +412,11 @@ pub trait RaylsHardforks {
     /// Return true if the EmptyOutputBlock fork is active at `block`.
     fn is_empty_output_block_active_at_block(&self, block: u64) -> bool {
         self.is_rayls_fork_active_at_block(RaylsHardFork::EmptyOutputBlock, block)
+    }
+
+    /// Return true if the DynamicCommitteeSizing fork is active at `block`.
+    fn is_dynamic_committee_sizing_active_at_block(&self, block: u64) -> bool {
+        self.is_rayls_fork_active_at_block(RaylsHardFork::DynamicCommitteeSizing, block)
     }
 
     /// Return the active version byte at `block`, if any.
@@ -798,8 +826,8 @@ mod tests {
     fn local_network_version_byte_at_block_0() {
         let hardforks = RaylsChainHardforks::local();
         let version = hardforks.version_byte_at_block(0);
-        // EmptyOutputBlock (0x0b) activates at block 0 on local and is the highest such fork.
-        assert_eq!(version, Some(0x0b));
+        // DynamicCommitteeSizing (0x0c) activates at block 0 on local and is the highest such fork.
+        assert_eq!(version, Some(0x0c));
     }
 
     // ── Schedule and version tests ──────────────────────────────────────
@@ -813,7 +841,7 @@ mod tests {
             RaylsNetwork::Local,
         ] {
             let schedule = RaylsHardFork::for_network(network);
-            assert_eq!(schedule.len(), 11, "expected 11 hardforks for {network}");
+            assert_eq!(schedule.len(), 12, "expected 12 hardforks for {network}");
             assert_eq!(schedule[0].0, RaylsHardFork::Eip1559);
             assert_eq!(schedule[1].0, RaylsHardFork::BatchDigestV2);
             assert_eq!(schedule[2].0, RaylsHardFork::AdminTransfer);
@@ -825,6 +853,7 @@ mod tests {
             assert_eq!(schedule[8].0, RaylsHardFork::TransactionLoadBalancing);
             assert_eq!(schedule[9].0, RaylsHardFork::UsdrSupplyCorrection);
             assert_eq!(schedule[10].0, RaylsHardFork::EmptyOutputBlock);
+            assert_eq!(schedule[11].0, RaylsHardFork::DynamicCommitteeSizing);
         }
     }
 

--- a/crates/execution/evm/src/chainspec.rs
+++ b/crates/execution/evm/src/chainspec.rs
@@ -583,6 +583,14 @@ impl RaylsChainSpecBuilder {
         self
     }
 
+    /// Activate DynamicCommitteeSizing at `block`.
+    pub fn dynamic_committee_sizing(mut self, block: u64) -> Self {
+        self.inner
+            .hardforks
+            .insert(RaylsHardFork::DynamicCommitteeSizing, ForkCondition::Block(block));
+        self
+    }
+
     /// Set the minimum EIP-1559 base fee floor.
     pub fn min_base_fee(mut self, min_base_fee: u64) -> Self {
         self.min_base_fee = min_base_fee;

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -399,7 +399,7 @@ where
         let new_committee_addresses =
             new_committee.into_iter().map(|v| v.validatorAddress).collect::<Vec<_>>();
 
-        trace!(target: "engine",  ?new_committee_size, ?new_committee_addresses, "truncated shuffle for new committee");
+        trace!(target: "engine",  ?new_committee_size, ?new_committee_addresses, "new committee");
 
         Ok(new_committee_addresses)
     }
@@ -517,7 +517,7 @@ where
             target: "engine",
             for_epoch = epoch + 3,
             new_committee_size = new_committee.len(),
-            "next_committee: new comittee size"
+            "next_committee: new committee size"
         );
 
         // this will fail on-chain if incorrect
@@ -849,8 +849,7 @@ where
         // don't support prague deposit requests
         let requests = Requests::default();
 
-        // potentially close epoch boundary (current we don't need the randomness data because
-        // validator set it not shuffled)
+        // potentially close epoch boundary
         if let Some(randomness) = self.ctx.close_epoch {
             debug!(target: "engine", "ctx indicates close epoch");
             let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -323,17 +323,17 @@ where
                 target: "engine",
                 nonce = self.ctx.nonce,
                 epoch,
-                "conclude epoch: called with EMPTY committee - aborting to prevent contract revert"
+                "concludeEpoch: called with EMPTY committee - aborting to prevent contract revert"
             );
             return Err(RaylsRethError::EVMCustom(format!(
-                "conclude epoch: empty committee at epoch {epoch} - \
+                "concludeEpoch: empty committee at epoch {epoch} - \
                  see 'NO ACTIVE VALIDATORS' log for validator statuses"
             )));
         }
 
         // sort addresses in ascending order (0x0...0xf)
         new_committee.sort();
-        info!(target: "engine", committee_size = new_committee.len(), "conclude epoch: committee");
+        info!(target: "engine", committee_size = new_committee.len(), "concludeEpoch: committee");
 
         // encode the call to bytes with method selector and args
         let bytes = ConsensusRegistry::concludeEpochCall { newCommittee: new_committee }

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -314,7 +314,7 @@ where
 
     /// Generate calldata for updating the ConsensusRegistry to conclude the epoch.
     fn generate_conclude_epoch_calldata(&mut self, randomness: B256) -> RaylsRethResult<Bytes> {
-        // shuffle all validators for new committee
+        // build committee for next epoch (pre-fork: shuffled; post-fork: sorted, no shuffle)
         let mut new_committee = self.new_committee(randomness)?;
 
         if new_committee.is_empty() {
@@ -399,7 +399,7 @@ where
         let new_committee_addresses =
             new_committee.into_iter().map(|v| v.validatorAddress).collect::<Vec<_>>();
 
-        trace!(target: "engine",  ?new_committee_size, ?new_committee_addresses, "new committee");
+        trace!(target: "engine", ?new_committee_size, ?new_committee_addresses, "new committee");
 
         Ok(new_committee_addresses)
     }

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -16,7 +16,6 @@ use alloy::{
     sol_types::SolCall as _,
 };
 use alloy_evm::{block::StateChangeSource, eth::EthTxResult, tx::RecoveredTx as _, Database, Evm};
-use rand::{rngs::StdRng, Rng as _, SeedableRng as _};
 use rayls_infrastructure_types::{
     rewards::build_withdrawals, Address, Bytes, Encodable2718, ExecHeader, Receipt, SolValue,
     TransactionSigned, Withdrawals, B256, EMPTY_WITHDRAWALS, U256,
@@ -227,9 +226,9 @@ where
     }
 
     /// Apply the closing epoch call to ConsensusRegistry.
-    fn apply_closing_epoch_contract_call(&mut self, randomness: B256) -> RaylsRethResult<()> {
-        debug!(target: "engine", ?randomness, "applying closing contract call");
-        let calldata = self.generate_conclude_epoch_calldata(randomness)?;
+    fn apply_closing_epoch_contract_call(&mut self) -> RaylsRethResult<()> {
+        debug!(target: "engine", "applying closing contract call");
+        let calldata = self.generate_conclude_epoch_calldata()?;
         trace!(target: "engine", ?calldata, "close epoch calldata");
 
         // execute system call to consensus registry
@@ -313,9 +312,9 @@ where
     }
 
     /// Generate calldata for updating the ConsensusRegistry to conclude the epoch.
-    fn generate_conclude_epoch_calldata(&mut self, randomness: B256) -> RaylsRethResult<Bytes> {
+    fn generate_conclude_epoch_calldata(&mut self) -> RaylsRethResult<Bytes> {
         // shuffle all validators for new committee
-        let mut new_committee = self.shuffle_new_committee(randomness)?;
+        let mut new_committee = self.new_committee()?;
 
         if new_committee.is_empty() {
             let epoch = self.extract_epoch_from_nonce(self.ctx.nonce);
@@ -366,15 +365,12 @@ where
         Ok(bytes)
     }
 
-    /// Read eligible validators from latest state and shuffle the committee deterministically.
-    fn shuffle_new_committee(&mut self, randomness: B256) -> RaylsRethResult<Vec<Address>> {
+    /// Read eligible validators from latest state
+    fn new_committee(&mut self) -> RaylsRethResult<Vec<Address>> {
         let block_number = self.evm.block().number().saturating_to::<u64>();
 
-        let mut new_committee: Vec<ValidatorInfo> = self.next_committee(block_number)?;
+        let new_committee: Vec<ValidatorInfo> = self.next_committee(block_number)?;
         let new_committee_size = new_committee.len();
-
-        // read all active validators from consensus registry
-        // let all_active_validators = self.get_active_validators()?;
 
         info!(
             target: "engine",
@@ -396,64 +392,8 @@ where
             );
         }
 
-        // create seed from hashed bls agg signature
-        let mut seed = [0; 32];
-        seed.copy_from_slice(randomness.as_slice());
-        trace!(target: "engine", ?seed, "seed after");
-
-        // used as deterministic randomness
-        let mut rng = StdRng::from_seed(seed);
-
-        // 1) separate active and pending validators
-        // 2) check if active length is sufficient
-        // 3) if missing, randomly select from the pending validators (pre-fork only)
-        // TODO: Why we're getting pending exit from active?!
-        // let (pending_exit, mut active_validators): (Vec<_>, Vec<_>) = new_committee
-        //     .into_iter()
-        //     .partition(|v| v.currentStatus == ValidatorStatus::PendingExit);
-
-        // let active_validator_count = active_validators.len();
-        // let mut validators_for_shuffle = if active_validator_count >= new_committee_size {
-        //     // enough active validators for next committee
-        //     active_validators
-        // } else if self.spec.is_dynamic_committee_sizing_active_at_block(block_number) {
-        //     // Post-fork: the committee size already equals the eligible count,
-        //     // so this branch should be unreachable. Return a clear error rather
-        //     // than silently pulling from pending-exit validators.
-        //     error!(
-        //         target: "engine",
-        //         active_validator_count,
-        //         new_committee_size,
-        //         "DynamicCommitteeSizing: active count < committee size - state mismatch"
-        //     );
-        //     return Err(RaylsRethError::EVMCustom(
-        //         "DynamicCommitteeSizing invariant violated: \
-        //          active validator count < committee size"
-        //             .to_string(),
-        //     ));
-        // } else {
-        //     // Pre-fork legacy: pull from PendingExit to maintain fixed committee size
-        //     let num_missing = new_committee_size - active_validator_count;
-
-        //     // randomly take enough pending exit validators to reach new committee size
-        //     let random_pending = pending_exit.into_iter().choose_multiple(&mut rng, num_missing);
-        //     active_validators.extend(random_pending);
-        //     active_validators
-        // };
-
-        // simple Fisher-Yates shuffle
-        for i in (1..new_committee.len()).rev() {
-            let j = rng.random_range(0..=i);
-            new_committee.swap(i, j);
-        }
-
-        debug!(target: "engine",  "validators post-shuffle {:?}", new_committee);
-
         let new_committee_addresses =
             new_committee.into_iter().map(|v| v.validatorAddress).collect::<Vec<_>>();
-
-        // // trim the shuffled committee to maintain correct size
-        // new_committee.truncate(new_committee_size);
 
         trace!(target: "engine",  ?new_committee_size, ?new_committee_addresses, "truncated shuffle for new committee");
 
@@ -489,7 +429,7 @@ where
 
         info!(
             target: "engine",
-            epoch = epoch + 2,
+            for_epoch = epoch + 3,
             new_committee_size = new_committee.len(),
             "next_committee: new comittee size"
         );
@@ -823,37 +763,37 @@ where
         // don't support prague deposit requests
         let requests = Requests::default();
 
-        // potentially close epoch boundary
-        if let Some(randomness) = self.ctx.close_epoch {
-            debug!(target: "engine", ?randomness, "ctx indicates close epoch");
-            let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();
-            self.apply_consensus_block_rewards(tally).map_err(|e| {
-                BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
-            })?;
+        // potentially close epoch boundary (current we don't need the randomness data because validator set it not shuffled)
+        // if let Some(randomness) = self.ctx.close_epoch {
+        debug!(target: "engine", "ctx indicates close epoch");
+        let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();
+        self.apply_consensus_block_rewards(tally).map_err(|e| {
+            BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
+        })?;
 
-            self.apply_closing_epoch_contract_call(randomness).map_err(|e| {
-                BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
-            })?;
+        self.apply_closing_epoch_contract_call().map_err(|e| {
+            BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
+        })?;
 
-            // best-effort, never blocks epoch close; testnet archive replay skips the
-            // historical reward-distribution outage window to match canonical state
-            #[cfg(feature = "archive-replay")]
-            let skip_distribution =
-                self.spec.is_tokenomics_outage_block(self.evm.block().number().saturating_to());
-            #[cfg(not(feature = "archive-replay"))]
-            let skip_distribution = false;
-            if !skip_distribution {
-                match self.apply_reward_distribution() {
-                    Ok(()) => {}
-                    Err(e) => {
-                        error!(target: "engine", "reward distribution failed (non-fatal): {:?}", e);
-                    }
+        // best-effort, never blocks epoch close; testnet archive replay skips the
+        // historical reward-distribution outage window to match canonical state
+        #[cfg(feature = "archive-replay")]
+        let skip_distribution =
+            self.spec.is_tokenomics_outage_block(self.evm.block().number().saturating_to());
+        #[cfg(not(feature = "archive-replay"))]
+        let skip_distribution = false;
+        if !skip_distribution {
+            match self.apply_reward_distribution() {
+                Ok(()) => {}
+                Err(e) => {
+                    error!(target: "engine", "reward distribution failed (non-fatal): {:?}", e);
                 }
             }
-
-            // merge transitions into bundle state
-            self.evm.db_mut().merge_transitions(BundleRetention::Reverts);
         }
+
+        // merge transitions into bundle state
+        self.evm.db_mut().merge_transitions(BundleRetention::Reverts);
+        // }
 
         Ok((
             self.evm,

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -16,7 +16,7 @@ use alloy::{
     sol_types::SolCall as _,
 };
 use alloy_evm::{block::StateChangeSource, eth::EthTxResult, tx::RecoveredTx as _, Database, Evm};
-use rand::{rngs::StdRng, seq::IteratorRandom, Rng as _, SeedableRng as _};
+use rand::{rngs::StdRng, Rng as _, SeedableRng as _};
 use rayls_infrastructure_types::{
     rewards::build_withdrawals, Address, Bytes, Encodable2718, ExecHeader, Receipt, SolValue,
     TransactionSigned, Withdrawals, B256, EMPTY_WITHDRAWALS, U256,
@@ -323,17 +323,17 @@ where
                 target: "engine",
                 nonce = self.ctx.nonce,
                 epoch,
-                "concludeEpoch called with EMPTY committee - aborting to prevent contract revert"
+                "conclude epoch: called with EMPTY committee - aborting to prevent contract revert"
             );
             return Err(RaylsRethError::EVMCustom(format!(
-                "concludeEpoch: empty committee at epoch {epoch} - \
+                "conclude epoch: empty committee at epoch {epoch} - \
                  see 'NO ACTIVE VALIDATORS' log for validator statuses"
             )));
         }
 
         // sort addresses in ascending order (0x0...0xf)
         new_committee.sort();
-        info!(target: "engine", committee_size = new_committee.len(), "concludeEpoch committee");
+        info!(target: "engine", committee_size = new_committee.len(), "conclude epoch: committee");
 
         // encode the call to bytes with method selector and args
         let bytes = ConsensusRegistry::concludeEpochCall { newCommittee: new_committee }
@@ -368,22 +368,23 @@ where
 
     /// Read eligible validators from latest state and shuffle the committee deterministically.
     fn shuffle_new_committee(&mut self, randomness: B256) -> RaylsRethResult<Vec<Address>> {
-        let new_committee_size = self.next_committee_size()?;
+        let block_number = self.evm.block().number().saturating_to::<u64>();
+
+        let mut new_committee: Vec<ValidatorInfo> = self.next_committee(block_number)?;
+        let new_committee_size = new_committee.len();
 
         // read all active validators from consensus registry
-        let all_active_validators = self.get_active_validators()?;
+        // let all_active_validators = self.get_active_validators()?;
 
         info!(
             target: "engine",
             new_committee_size,
-            active_validators = all_active_validators.len(),
-            "shuffle_new_committee: read active validators"
+            "shuffle_new_committee: read validators (Active + PendingActivation)"
         );
 
-        if all_active_validators.is_empty() {
+        if new_committee.is_empty() {
             // query ALL validators (Any status) to understand their statuses
             let all_validators = self.get_all_validators()?;
-
             error!(
                 target: "engine",
                 total_validators = all_validators.len(),
@@ -405,80 +406,96 @@ where
 
         // 1) separate active and pending validators
         // 2) check if active length is sufficient
-        // 3) if missing, randomly select from the pending validators
-        let (pending_exit, mut active_validators): (Vec<_>, Vec<_>) = all_active_validators
-            .into_iter()
-            .partition(|v| v.currentStatus == ValidatorStatus::PendingExit);
+        // 3) if missing, randomly select from the pending validators (pre-fork only)
+        // TODO: Why we're getting pending exit from active?!
+        // let (pending_exit, mut active_validators): (Vec<_>, Vec<_>) = new_committee
+        //     .into_iter()
+        //     .partition(|v| v.currentStatus == ValidatorStatus::PendingExit);
 
-        let active_validator_count = active_validators.len();
-        let mut validators_for_shuffle = if active_validator_count >= new_committee_size {
-            // enough active validators for next committee
-            active_validators
-        } else {
-            // NOTE: already checked if active_validator_count >= new_committee_size above
-            let num_missing = new_committee_size - active_validator_count;
+        // let active_validator_count = active_validators.len();
+        // let mut validators_for_shuffle = if active_validator_count >= new_committee_size {
+        //     // enough active validators for next committee
+        //     active_validators
+        // } else if self.spec.is_dynamic_committee_sizing_active_at_block(block_number) {
+        //     // Post-fork: the committee size already equals the eligible count,
+        //     // so this branch should be unreachable. Return a clear error rather
+        //     // than silently pulling from pending-exit validators.
+        //     error!(
+        //         target: "engine",
+        //         active_validator_count,
+        //         new_committee_size,
+        //         "DynamicCommitteeSizing: active count < committee size - state mismatch"
+        //     );
+        //     return Err(RaylsRethError::EVMCustom(
+        //         "DynamicCommitteeSizing invariant violated: \
+        //          active validator count < committee size"
+        //             .to_string(),
+        //     ));
+        // } else {
+        //     // Pre-fork legacy: pull from PendingExit to maintain fixed committee size
+        //     let num_missing = new_committee_size - active_validator_count;
 
-            // randomly take enough pending exit validators to reach new committee size
-            let random_pending = pending_exit.into_iter().choose_multiple(&mut rng, num_missing);
-            active_validators.extend(random_pending);
-            active_validators
-        };
+        //     // randomly take enough pending exit validators to reach new committee size
+        //     let random_pending = pending_exit.into_iter().choose_multiple(&mut rng, num_missing);
+        //     active_validators.extend(random_pending);
+        //     active_validators
+        // };
 
         // simple Fisher-Yates shuffle
-        for i in (1..validators_for_shuffle.len()).rev() {
+        for i in (1..new_committee.len()).rev() {
             let j = rng.random_range(0..=i);
-            validators_for_shuffle.swap(i, j);
+            new_committee.swap(i, j);
         }
 
-        debug!(target: "engine",  "validators post-shuffle {:?}", validators_for_shuffle);
+        debug!(target: "engine",  "validators post-shuffle {:?}", new_committee);
 
-        let mut new_committee =
-            validators_for_shuffle.into_iter().map(|v| v.validatorAddress).collect::<Vec<_>>();
+        let new_committee_addresses =
+            new_committee.into_iter().map(|v| v.validatorAddress).collect::<Vec<_>>();
 
-        // trim the shuffled committee to maintain correct size
-        new_committee.truncate(new_committee_size);
+        // // trim the shuffled committee to maintain correct size
+        // new_committee.truncate(new_committee_size);
 
-        trace!(target: "engine",  ?new_committee_size, ?new_committee, "truncated shuffle for new committee");
+        trace!(target: "engine",  ?new_committee_size, ?new_committee_addresses, "truncated shuffle for new committee");
 
-        Ok(new_committee)
+        Ok(new_committee_addresses)
     }
 
-    /// Return the next committee size.
+    /// Return the next committee.
     ///
-    /// This is isolated into a function and requires a fork to change.
-    fn next_committee_size(&mut self) -> RaylsRethResult<usize> {
+    /// Pre-fork: reuses the current epoch's committee so the size is fixed across epochs
+    /// Post-fork: counts (Active + PendingActivation) validators so the committee dynamically grows/shrinks with the validator set.
+    fn next_committee(&mut self, block_number: u64) -> RaylsRethResult<Vec<ValidatorInfo>> {
         // retrieve the current committee size
         let epoch = self.extract_epoch_from_nonce(self.ctx.nonce);
 
         // query contract's currentEpoch to detect desync
         let contract_epoch: u32 = self.get_current_epoch_number()?;
-        info!(
-            target: "engine",
-            nonce_epoch = epoch,
-            contract_epoch,
-            "next_committee_size: epoch comparison"
-        );
+        info!(target: "engine", nonce_epoch = epoch, contract_epoch, "next_committee: epoch comparison");
 
         if contract_epoch != epoch {
-            error!(
-                target: "engine",
-                nonce_epoch = epoch,
-                contract_epoch,
-                "EPOCH DESYNC: contract currentEpoch != nonce epoch"
-            );
+            error!(target: "engine", nonce_epoch = epoch, contract_epoch, "EPOCH DESYNC: contract currentEpoch != nonce epoch");
         }
 
-        let current_committee: Vec<ValidatorInfo> = self.get_epoch_committee_validators(epoch)?;
+        let new_committee = if self.spec.is_dynamic_committee_sizing_active_at_block(block_number) {
+            // this function returns (SmartContract implementation) Active + PendingActivation + PendingExit
+            let validators = self.get_active_validators()?;
+            validators
+                .into_iter()
+                .filter(|v| v.currentStatus != ValidatorStatus::PendingExit)
+                .collect()
+        } else {
+            self.get_epoch_committee_validators(epoch)?
+        };
 
         info!(
             target: "engine",
-            epoch,
-            committee_size = current_committee.len(),
-            "next_committee_size: read committee for epoch"
+            epoch = epoch + 2,
+            new_committee_size = new_committee.len(),
+            "next_committee: new comittee size"
         );
 
         // this will fail on-chain if incorrect
-        Ok(current_committee.len())
+        Ok(new_committee)
     }
 
     /// Extract the epoch number from a header's nonce.

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -484,7 +484,8 @@ where
     /// Return the next committee.
     ///
     /// Pre-fork: reuses the current epoch's committee so the size is fixed across epochs
-    /// Post-fork: counts (Active + PendingActivation) validators so the committee dynamically grows/shrinks with the validator set.
+    /// Post-fork: counts (Active + PendingActivation) validators so the committee dynamically
+    /// grows/shrinks with the validator set.
     fn next_committee(
         &mut self,
         is_dynamic_committee_sizing_active: bool,
@@ -501,7 +502,8 @@ where
         }
 
         let new_committee = if is_dynamic_committee_sizing_active {
-            // this function returns (SmartContract implementation) Active + PendingActivation + PendingExit
+            // this function returns (SmartContract implementation) Active + PendingActivation +
+            // PendingExit
             let validators = self.get_active_validators()?;
             validators
                 .into_iter()
@@ -847,7 +849,8 @@ where
         // don't support prague deposit requests
         let requests = Requests::default();
 
-        // potentially close epoch boundary (current we don't need the randomness data because validator set it not shuffled)
+        // potentially close epoch boundary (current we don't need the randomness data because
+        // validator set it not shuffled)
         if let Some(randomness) = self.ctx.close_epoch {
             debug!(target: "engine", "ctx indicates close epoch");
             let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -366,7 +366,7 @@ where
         Ok(bytes)
     }
 
-    /// Read eligible validators from latest state and shuffle the committee deterministically.
+    /// Prepares the next committee from the latest state
     fn new_committee(&mut self, randomness: B256) -> RaylsRethResult<Vec<Address>> {
         let block_number = self.evm.block().number().saturating_to::<u64>();
         if !self.spec.is_dynamic_committee_sizing_active_at_block(block_number) {
@@ -502,8 +502,8 @@ where
         }
 
         let new_committee = if is_dynamic_committee_sizing_active {
-            // this function returns (SmartContract implementation) Active + PendingActivation +
-            // PendingExit
+            // get_active_validators() returns Active + PendingActivation + PendingExit;
+            // we exclude PendingExit to get only the eligible validators.
             let validators = self.get_active_validators()?;
             validators
                 .into_iter()

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -764,36 +764,36 @@ where
         let requests = Requests::default();
 
         // potentially close epoch boundary (current we don't need the randomness data because validator set it not shuffled)
-        // if let Some(randomness) = self.ctx.close_epoch {
-        debug!(target: "engine", "ctx indicates close epoch");
-        let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();
-        self.apply_consensus_block_rewards(tally).map_err(|e| {
-            BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
-        })?;
+        if let Some(_randomness) = self.ctx.close_epoch {
+            debug!(target: "engine", "ctx indicates close epoch");
+            let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();
+            self.apply_consensus_block_rewards(tally).map_err(|e| {
+                BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
+            })?;
 
-        self.apply_closing_epoch_contract_call().map_err(|e| {
-            BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
-        })?;
+            self.apply_closing_epoch_contract_call().map_err(|e| {
+                BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
+            })?;
 
-        // best-effort, never blocks epoch close; testnet archive replay skips the
-        // historical reward-distribution outage window to match canonical state
-        #[cfg(feature = "archive-replay")]
-        let skip_distribution =
-            self.spec.is_tokenomics_outage_block(self.evm.block().number().saturating_to());
-        #[cfg(not(feature = "archive-replay"))]
-        let skip_distribution = false;
-        if !skip_distribution {
-            match self.apply_reward_distribution() {
-                Ok(()) => {}
-                Err(e) => {
-                    error!(target: "engine", "reward distribution failed (non-fatal): {:?}", e);
+            // best-effort, never blocks epoch close; testnet archive replay skips the
+            // historical reward-distribution outage window to match canonical state
+            #[cfg(feature = "archive-replay")]
+            let skip_distribution =
+                self.spec.is_tokenomics_outage_block(self.evm.block().number().saturating_to());
+            #[cfg(not(feature = "archive-replay"))]
+            let skip_distribution = false;
+            if !skip_distribution {
+                match self.apply_reward_distribution() {
+                    Ok(()) => {}
+                    Err(e) => {
+                        error!(target: "engine", "reward distribution failed (non-fatal): {:?}", e);
+                    }
                 }
             }
-        }
 
-        // merge transitions into bundle state
-        self.evm.db_mut().merge_transitions(BundleRetention::Reverts);
-        // }
+            // merge transitions into bundle state
+            self.evm.db_mut().merge_transitions(BundleRetention::Reverts);
+        }
 
         Ok((
             self.evm,

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -16,6 +16,7 @@ use alloy::{
     sol_types::SolCall as _,
 };
 use alloy_evm::{block::StateChangeSource, eth::EthTxResult, tx::RecoveredTx as _, Database, Evm};
+use rand::{rngs::StdRng, seq::IteratorRandom, Rng as _, SeedableRng as _};
 use rayls_infrastructure_types::{
     rewards::build_withdrawals, Address, Bytes, Encodable2718, ExecHeader, Receipt, SolValue,
     TransactionSigned, Withdrawals, B256, EMPTY_WITHDRAWALS, U256,
@@ -226,9 +227,9 @@ where
     }
 
     /// Apply the closing epoch call to ConsensusRegistry.
-    fn apply_closing_epoch_contract_call(&mut self) -> RaylsRethResult<()> {
-        debug!(target: "engine", "applying closing contract call");
-        let calldata = self.generate_conclude_epoch_calldata()?;
+    fn apply_closing_epoch_contract_call(&mut self, randomness: B256) -> RaylsRethResult<()> {
+        debug!(target: "engine", ?randomness, "applying closing contract call");
+        let calldata = self.generate_conclude_epoch_calldata(randomness)?;
         trace!(target: "engine", ?calldata, "close epoch calldata");
 
         // execute system call to consensus registry
@@ -312,9 +313,9 @@ where
     }
 
     /// Generate calldata for updating the ConsensusRegistry to conclude the epoch.
-    fn generate_conclude_epoch_calldata(&mut self) -> RaylsRethResult<Bytes> {
+    fn generate_conclude_epoch_calldata(&mut self, randomness: B256) -> RaylsRethResult<Bytes> {
         // shuffle all validators for new committee
-        let mut new_committee = self.new_committee()?;
+        let mut new_committee = self.new_committee(randomness)?;
 
         if new_committee.is_empty() {
             let epoch = self.extract_epoch_from_nonce(self.ctx.nonce);
@@ -365,17 +366,20 @@ where
         Ok(bytes)
     }
 
-    /// Read eligible validators from latest state
-    fn new_committee(&mut self) -> RaylsRethResult<Vec<Address>> {
+    /// Read eligible validators from latest state and shuffle the committee deterministically.
+    fn new_committee(&mut self, randomness: B256) -> RaylsRethResult<Vec<Address>> {
         let block_number = self.evm.block().number().saturating_to::<u64>();
+        if !self.spec.is_dynamic_committee_sizing_active_at_block(block_number) {
+            return self.shuffle_new_committee(randomness);
+        }
 
-        let new_committee: Vec<ValidatorInfo> = self.next_committee(block_number)?;
+        let new_committee: Vec<ValidatorInfo> = self.next_committee(true)?;
         let new_committee_size = new_committee.len();
 
         info!(
             target: "engine",
             new_committee_size,
-            "shuffle_new_committee: read validators (Active + PendingActivation)"
+            "new_committee: read validators (Active + PendingActivation)"
         );
 
         if new_committee.is_empty() {
@@ -400,11 +404,91 @@ where
         Ok(new_committee_addresses)
     }
 
+    fn shuffle_new_committee(&mut self, randomness: B256) -> RaylsRethResult<Vec<Address>> {
+        let next_committee = self.next_committee(false)?;
+        let new_committee_size = next_committee.len();
+
+        // read all active validators from consensus registry
+        let all_active_validators = self.get_active_validators()?;
+
+        info!(
+            target: "engine",
+            new_committee_size,
+            active_validators = all_active_validators.len(),
+            "shuffle_new_committee: read active validators"
+        );
+
+        if all_active_validators.is_empty() {
+            // query ALL validators (Any status) to understand their statuses
+            let all_validators = self.get_all_validators()?;
+
+            error!(
+                target: "engine",
+                total_validators = all_validators.len(),
+                statuses = ?all_validators
+                    .iter()
+                    .map(|v| (v.validatorAddress, v.currentStatus))
+                    .collect::<Vec<_>>(),
+                "NO ACTIVE VALIDATORS - dumping all validator statuses"
+            );
+        }
+
+        // create seed from hashed bls agg signature
+        let mut seed = [0; 32];
+        seed.copy_from_slice(randomness.as_slice());
+        trace!(target: "engine", ?seed, "seed after");
+
+        // used as deterministic randomness
+        let mut rng = StdRng::from_seed(seed);
+
+        // 1) separate active and pending validators
+        // 2) check if active length is sufficient
+        // 3) if missing, randomly select from the pending validators
+        let (pending_exit, mut active_validators): (Vec<_>, Vec<_>) = all_active_validators
+            .into_iter()
+            .partition(|v| v.currentStatus == ValidatorStatus::PendingExit);
+
+        let active_validator_count = active_validators.len();
+        let mut validators_for_shuffle = if active_validator_count >= new_committee_size {
+            // enough active validators for next committee
+            active_validators
+        } else {
+            // NOTE: already checked if active_validator_count >= new_committee_size above
+            let num_missing = new_committee_size - active_validator_count;
+
+            // randomly take enough pending exit validators to reach new committee size
+            let random_pending = pending_exit.into_iter().choose_multiple(&mut rng, num_missing);
+            active_validators.extend(random_pending);
+            active_validators
+        };
+
+        // simple Fisher-Yates shuffle
+        for i in (1..validators_for_shuffle.len()).rev() {
+            let j = rng.random_range(0..=i);
+            validators_for_shuffle.swap(i, j);
+        }
+
+        debug!(target: "engine",  "validators post-shuffle {:?}", validators_for_shuffle);
+
+        let mut new_committee =
+            validators_for_shuffle.into_iter().map(|v| v.validatorAddress).collect::<Vec<_>>();
+
+        // trim the shuffled committee to maintain correct size
+        new_committee.truncate(new_committee_size);
+
+        trace!(target: "engine",  ?new_committee_size, ?new_committee, "truncated shuffle for new committee");
+
+        Ok(new_committee)
+    }
+
     /// Return the next committee.
     ///
     /// Pre-fork: reuses the current epoch's committee so the size is fixed across epochs
     /// Post-fork: counts (Active + PendingActivation) validators so the committee dynamically grows/shrinks with the validator set.
-    fn next_committee(&mut self, block_number: u64) -> RaylsRethResult<Vec<ValidatorInfo>> {
+    fn next_committee(
+        &mut self,
+        is_dynamic_committee_sizing_active: bool,
+    ) -> RaylsRethResult<Vec<ValidatorInfo>> {
         // retrieve the current committee size
         let epoch = self.extract_epoch_from_nonce(self.ctx.nonce);
 
@@ -416,7 +500,7 @@ where
             error!(target: "engine", nonce_epoch = epoch, contract_epoch, "EPOCH DESYNC: contract currentEpoch != nonce epoch");
         }
 
-        let new_committee = if self.spec.is_dynamic_committee_sizing_active_at_block(block_number) {
+        let new_committee = if is_dynamic_committee_sizing_active {
             // this function returns (SmartContract implementation) Active + PendingActivation + PendingExit
             let validators = self.get_active_validators()?;
             validators
@@ -764,14 +848,14 @@ where
         let requests = Requests::default();
 
         // potentially close epoch boundary (current we don't need the randomness data because validator set it not shuffled)
-        if let Some(_randomness) = self.ctx.close_epoch {
+        if let Some(randomness) = self.ctx.close_epoch {
             debug!(target: "engine", "ctx indicates close epoch");
             let tally = self.ctx.close_epoch_tally.clone().unwrap_or_default();
             self.apply_consensus_block_rewards(tally).map_err(|e| {
                 BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
             })?;
 
-            self.apply_closing_epoch_contract_call().map_err(|e| {
+            self.apply_closing_epoch_contract_call(randomness).map_err(|e| {
                 BlockExecutionError::Internal(InternalBlockExecutionError::Other(e.into()))
             })?;
 

--- a/crates/execution/evm/src/evm/hardforks/mod.rs
+++ b/crates/execution/evm/src/evm/hardforks/mod.rs
@@ -120,7 +120,8 @@ where
             | RaylsHardFork::BatchDigestV2
             | RaylsHardFork::PrecompileGasFix
             | RaylsHardFork::TransactionLoadBalancing
-            | RaylsHardFork::EmptyOutputBlock => continue,
+            | RaylsHardFork::EmptyOutputBlock
+            | RaylsHardFork::DynamicCommitteeSizing => continue,
         };
 
         // Pre-load accounts into cache and copy their real AccountInfo.

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -1082,13 +1082,12 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     // With DynamicCommitteeSizing the future committee is deterministic (sorted, no shuffle).
     // new_validator is PendingActivation at this point, so it is included.
     // Future committee = 6 validators sorted by address.
-    expected_epoch += 1;
     let consensus_output = consensus_output_for_tests(2, expected_epoch, 2);
     let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
     let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
     let canonical_header = block2.recovered_block.clone_sealed_header();
 
-    // Read future committee (2 epochs ahead)
+    // Read future committee (3 epochs ahead of the one that is closing)
     let state = StateProviderDatabase::new(reth_env.latest()?);
     let mut cached_reads = CachedReads::default();
     let mut db = State::builder()
@@ -1102,9 +1101,10 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         .create_evm(&mut db, reth_env.evm_config.evm_env(canonical_header.header())?);
 
     let calldata =
-        ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 2 }.abi_encode().into();
+        ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 3 }.abi_encode().into();
     let future_epoch_info = reth_env
         .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
+    expected_epoch += 1;
 
     // Dynamic committee: 6 validators sorted by address (no truncate)
     let expected_sorted_6 = vec![
@@ -1121,18 +1121,15 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     );
 
     // ── Block 3: close epoch 1 ──
-    expected_epoch += 1;
     let consensus_output = consensus_output_for_tests(2, expected_epoch, 3);
     let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
     let block3 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
     let canonical_header = block3.recovered_block.clone_sealed_header();
 
-    // Current epoch committee should now be 6 (the 6-validator committee becomes current at epoch
-    // 3)
-    let EpochState { epoch: current_epoch, .. } = reth_env.epoch_state_from_canonical_tip()?;
-    assert_eq!(current_epoch, expected_epoch);
     // The 6-validator committee is stored for epoch 3 (two epochs ahead at block 2).
-    // We need to wait until block 5 (close epoch 2) for it to become current.
+    // It becomes current at epoch 3, which is after block 5 closes epoch 2.
+    let EpochState { epoch: current_epoch, .. } = reth_env.epoch_state_from_canonical_tip()?;
+    assert_eq!(current_epoch, expected_epoch + 1);
     // For now, check the future epoch (epoch 3) which has the 6-validator committee.
     let state = StateProviderDatabase::new(reth_env.latest()?);
     let mut cached_reads = CachedReads::default();
@@ -1153,6 +1150,7 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         future_epoch_info.committee, expected_sorted_6,
         "future epoch (epoch 3) must have 6 validators"
     );
+    expected_epoch += 1;
 
     // ── Block 4: no epoch close, validator 2 begins exit ──
     let calldata = ConsensusRegistry::beginExitCall {}.abi_encode().into();
@@ -1164,7 +1162,6 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         U256::ZERO,
         calldata,
     );
-    expected_epoch += 1;
     let mut consensus_output = consensus_output_for_tests(2, expected_epoch, 4);
     consensus_output.close_epoch = false;
     let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
@@ -1173,24 +1170,24 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     let canonical_header = block4.recovered_block.clone_sealed_header();
 
     // ── Block 5: close epoch 2 ──
-    expected_epoch += 1;
     let consensus_output = consensus_output_for_tests(2, expected_epoch, 5);
     let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
     let block5 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    expected_epoch += 1;
     let canonical_header = block5.recovered_block.clone_sealed_header();
 
     // ── Block 6: close epoch 3 ──
-    expected_epoch += 1;
     let consensus_output = consensus_output_for_tests(2, expected_epoch, 6);
     let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
     let block6 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    expected_epoch += 1;
     let canonical_header = block6.recovered_block.clone_sealed_header();
 
     // ── Block 7: close epoch 4 ──
-    expected_epoch += 1;
     let consensus_output = consensus_output_for_tests(2, expected_epoch, 7);
     let payload = RLPayload::new_for_test(canonical_header.clone(), &consensus_output);
     execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    expected_epoch += 1;
 
     // validator 2 should now be Exited
     let state = StateProviderDatabase::new(reth_env.latest()?);

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -1150,8 +1150,7 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     let future_epoch_info = reth_env
         .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
     assert_eq!(
-        future_epoch_info.committee.len(),
-        6,
+        future_epoch_info.committee, expected_sorted_6,
         "future epoch (epoch 3) must have 6 validators"
     );
 
@@ -1191,8 +1190,7 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     expected_epoch += 1;
     let consensus_output = consensus_output_for_tests(2, expected_epoch, 7);
     let payload = RLPayload::new_for_test(canonical_header.clone(), &consensus_output);
-    let block7 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
-    let _ = block7;
+    execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
 
     // validator 2 should now be Exited
     let state = StateProviderDatabase::new(reth_env.latest()?);

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -930,10 +930,7 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
     let governance = governance_multisig.address();
     let tmp_genesis = rayls_infrastructure_types::test_genesis().extend_accounts([
-        (
-            governance,
-            GenesisAccount::default().with_balance(U256::from((50_000_000 * 10) ^ 18)),
-        ),
+        (governance, GenesisAccount::default().with_balance(U256::from((50_000_000 * 10) ^ 18))),
         (
             new_validator_eoa.address(),
             GenesisAccount::default()
@@ -960,11 +957,8 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
 
     // Build a RaylsChainSpec with DynamicCommitteeSizing active from block 0
-    let rayls_chain_spec: Arc<RaylsChainSpec> = Arc::new(
-        RaylsChainSpec::builder(chain.clone())
-            .dynamic_committee_sizing(0)
-            .build(),
-    );
+    let rayls_chain_spec: Arc<RaylsChainSpec> =
+        Arc::new(RaylsChainSpec::builder(chain.clone()).dynamic_committee_sizing(0).build());
 
     // governance allowlists the new validator
     let calldata =
@@ -1041,15 +1035,14 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     // create env with custom RaylsChainSpec
     let tmp_dir = TempDir::new()?;
     let task_manager = TaskManager::new("Test Task Manager");
-    let reth_env =
-        RethEnv::new_for_temp_chain_with_rayls_spec(
-            chain.clone(),
-            rayls_chain_spec.clone(),
-            tmp_dir.path(),
-            &task_manager,
-            None,
-        )
-        .await?;
+    let reth_env = RethEnv::new_for_temp_chain_with_rayls_spec(
+        chain.clone(),
+        rayls_chain_spec.clone(),
+        tmp_dir.path(),
+        &task_manager,
+        None,
+    )
+    .await?;
 
     // verify fork is active
     assert!(
@@ -1108,9 +1101,8 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         .evm_factory()
         .create_evm(&mut db, reth_env.evm_config.evm_env(canonical_header.header())?);
 
-    let calldata = ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 2 }
-        .abi_encode()
-        .into();
+    let calldata =
+        ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 2 }.abi_encode().into();
     let future_epoch_info = reth_env
         .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
 
@@ -1135,9 +1127,9 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     let block3 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
     let canonical_header = block3.recovered_block.clone_sealed_header();
 
-    // Current epoch committee should now be 6 (the 6-validator committee becomes current at epoch 3)
-    let EpochState { epoch: current_epoch, .. } =
-        reth_env.epoch_state_from_canonical_tip()?;
+    // Current epoch committee should now be 6 (the 6-validator committee becomes current at epoch
+    // 3)
+    let EpochState { epoch: current_epoch, .. } = reth_env.epoch_state_from_canonical_tip()?;
     assert_eq!(current_epoch, expected_epoch);
     // The 6-validator committee is stored for epoch 3 (two epochs ahead at block 2).
     // We need to wait until block 5 (close epoch 2) for it to become current.
@@ -1153,12 +1145,15 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         .evm_config
         .evm_factory()
         .create_evm(&mut db, reth_env.evm_config.evm_env(canonical_header.header())?);
-    let calldata = ConsensusRegistry::getEpochInfoCall { epoch: current_epoch + 1 }
-        .abi_encode()
-        .into();
+    let calldata =
+        ConsensusRegistry::getEpochInfoCall { epoch: current_epoch + 1 }.abi_encode().into();
     let future_epoch_info = reth_env
         .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
-    assert_eq!(future_epoch_info.committee.len(), 6, "future epoch (epoch 3) must have 6 validators");
+    assert_eq!(
+        future_epoch_info.committee.len(),
+        6,
+        "future epoch (epoch 3) must have 6 validators"
+    );
 
     // ── Block 4: no epoch close, validator 2 begins exit ──
     let calldata = ConsensusRegistry::beginExitCall {}.abi_encode().into();
@@ -1220,19 +1215,13 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     assert_eq!(validator_2_info.currentStatus, ValidatorStatus::Exited);
 
     // Future committee should have shrunk to 5 (validator 2 excluded)
-    let calldata = ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 1 }
-        .abi_encode()
-        .into();
+    let calldata =
+        ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 1 }.abi_encode().into();
     let shrunken_epoch_info = reth_env
         .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
 
-    let expected_sorted_5 = vec![
-        validator_1,
-        validator_3,
-        validator_4,
-        validator_5,
-        new_validator.execution_address,
-    ];
+    let expected_sorted_5 =
+        vec![validator_1, validator_3, validator_4, validator_5, new_validator.execution_address];
     assert_eq!(
         shrunken_epoch_info.committee, expected_sorted_5,
         "dynamic committee must shrink to 5 after validator 2 exits"

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -871,6 +871,376 @@ async fn test_close_epochs() -> eyre::Result<()> {
     Ok(())
 }
 
+/// Same lifecycle as `test_close_epochs` but with `DynamicCommitteeSizing` active from genesis.
+/// Verifies three key differences from the pre-fork behaviour:
+///   1. Committee is deterministic (sorted, no shuffle).
+///   2. Committee grows when a new validator joins (no truncate).
+///   3. Committee shrinks when a validator exits.
+#[tokio::test]
+async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
+    use crate::chainspec::{RaylsChainSpec, RaylsHardforks};
+
+    let validator_1 = Address::from_slice(&[0x11; 20]);
+    let validator_3 = Address::from_slice(&[0x33; 20]);
+    let validator_4 = Address::from_slice(&[0x44; 20]);
+    let validator_5 = Address::from_slice(&[0x55; 20]);
+
+    let mut new_validator_eoa =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(6));
+
+    let mut validator_2_eoa =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(2));
+    let validator_2_address = validator_2_eoa.address();
+
+    let all_validators = [
+        validator_1,
+        validator_2_address,
+        validator_3,
+        validator_4,
+        validator_5,
+        new_validator_eoa.address(),
+    ];
+
+    let mut validators: Vec<_> = all_validators
+        .iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let bls = BlsKeypair::generate(&mut rng);
+            let bls_pubkey = bls.public();
+            let pop = generate_proof_of_possession_bls(&bls, addr).expect("pop generation failed");
+            NodeInfo {
+                name: format!("validator-{i}"),
+                bls_public_key: *bls_pubkey,
+                p2p_info: NodeP2pInfo::default(),
+                execution_address: *addr,
+                proof_of_possession: pop,
+            }
+        })
+        .collect();
+
+    let epoch_duration = 60 * 60 * 24;
+    let initial_stake_config = ConsensusRegistry::StakeConfig {
+        stakeAmount: U256::from(parse_ether("1_000_000").unwrap()),
+        minWithdrawAmount: U256::from(parse_ether("1_000").unwrap()),
+        epochDuration: epoch_duration,
+    };
+
+    let mut governance_multisig =
+        TransactionFactory::new_random_from_seed(&mut StdRng::seed_from_u64(33));
+    let governance = governance_multisig.address();
+    let tmp_genesis = rayls_infrastructure_types::test_genesis().extend_accounts([
+        (
+            governance,
+            GenesisAccount::default().with_balance(U256::from((50_000_000 * 10) ^ 18)),
+        ),
+        (
+            new_validator_eoa.address(),
+            GenesisAccount::default()
+                .with_balance(initial_stake_config.stakeAmount.saturating_mul(U256::from(2))),
+        ),
+        (
+            validator_2_address,
+            GenesisAccount::default()
+                .with_balance(initial_stake_config.stakeAmount.saturating_mul(U256::from(2))),
+        ),
+    ]);
+
+    let new_validator = validators.pop().expect("six validators");
+
+    let genesis = RethEnv::create_consensus_registry_genesis_accounts(
+        validators.clone(),
+        tmp_genesis,
+        initial_stake_config.clone(),
+        governance,
+        governance,
+        vec![(governance, initial_stake_config.stakeAmount)],
+    )?;
+
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+
+    // Build a RaylsChainSpec with DynamicCommitteeSizing active from block 0
+    let rayls_chain_spec: Arc<RaylsChainSpec> = Arc::new(
+        RaylsChainSpec::builder(chain.clone())
+            .dynamic_committee_sizing(0)
+            .build(),
+    );
+
+    // governance allowlists the new validator
+    let calldata =
+        ConsensusRegistry::allowlistValidatorCall { validatorAddress: new_validator_eoa.address() }
+            .abi_encode()
+            .into();
+    let allowlist_tx = governance_multisig.create_eip1559_encoded(
+        chain.clone(),
+        None,
+        100,
+        Some(CONSENSUS_REGISTRY_ADDRESS),
+        U256::ZERO,
+        calldata,
+    );
+
+    let calldata = RLSToken::transferCall {
+        to: new_validator_eoa.address(),
+        amount: initial_stake_config.stakeAmount,
+    }
+    .abi_encode()
+    .into();
+    let rls_transfer_tx = governance_multisig.create_eip1559_encoded(
+        chain.clone(),
+        None,
+        100,
+        Some(RLS_ADDRESS),
+        U256::ZERO,
+        calldata,
+    );
+
+    let calldata = RLSToken::approveCall {
+        spender: CONSENSUS_REGISTRY_ADDRESS,
+        amount: initial_stake_config.stakeAmount,
+    }
+    .abi_encode()
+    .into();
+    let rls_approve_tx = new_validator_eoa.create_eip1559_encoded(
+        chain.clone(),
+        None,
+        100,
+        Some(RLS_ADDRESS),
+        U256::ZERO,
+        calldata,
+    );
+
+    let proof = ConsensusRegistry::ProofOfPossession {
+        uncompressedPubkey: new_validator.bls_public_key.serialize().into(),
+        uncompressedSignature: new_validator.proof_of_possession.serialize().into(),
+    };
+    let calldata = ConsensusRegistry::stakeCall {
+        blsPubkey: new_validator.bls_public_key.to_bytes().into(),
+        proofOfPossession: proof,
+    }
+    .abi_encode()
+    .into();
+    let stake_tx = new_validator_eoa.create_eip1559_encoded(
+        chain.clone(),
+        None,
+        100,
+        Some(CONSENSUS_REGISTRY_ADDRESS),
+        U256::ZERO,
+        calldata,
+    );
+    let calldata = ConsensusRegistry::activateCall {}.abi_encode().into();
+    let activate_tx = new_validator_eoa.create_eip1559_encoded(
+        chain.clone(),
+        None,
+        100,
+        Some(CONSENSUS_REGISTRY_ADDRESS),
+        U256::ZERO,
+        calldata,
+    );
+
+    // create env with custom RaylsChainSpec
+    let tmp_dir = TempDir::new()?;
+    let task_manager = TaskManager::new("Test Task Manager");
+    let reth_env =
+        RethEnv::new_for_temp_chain_with_rayls_spec(
+            chain.clone(),
+            rayls_chain_spec.clone(),
+            tmp_dir.path(),
+            &task_manager,
+            None,
+        )
+        .await?;
+
+    // verify fork is active
+    assert!(
+        rayls_chain_spec.is_dynamic_committee_sizing_active_at_block(0),
+        "DynamicCommitteeSizing must be active at block 0"
+    );
+
+    let mut expected_epoch = 0;
+    let expected_committee = validators.iter().map(|v| v.execution_address).collect();
+    let expected_epoch_info = ConsensusRegistry::EpochInfo {
+        committee: expected_committee,
+        blockHeight: 0,
+        epochDuration: epoch_duration,
+        stakeVersion: 0,
+    };
+
+    // assert genesis epoch state
+    let EpochState { epoch, epoch_info, epoch_start, .. } =
+        reth_env.epoch_state_from_canonical_tip()?;
+    assert_eq!(epoch, expected_epoch);
+    assert_eq!(epoch_start, chain.genesis_timestamp());
+    assert_eq!(epoch_info, expected_epoch_info);
+
+    // ── Block 1: no epoch close, new validator stakes + activates ──
+    let mut consensus_output = consensus_output_for_tests(2, expected_epoch, 1);
+    consensus_output.close_epoch = false;
+    let payload = RLPayload::new_for_test(chain.sealed_genesis_header(), &consensus_output);
+    let block1 = execute_payload_and_update_canonical_chain(
+        &reth_env,
+        payload,
+        vec![allowlist_tx, rls_transfer_tx, rls_approve_tx, stake_tx, activate_tx],
+    )
+    .await?;
+    let canonical_header = block1.recovered_block.clone_sealed_header();
+
+    // ── Block 2: close epoch 0 ──
+    // With DynamicCommitteeSizing the future committee is deterministic (sorted, no shuffle).
+    // new_validator is PendingActivation at this point, so it is included.
+    // Future committee = 6 validators sorted by address.
+    expected_epoch += 1;
+    let consensus_output = consensus_output_for_tests(2, expected_epoch, 2);
+    let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
+    let block2 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    let canonical_header = block2.recovered_block.clone_sealed_header();
+
+    // Read future committee (2 epochs ahead)
+    let state = StateProviderDatabase::new(reth_env.latest()?);
+    let mut cached_reads = CachedReads::default();
+    let mut db = State::builder()
+        .with_database(cached_reads.as_db_mut(state))
+        .with_bundle_update()
+        .without_state_clear()
+        .build();
+    let mut rayls_evm = reth_env
+        .evm_config
+        .evm_factory()
+        .create_evm(&mut db, reth_env.evm_config.evm_env(canonical_header.header())?);
+
+    let calldata = ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 2 }
+        .abi_encode()
+        .into();
+    let future_epoch_info = reth_env
+        .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
+
+    // Dynamic committee: 6 validators sorted by address (no truncate)
+    let expected_sorted_6 = vec![
+        validator_1,
+        validator_3,
+        validator_4,
+        validator_5,
+        validator_2_address,
+        new_validator.execution_address,
+    ];
+    assert_eq!(
+        future_epoch_info.committee, expected_sorted_6,
+        "dynamic committee must include all 6 active validators sorted by address (no truncate)"
+    );
+
+    // ── Block 3: close epoch 1 ──
+    expected_epoch += 1;
+    let consensus_output = consensus_output_for_tests(2, expected_epoch, 3);
+    let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
+    let block3 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    let canonical_header = block3.recovered_block.clone_sealed_header();
+
+    // Current epoch committee should now be 6 (the 6-validator committee becomes current at epoch 3)
+    let EpochState { epoch: current_epoch, .. } =
+        reth_env.epoch_state_from_canonical_tip()?;
+    assert_eq!(current_epoch, expected_epoch);
+    // The 6-validator committee is stored for epoch 3 (two epochs ahead at block 2).
+    // We need to wait until block 5 (close epoch 2) for it to become current.
+    // For now, check the future epoch (epoch 3) which has the 6-validator committee.
+    let state = StateProviderDatabase::new(reth_env.latest()?);
+    let mut cached_reads = CachedReads::default();
+    let mut db = State::builder()
+        .with_database(cached_reads.as_db_mut(state))
+        .with_bundle_update()
+        .without_state_clear()
+        .build();
+    let mut rayls_evm = reth_env
+        .evm_config
+        .evm_factory()
+        .create_evm(&mut db, reth_env.evm_config.evm_env(canonical_header.header())?);
+    let calldata = ConsensusRegistry::getEpochInfoCall { epoch: current_epoch + 1 }
+        .abi_encode()
+        .into();
+    let future_epoch_info = reth_env
+        .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
+    assert_eq!(future_epoch_info.committee.len(), 6, "future epoch (epoch 3) must have 6 validators");
+
+    // ── Block 4: no epoch close, validator 2 begins exit ──
+    let calldata = ConsensusRegistry::beginExitCall {}.abi_encode().into();
+    let begin_exit_tx = validator_2_eoa.create_eip1559_encoded(
+        chain.clone(),
+        None,
+        100,
+        Some(CONSENSUS_REGISTRY_ADDRESS),
+        U256::ZERO,
+        calldata,
+    );
+    expected_epoch += 1;
+    let mut consensus_output = consensus_output_for_tests(2, expected_epoch, 4);
+    consensus_output.close_epoch = false;
+    let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
+    let block4 =
+        execute_payload_and_update_canonical_chain(&reth_env, payload, vec![begin_exit_tx]).await?;
+    let canonical_header = block4.recovered_block.clone_sealed_header();
+
+    // ── Block 5: close epoch 2 ──
+    expected_epoch += 1;
+    let consensus_output = consensus_output_for_tests(2, expected_epoch, 5);
+    let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
+    let block5 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    let canonical_header = block5.recovered_block.clone_sealed_header();
+
+    // ── Block 6: close epoch 3 ──
+    expected_epoch += 1;
+    let consensus_output = consensus_output_for_tests(2, expected_epoch, 6);
+    let payload = RLPayload::new_for_test(canonical_header, &consensus_output);
+    let block6 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    let canonical_header = block6.recovered_block.clone_sealed_header();
+
+    // ── Block 7: close epoch 4 ──
+    expected_epoch += 1;
+    let consensus_output = consensus_output_for_tests(2, expected_epoch, 7);
+    let payload = RLPayload::new_for_test(canonical_header.clone(), &consensus_output);
+    let block7 = execute_payload_and_update_canonical_chain(&reth_env, payload, vec![]).await?;
+    let _ = block7;
+
+    // validator 2 should now be Exited
+    let state = StateProviderDatabase::new(reth_env.latest()?);
+    let mut cached_reads = CachedReads::default();
+    let mut db = State::builder()
+        .with_database(cached_reads.as_db_mut(state))
+        .with_bundle_update()
+        .without_state_clear()
+        .build();
+    let mut rayls_evm = reth_env
+        .evm_config
+        .evm_factory()
+        .create_evm(&mut db, reth_env.evm_config.evm_env(canonical_header.header())?);
+
+    let calldata = ConsensusRegistry::getValidatorCall { validatorAddress: validator_2_address }
+        .abi_encode()
+        .into();
+    let validator_2_info = reth_env
+        .call_consensus_registry::<_, ConsensusRegistry::ValidatorInfo>(&mut rayls_evm, calldata)?;
+    assert_eq!(validator_2_info.currentStatus, ValidatorStatus::Exited);
+
+    // Future committee should have shrunk to 5 (validator 2 excluded)
+    let calldata = ConsensusRegistry::getEpochInfoCall { epoch: expected_epoch + 1 }
+        .abi_encode()
+        .into();
+    let shrunken_epoch_info = reth_env
+        .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
+
+    let expected_sorted_5 = vec![
+        validator_1,
+        validator_3,
+        validator_4,
+        validator_5,
+        new_validator.execution_address,
+    ];
+    assert_eq!(
+        shrunken_epoch_info.committee, expected_sorted_5,
+        "dynamic committee must shrink to 5 after validator 2 exits"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_rpc_validator() {
     let mut mods: Option<RpcModuleSelection> = None;

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -1107,7 +1107,7 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     expected_epoch += 1;
 
     // Dynamic committee: 6 validators sorted by address (no truncate)
-    let expected_sorted_6 = vec![
+    let mut expected_sorted_6 = vec![
         validator_1,
         validator_3,
         validator_4,
@@ -1115,6 +1115,7 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
         validator_2_address,
         new_validator.execution_address,
     ];
+    expected_sorted_6.sort();
     assert_eq!(
         future_epoch_info.committee, expected_sorted_6,
         "dynamic committee must include all 6 active validators sorted by address (no truncate)"
@@ -1215,8 +1216,9 @@ async fn test_close_epochs_with_dynamic_committee() -> eyre::Result<()> {
     let shrunken_epoch_info = reth_env
         .call_consensus_registry::<_, ConsensusRegistry::EpochInfo>(&mut rayls_evm, calldata)?;
 
-    let expected_sorted_5 =
+    let mut expected_sorted_5 =
         vec![validator_1, validator_3, validator_4, validator_5, new_validator.execution_address];
+    expected_sorted_5.sort();
     assert_eq!(
         shrunken_epoch_info.committee, expected_sorted_5,
         "dynamic committee must shrink to 5 after validator 2 exits"

--- a/etc/validator/create-validator.sh
+++ b/etc/validator/create-validator.sh
@@ -97,6 +97,31 @@ else
     echo "Adding validator to whitelist"
     cast send $REGISTRY_CONTRACT_ADDRESS "allowlistValidator(address)" $ADDRESS --private-key $ADMIN_PRIVATE_KEY --rpc-url $RPC_URL
 
+    # Get RLS token contract address from registry
+    RLS_TOKEN=$(cast call --rpc-url $RPC_URL $REGISTRY_CONTRACT_ADDRESS "rlsToken()(address)" 2>&1)
+    echo "RLS token contract: $RLS_TOKEN"
+
+    # Get the required stake amount from the current stake config
+    STAKE_CONFIG=$(cast call --rpc-url $RPC_URL $REGISTRY_CONTRACT_ADDRESS "getCurrentStakeConfig()(uint256,uint256,uint32)" 2>&1)
+    REQUIRED_STAKE=$(echo "$STAKE_CONFIG" | head -1 | sed 's/\[.*\]//;s/ //g')
+    echo "Required stake amount: $REQUIRED_STAKE"
+
+    # Mint RLS tokens to validator address (admin has MINTER_ROLE)
+    echo "Minting $REQUIRED_STAKE RLS tokens to validator address ${ADDRESS}"
+    cast send $RLS_TOKEN \
+      "mint(address,uint256)" \
+      $ADDRESS \
+      $REQUIRED_STAKE \
+      --private-key $ADMIN_PRIVATE_KEY --rpc-url $RPC_URL
+
+    # Approve the registry to spend the RLS tokens
+    echo "Approving registry to spend $REQUIRED_STAKE RLS tokens"
+    cast send $RLS_TOKEN \
+      "approve(address,uint256)(bool)" \
+      $REGISTRY_CONTRACT_ADDRESS \
+      $REQUIRED_STAKE \
+      --private-key $PRIVATE_KEY --rpc-url $RPC_URL
+
     # extract stake calldata from output
     echo "Submitting stake transaction to registry contract at address ${REGISTRY_CONTRACT_ADDRESS}"
     CALLDATA_RES=$(RL_BLS_PASSPHRASE="local" ${workingDir}/../../target/${RELEASE}/rayls-network keytool stake-calldata \
@@ -104,7 +129,7 @@ else
 
     CALLDATA=$(echo "$CALLDATA_RES" | grep 'Calldata:' | awk '{print $2}')
 
-    echo "Stake: $STAKE_AMOUNT, CallData: $CALLDATA"
+    echo "Stake: $REQUIRED_STAKE, CallData: $CALLDATA"
 
     # send stake transaction
     cast send $REGISTRY_CONTRACT_ADDRESS $CALLDATA --private-key $PRIVATE_KEY --rpc-url $RPC_URL -vvvv


### PR DESCRIPTION
## Summary

- Introduces the `DynamicCommitteeSizing` hardfork (version byte 0x0c), which changes how the next epoch's committee is sized: instead of reusing the current epoch's fixed committee size, it now sizes based on Active + PendingActivation validators (excluding PendingExit).
- Refactors committee selection logic: replaces `next_committee_size()` with `next_committee()` returning validator info, removes the validators' shuffle (committee is now deterministic/sorted post-fork), and adds proper logging for validator status debugging.
- Adds integration test `test_close_epochs_with_dynamic_committee` verifying committee determinism, dynamic growth when validators join, and shrinking when validators exit.

Closes https://github.com/raylsnetwork/axyl/issues/36

## Surface areas touched

- [x] Execution / EVM
- [ ] Tests only

## Breaking / compatibility

The hardfork is currently only enabled for LOCAL setup. We must enable it for dev/test/main before publishing.

## Test plan

- [x] Run `cargo test` in `crates/execution/evm` to verify all existing + new tests pass
- [x] Run `test_close_epochs_with_dynamic_committee` integration test end-to-end with a local sandbox network
