### PR TITLE
feat: apply storage slot fix as hardfork

### DIFF
--- a/crates/execution/evm/src/chainspec.rs
+++ b/crates/execution/evm/src/chainspec.rs
@@ -49,6 +49,9 @@ hardfork!(
         /// Produce a fallback empty block for any consensus output that contributed no block
         /// (no batches, all deduped, or all parked), so every output maps to a block.
         EmptyOutputBlock,
+        /// Re-key genesis storage history from plaintext slot keys to hashed keys
+        /// so v2 archive reads reconstruct genesis-seeded storage (e.g. versions[0]).
+        GenesisStorageRekey,
     }
 );
 
@@ -166,6 +169,15 @@ pub const MAINNET_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 3_569_194;
 /// UsdrSupplyCorrection activation block on the Rayls mainnet.
 pub const MAINNET_USDR_SUPPLY_CORRECTION_BLOCK: u64 = 3_569_194;
 
+/// GenesisStorageRekey activation block on the Rayls devnet.
+pub const DEVNET_GENESIS_STORAGE_REKEY_BLOCK: u64 = u64::MAX;
+/// GenesisStorageRekey activation block on the Rayls testnet.
+pub const TESTNET_GENESIS_STORAGE_REKEY_BLOCK: u64 = u64::MAX;
+/// GenesisStorageRekey activation block on the Rayls mainnet.
+pub const MAINNET_GENESIS_STORAGE_REKEY_BLOCK: u64 = u64::MAX;
+/// GenesisStorageRekey activation block on the Rayls local network.
+pub const LOCAL_GENESIS_STORAGE_REKEY_BLOCK: u64 = 1;
+
 impl RaylsHardFork {
     /// Return the protocol version byte for this hardfork.
     pub const fn version_byte(self) -> u8 {
@@ -181,11 +193,12 @@ impl RaylsHardFork {
             Self::TransactionLoadBalancing => 0x09,
             Self::UsdrSupplyCorrection => 0x0a,
             Self::EmptyOutputBlock => 0x0b,
+            Self::GenesisStorageRekey => 0x0c,
         }
     }
 
     /// Devnet hardfork schedule.
-    pub const fn devnet() -> [(Self, ForkCondition); 11] {
+    pub const fn devnet() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(DEVNET_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(DEVNET_BATCH_DIGEST_V2_BLOCK)),
@@ -201,11 +214,12 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(DEVNET_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Never),
             (Self::EmptyOutputBlock, ForkCondition::Block(DEVNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::GenesisStorageRekey, ForkCondition::Block(DEVNET_GENESIS_STORAGE_REKEY_BLOCK)),
         ]
     }
 
     /// Testnet hardfork schedule.
-    pub const fn testnet() -> [(Self, ForkCondition); 11] {
+    pub const fn testnet() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(TESTNET_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(TESTNET_BATCH_DIGEST_V2_BLOCK)),
@@ -219,11 +233,12 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(TESTNET_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Never),
             (Self::EmptyOutputBlock, ForkCondition::Block(TESTNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::GenesisStorageRekey, ForkCondition::Block(TESTNET_GENESIS_STORAGE_REKEY_BLOCK)),
         ]
     }
 
     /// Mainnet hardfork schedule.
-    pub const fn mainnet() -> [(Self, ForkCondition); 11] {
+    pub const fn mainnet() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(MAINNET_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(MAINNET_BATCH_DIGEST_V2_BLOCK)),
@@ -242,11 +257,12 @@ impl RaylsHardFork {
                 ForkCondition::Block(MAINNET_USDR_SUPPLY_CORRECTION_BLOCK),
             ),
             (Self::EmptyOutputBlock, ForkCondition::Block(MAINNET_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::GenesisStorageRekey, ForkCondition::Block(MAINNET_GENESIS_STORAGE_REKEY_BLOCK)),
         ]
     }
 
     /// Local network hardfork schedule (first four hardforks active at genesis).
-    pub const fn local() -> [(Self, ForkCondition); 11] {
+    pub const fn local() -> [(Self, ForkCondition); 12] {
         [
             (Self::Eip1559, ForkCondition::Block(LOCAL_EIP1559_BLOCK)),
             (Self::BatchDigestV2, ForkCondition::Block(LOCAL_BATCH_DIGEST_V2_BLOCK)),
@@ -262,11 +278,12 @@ impl RaylsHardFork {
             (Self::TransactionLoadBalancing, ForkCondition::Block(LOCAL_LOAD_BALANCING_BLOCK)),
             (Self::UsdrSupplyCorrection, ForkCondition::Block(LOCAL_USDR_SUPPLY_CORRECTION_BLOCK)),
             (Self::EmptyOutputBlock, ForkCondition::Block(LOCAL_EMPTY_OUTPUT_BLOCK_BLOCK)),
+            (Self::GenesisStorageRekey, ForkCondition::Block(LOCAL_GENESIS_STORAGE_REKEY_BLOCK)),
         ]
     }
 
     /// Return the hardfork schedule for the given network.
-    pub const fn for_network(network: RaylsNetwork) -> [(Self, ForkCondition); 11] {
+    pub const fn for_network(network: RaylsNetwork) -> [(Self, ForkCondition); 12] {
         match network {
             RaylsNetwork::Devnet => Self::devnet(),
             RaylsNetwork::Testnet => Self::testnet(),
@@ -389,6 +406,11 @@ pub trait RaylsHardforks {
     /// Return true if the EmptyOutputBlock fork is active at `block`.
     fn is_empty_output_block_active_at_block(&self, block: u64) -> bool {
         self.is_rayls_fork_active_at_block(RaylsHardFork::EmptyOutputBlock, block)
+    }
+
+    /// Return true if the GenesisStorageRekey fork is active at `block`.
+    fn is_genesis_storage_rekey_active_at_block(&self, block: u64) -> bool {
+        self.is_rayls_fork_active_at_block(RaylsHardFork::GenesisStorageRekey, block)
     }
 
     /// Return the active version byte at `block`, if any.
@@ -552,6 +574,14 @@ impl RaylsChainSpecBuilder {
         self.inner
             .hardforks
             .insert(RaylsHardFork::Erc20PrecompileBytecode, ForkCondition::Block(block));
+        self
+    }
+
+    /// Activate GenesisStorageRekey at `block`.
+    pub fn genesis_storage_rekey(mut self, block: u64) -> Self {
+        self.inner
+            .hardforks
+            .insert(RaylsHardFork::GenesisStorageRekey, ForkCondition::Block(block));
         self
     }
 
@@ -813,7 +843,7 @@ mod tests {
             RaylsNetwork::Local,
         ] {
             let schedule = RaylsHardFork::for_network(network);
-            assert_eq!(schedule.len(), 11, "expected 11 hardforks for {network}");
+            assert_eq!(schedule.len(), 12, "expected 12 hardforks for {network}");
             assert_eq!(schedule[0].0, RaylsHardFork::Eip1559);
             assert_eq!(schedule[1].0, RaylsHardFork::BatchDigestV2);
             assert_eq!(schedule[2].0, RaylsHardFork::AdminTransfer);
@@ -825,6 +855,7 @@ mod tests {
             assert_eq!(schedule[8].0, RaylsHardFork::TransactionLoadBalancing);
             assert_eq!(schedule[9].0, RaylsHardFork::UsdrSupplyCorrection);
             assert_eq!(schedule[10].0, RaylsHardFork::EmptyOutputBlock);
+            assert_eq!(schedule[11].0, RaylsHardFork::GenesisStorageRekey);
         }
     }
 

--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -128,6 +128,8 @@ pub(crate) struct RaylsBlockExecutor<Evm, Spec, R: ReceiptBuilder> {
     gas_used: u64,
     /// Hook for per-transaction state change notifications
     state_hook: Option<Box<dyn OnStateHook>>,
+    /// Provider factory for RocksDB access (needed by genesis storage migration).
+    provider_factory: Option<Arc<reth_provider::ProviderFactory<crate::traits::RaylsNode>>>,
 }
 
 impl<Evm: std::fmt::Debug, Spec: std::fmt::Debug, R: ReceiptBuilder> std::fmt::Debug
@@ -165,6 +167,17 @@ where
         spec: Spec,
         receipt_builder: R,
     ) -> Self {
+        Self::new_with_provider_factory(evm, ctx, spec, receipt_builder, None)
+    }
+
+    /// Creates a new [`RaylsBlockExecutor`] with a provider factory for RocksDB access.
+    pub(crate) fn new_with_provider_factory(
+        evm: Evm,
+        ctx: RaylsBlockExecutionCtx,
+        spec: Spec,
+        receipt_builder: R,
+        provider_factory: Option<Arc<reth_provider::ProviderFactory<crate::traits::RaylsNode>>>,
+    ) -> Self {
         Self {
             evm,
             ctx,
@@ -173,6 +186,7 @@ where
             spec,
             receipt_builder,
             state_hook: None,
+            provider_factory,
         }
     }
 
@@ -730,6 +744,7 @@ where
                 self.receipts.len(),
                 parent_number,
                 block_number,
+                self.provider_factory.as_ref().map(|v| &**v),
             )?;
         }
 

--- a/crates/execution/evm/src/evm/config.rs
+++ b/crates/execution/evm/src/evm/config.rs
@@ -37,21 +37,36 @@ pub struct RaylsEvmConfig<ChainSpec = RaylsChainSpec> {
     pub block_assembler: RaylsBlockAssembler<ChainSpec>,
     /// Counter that resolves epoch leader counts from the consensus DB.
     pub rewards_counter: RewardsCounter,
+    /// Provider factory for RocksDB access (needed by genesis storage migration).
+    /// `None` for test/temp chains that don't have a real provider factory.
+    pub provider_factory: Option<Arc<reth_provider::ProviderFactory<crate::traits::RaylsNode>>>,
 }
 
 impl RaylsEvmConfig {
     /// Creates a new Rayls EVM configuration with the given chain spec.
+    /// Use `new_with_provider_factory` when you have a real provider factory (production).
     pub fn new(chain_spec: Arc<RaylsChainSpec>, rewards_counter: RewardsCounter) -> Self {
+        Self::new_with_provider_factory(chain_spec, rewards_counter, None)
+    }
+
+    /// Creates a new Rayls EVM configuration with a provider factory for RocksDB access.
+    pub fn new_with_provider_factory(
+        chain_spec: Arc<RaylsChainSpec>,
+        rewards_counter: RewardsCounter,
+        provider_factory: Option<Arc<reth_provider::ProviderFactory<crate::traits::RaylsNode>>>,
+    ) -> Self {
         let evm_factory = RaylsEvmFactory::default();
         Self {
             block_assembler: RaylsBlockAssembler::new(chain_spec.clone()),
-            executor_factory: RaylsBlockExecutorFactory::new(
+            executor_factory: RaylsBlockExecutorFactory::new_with_provider_factory(
                 RethReceiptBuilder::default(),
                 chain_spec,
                 evm_factory,
+                provider_factory.clone(),
             ),
             evm_factory,
             rewards_counter,
+            provider_factory,
         }
     }
 

--- a/crates/execution/evm/src/evm/factory.rs
+++ b/crates/execution/evm/src/evm/factory.rs
@@ -379,7 +379,7 @@ impl EvmFactory for RaylsEvmFactory {
 }
 
 /// Ethereum block executor factory.
-#[derive(Debug, Clone, Default, Copy)]
+#[derive(Debug, Clone)]
 pub struct RaylsBlockExecutorFactory<
     R = AlloyReceiptBuilder,
     Spec = EthSpec,
@@ -391,14 +391,26 @@ pub struct RaylsBlockExecutorFactory<
     spec: Spec,
     /// EVM factory.
     evm_factory: EvmFactory,
+    /// Provider factory for RocksDB access (needed by genesis storage migration).
+    pub(crate) provider_factory: Option<Arc<reth_provider::ProviderFactory<crate::traits::RaylsNode>>>,
 }
 
 // alloy-evm
 impl<R, Spec, EvmFactory> RaylsBlockExecutorFactory<R, Spec, EvmFactory> {
     /// Creates a new [`RaylsBlockExecutorFactory`] with the given spec, [`EvmFactory`], and
     /// [`ReceiptBuilder`].
-    pub const fn new(receipt_builder: R, spec: Spec, evm_factory: EvmFactory) -> Self {
-        Self { receipt_builder, spec, evm_factory }
+    pub fn new(receipt_builder: R, spec: Spec, evm_factory: EvmFactory) -> Self {
+        Self { receipt_builder, spec, evm_factory, provider_factory: None }
+    }
+
+    /// Creates a new [`RaylsBlockExecutorFactory`] with a provider factory for RocksDB access.
+    pub fn new_with_provider_factory(
+        receipt_builder: R,
+        spec: Spec,
+        evm_factory: EvmFactory,
+        provider_factory: Option<Arc<reth_provider::ProviderFactory<crate::traits::RaylsNode>>>,
+    ) -> Self {
+        Self { receipt_builder, spec, evm_factory, provider_factory }
     }
 
     /// Exposes the receipt builder.
@@ -443,6 +455,9 @@ where
         DB: Database + 'a,
         I: Inspector<EvmF::Context<&'a mut State<DB>>> + 'a,
     {
-        RaylsBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
+        RaylsBlockExecutor::new_with_provider_factory(
+            evm, ctx, &self.spec, &self.receipt_builder,
+            self.provider_factory.clone(),
+        )
     }
 }

--- a/crates/execution/evm/src/evm/hardforks/mod.rs
+++ b/crates/execution/evm/src/evm/hardforks/mod.rs
@@ -19,6 +19,7 @@ use reth_evm::OnStateHook;
 use reth_revm::{
     bytecode::Bytecode,
     db::StorageWithOriginalValues,
+    primitives::HashMap,
     state::{Account as RevmAccount, AccountInfo, AccountStatus},
     State,
 };
@@ -54,6 +55,7 @@ pub(crate) fn apply_activated_migrations<DB: alloy_evm::Database>(
     receipt_count: usize,
     parent_number: u64,
     block_number: u64,
+    provider_factory: Option<&reth_provider::ProviderFactory<crate::traits::RaylsNode>>,
 ) -> Result<(), BlockExecutionError>
 where
     DB::Error: core::fmt::Display,
@@ -114,6 +116,32 @@ where
                 // Corrective migration: needs db read access to compute
                 // `slot + correction` at activation. See module docs.
                 usdr_supply_correction::usdr_supply_correction_state(db)?
+            }
+            RaylsHardFork::GenesisStorageRekey => {
+                let pf = provider_factory.expect("GenesisStorageRekey requires a provider factory");
+                info!(
+                    target: "engine",
+                    block_number,
+                    "Applying GenesisStorageRekey hardfork: re-keying genesis storage history"
+                );
+                crate::reth_env::RethEnv::fix_genesis_history_with(pf, true).map_err(|e| {
+                    BlockExecutionError::msg(format!(
+                        "GenesisStorageRekey: failed to re-key genesis storage: {e}"
+                    ))
+                })?;
+                info!(
+                    target: "engine",
+                    block_number,
+                    "Applying GenesisStorageRekey hardfork: seeding genesis account history"
+                );
+                crate::reth_env::RethEnv::fix_genesis_account_history_with(pf, true).map_err(
+                    |e| {
+                        BlockExecutionError::msg(format!(
+                            "GenesisStorageRekey: failed to seed genesis account history: {e}"
+                        ))
+                    },
+                )?;
+                HashMap::default()
             }
             // Continuous behavioral forks -- not one-shot migrations.
             RaylsHardFork::Eip1559
@@ -233,6 +261,7 @@ mod tests {
             0,
             TESTNET_ADMIN_TRANSFER_BLOCK - 1,
             TESTNET_ADMIN_TRANSFER_BLOCK,
+            None,
         )
         .expect("migration should succeed");
 
@@ -285,6 +314,7 @@ mod tests {
             0,
             crate::chainspec::TESTNET_ADMIN_TRANSFER_BLOCK - 2,
             crate::chainspec::TESTNET_ADMIN_TRANSFER_BLOCK - 1,
+            None,
         )
         .expect("migration should succeed");
 
@@ -306,6 +336,7 @@ mod tests {
             0,
             crate::chainspec::TESTNET_ADMIN_TRANSFER_BLOCK,
             crate::chainspec::TESTNET_ADMIN_TRANSFER_BLOCK + 1,
+            None,
         )
         .expect("should succeed");
 
@@ -329,6 +360,7 @@ mod tests {
             0,
             TESTNET_ADMIN_TRANSFER_BLOCK - 1,
             TESTNET_ADMIN_TRANSFER_BLOCK,
+            None,
         )
         .expect("migration should succeed");
 
@@ -378,6 +410,7 @@ mod tests {
             0,
             crate::chainspec::TESTNET_EIP1559_BLOCK - 1,
             crate::chainspec::TESTNET_EIP1559_BLOCK,
+            None,
         )
         .expect("should succeed");
 
@@ -400,6 +433,7 @@ mod tests {
             0,
             crate::chainspec::TESTNET_ADMIN_TRANSFER_BLOCK - 1,
             crate::chainspec::TESTNET_ADMIN_TRANSFER_BLOCK,
+            None,
         )
         .expect("should succeed");
 
@@ -436,6 +470,7 @@ mod tests {
             0,
             ACTIVATION_BLOCK - 1,
             ACTIVATION_BLOCK,
+            None,
         )
         .expect("migration should succeed");
 
@@ -467,6 +502,7 @@ mod tests {
             0,
             ACTIVATION_BLOCK - 2,
             ACTIVATION_BLOCK - 1,
+            None,
         )
         .expect("should succeed");
 
@@ -489,6 +525,7 @@ mod tests {
             0,
             ACTIVATION_BLOCK,
             ACTIVATION_BLOCK + 1,
+            None,
         )
         .expect("should succeed");
 

--- a/crates/execution/evm/src/reth_env/env.rs
+++ b/crates/execution/evm/src/reth_env/env.rs
@@ -29,7 +29,6 @@ pub struct RethEnv {
     /// Type that fetches data from the database.
     pub(crate) blockchain_provider: BlockchainProvider<RaylsNode>,
     /// Provider factory for direct storage operations such as pipeline unwind.
-    #[cfg(feature = "archive-replay")]
     pub(crate) provider_factory: ProviderFactory<RaylsNode>,
     /// The type to configure the EVM for execution.
     pub(crate) evm_config: RaylsEvmConfig,

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -69,18 +69,22 @@ impl RethEnv {
             builder = builder.min_base_fee(min_fee);
         }
         let chain_spec = Arc::new(builder.build());
-        let evm_config = RaylsEvmConfig::new(chain_spec.clone(), rewards_counter.clone());
         let task_spawner = task_manager.get_spawner();
         let runtime = reth_tasks::Runtime::with_existing_handle(tokio::runtime::Handle::current())?;
         let provider_factory = Self::init_provider_factory(
             &node_config,
-            chain_spec,
+            chain_spec.clone(),
             database.clone(),
             &task_spawner,
             runtime.clone(),
-            rewards_counter,
+            rewards_counter.clone(),
         )
         .await?;
+        let evm_config = RaylsEvmConfig::new_with_provider_factory(
+            chain_spec,
+            rewards_counter,
+            Some(Arc::new(provider_factory.clone())),
+        );
         let blockchain_provider = BlockchainProvider::new(provider_factory.clone())?;
         set_basefee_address(basefee_address);
 
@@ -133,7 +137,6 @@ impl RethEnv {
         Ok(Self {
             node_config,
             blockchain_provider,
-            #[cfg(feature = "archive-replay")]
             provider_factory,
             evm_config,
             task_spawner,
@@ -490,7 +493,6 @@ impl RethEnv {
     /// block-0 entry. This is a non-issue for replay-built archives, where that
     /// stage never runs; account history is written once by genesis init and only
     /// appended to.
-    #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_account_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_account_history_with(
             &self.provider_factory,
@@ -501,7 +503,6 @@ impl RethEnv {
 
     /// Testable core of [`Self::fix_genesis_account_history`]. Returns the number
     /// of accounts seeded.
-    #[cfg(feature = "archive-replay")]
     pub(crate) fn fix_genesis_account_history_with(
         provider_factory: &ProviderFactory<RaylsNode>,
         use_hashed_state: bool,
@@ -623,7 +624,6 @@ impl RethEnv {
     /// written by genesis init is intentionally left in place. It's never read by
     /// v2 (which looks up the hashed key) and deleting it is avoidable risk for no
     /// functional gain, so it's kept as harmless dead weight rather than removed.
-    #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_history_with(
             &self.provider_factory,
@@ -634,7 +634,6 @@ impl RethEnv {
 
     /// Testable core of [`Self::fix_genesis_history`]. Returns the number of
     /// storage slots re-keyed (0 when everything is already correct).
-    #[cfg(feature = "archive-replay")]
     pub(crate) fn fix_genesis_history_with(
         provider_factory: &ProviderFactory<RaylsNode>,
         use_hashed_state: bool,

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -129,7 +129,6 @@ impl RethEnv {
         Ok(Self {
             node_config,
             blockchain_provider,
-            #[cfg(feature = "archive-replay")]
             provider_factory,
             evm_config,
             task_spawner,


### PR DESCRIPTION
## Summary

- Adds a new `GenesisStorageRekey` hardfork that re-keys genesis storage history from plaintext slot keys to hashed keys at activation, fixing a bug where v2 archive reads (e.g. `versions[0]` lookups) returned zero for genesis-seeded storage values
- Removes `#[cfg(feature = "archive-replay")]` guards from `provider_factory` and the `fix_genesis_history*` / `fix_genesis_account_history*` methods so they can be called during live block execution at the hardfork activation block, not only during offline archive replay
- Threads `ProviderFactory` through `RaylsEvmConfig` → `RaylsBlockExecutorFactory` → `RaylsBlockExecutor` so the hardfork migration has access to RocksDB at activation time

Closes #

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

Scheduled at `u64::MAX` for devnet, testnet, and mainnet (not yet activated); block 1 on localnet. Node operators are unaffected until the fork block is set — at that point a coordinated activation is required.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo test --features archive-replay`
