### PR TITLE
feat: apply storage slot fix on node start

### DIFF
--- a/crates/execution/evm/src/reth_env/env.rs
+++ b/crates/execution/evm/src/reth_env/env.rs
@@ -29,7 +29,6 @@ pub struct RethEnv {
     /// Type that fetches data from the database.
     pub(crate) blockchain_provider: BlockchainProvider<RaylsNode>,
     /// Provider factory for direct storage operations such as pipeline unwind.
-    #[cfg(feature = "archive-replay")]
     pub(crate) provider_factory: ProviderFactory<RaylsNode>,
     /// The type to configure the EVM for execution.
     pub(crate) evm_config: RaylsEvmConfig,

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -588,6 +588,10 @@ impl RethEnv {
                 Some(existing_list) => {
                     let blocks: Vec<u64> =
                         core::iter::once(block).chain(existing_list.iter()).collect();
+                    debug_assert!(
+                        blocks.windows(2).all(|w| w[0] < w[1]),
+                        "merged genesis account history must be strictly ascending"
+                    );
                     BlockNumberList::new(blocks)
                         .map_err(|e| eyre::eyre!("failed to build block number list: {e}"))?
                 }

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -492,7 +492,7 @@ impl RethEnv {
     /// from `AccountChangeSets` by `IndexAccountHistoryStage` (a normally-synced
     /// node — not `rayls-replay`), a *multi-shard* genesis account is skipped here
     /// and genesis has no changeset to rebuild from, so it never regains its
-    /// block-0 entry. This is a non-issue for replay-built, where that
+    /// block-0 entry. This is a non-issue for replay-built nodes, where that
     /// stage never runs; account history is written once by genesis init and only
     /// appended to.
     pub fn fix_genesis_account_history(&self) -> eyre::Result<()> {
@@ -522,10 +522,11 @@ impl RethEnv {
         let genesis = chain_spec.genesis();
         let block = chain_spec.genesis_header().number;
 
+        let rocksdb = provider_factory.rocksdb_provider();
+
         // Per-account prefix scan — mirrors fix_genesis_history_with pattern.
         // Only scans shards for genesis accounts, not the entire table.
         let (already_fixed, shard_counts): (HashSet<Address>, HashMap<Address, usize>) = {
-            let rocksdb = provider_factory.rocksdb_provider();
             let mut fixed = HashSet::new();
             let mut counts: HashMap<Address, usize> = HashMap::new();
             for addr in genesis.alloc.keys() {
@@ -579,7 +580,6 @@ impl RethEnv {
             return Ok(0);
         }
 
-        let rocksdb = provider_factory.rocksdb_provider();
         let mut batch = rocksdb.batch();
         for addr in &to_fix {
             let key = ShardedKey::last(*addr);

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -81,6 +81,12 @@ impl RethEnv {
             rewards_counter,
         )
         .await?;
+
+        // Apply genesis history fixes (idempotent, no-op on v1 storage).
+        let use_hashed_state = node_config.storage_settings().use_hashed_state();
+        Self::fix_genesis_history_with(&provider_factory, use_hashed_state)?;
+        Self::fix_genesis_account_history_with(&provider_factory, use_hashed_state)?;
+
         let blockchain_provider = BlockchainProvider::new(provider_factory.clone())?;
         set_basefee_address(basefee_address);
 
@@ -133,7 +139,6 @@ impl RethEnv {
         Ok(Self {
             node_config,
             blockchain_provider,
-            #[cfg(feature = "archive-replay")]
             provider_factory,
             evm_config,
             task_spawner,
@@ -481,16 +486,15 @@ impl RethEnv {
     /// This re-inserts a genesis block-0 entry for every such account via a
     /// read-merge-write so existing post-genesis shards are preserved. Accounts
     /// with more than one shard already carry post-genesis changesets and are
-    /// left untouched. Only applicable to v2 (RocksDB) archives. Idempotent.
+    /// left untouched. Only applicable to v2 (RocksDB). Idempotent.
     ///
-    /// Limitation: on an archive whose `AccountsHistory` was cleared and rebuilt
+    /// Limitation: on a node whose `AccountsHistory` was cleared and rebuilt
     /// from `AccountChangeSets` by `IndexAccountHistoryStage` (a normally-synced
     /// node — not `rayls-replay`), a *multi-shard* genesis account is skipped here
     /// and genesis has no changeset to rebuild from, so it never regains its
-    /// block-0 entry. This is a non-issue for replay-built archives, where that
+    /// block-0 entry. This is a non-issue for replay-built, where that
     /// stage never runs; account history is written once by genesis init and only
     /// appended to.
-    #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_account_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_account_history_with(
             &self.provider_factory,
@@ -501,7 +505,6 @@ impl RethEnv {
 
     /// Testable core of [`Self::fix_genesis_account_history`]. Returns the number
     /// of accounts seeded.
-    #[cfg(feature = "archive-replay")]
     pub(crate) fn fix_genesis_account_history_with(
         provider_factory: &ProviderFactory<RaylsNode>,
         use_hashed_state: bool,
@@ -519,17 +522,20 @@ impl RethEnv {
         let genesis = chain_spec.genesis();
         let block = chain_spec.genesis_header().number;
 
-        // Single pass: collect which addresses already have a block-0 entry
-        // (idempotency guard) and how many shards each address has (safety guard).
+        // Per-account prefix scan — mirrors fix_genesis_history_with pattern.
+        // Only scans shards for genesis accounts, not the entire table.
         let (already_fixed, shard_counts): (HashSet<Address>, HashMap<Address, usize>) = {
             let rocksdb = provider_factory.rocksdb_provider();
             let mut fixed = HashSet::new();
             let mut counts: HashMap<Address, usize> = HashMap::new();
-            for entry in rocksdb.iter::<reth_db::tables::AccountsHistory>()? {
-                let (key, value) = entry?;
-                *counts.entry(key.key).or_insert(0) += 1;
-                if value.contains(block) {
-                    fixed.insert(key.key);
+            for addr in genesis.alloc.keys() {
+                let shards = rocksdb.account_history_shards(*addr)?;
+                if shards.is_empty() {
+                    continue;
+                }
+                counts.insert(*addr, shards.len());
+                if shards.iter().any(|(_, list)| list.contains(block)) {
+                    fixed.insert(*addr);
                 }
             }
             (fixed, counts)
@@ -595,12 +601,12 @@ impl RethEnv {
             target: "rayls::reth",
             accounts = to_fix.len(),
             block,
-            "seeded genesis account history for v2 archive"
+            "seeded genesis account history for v2"
         );
         Ok(to_fix.len())
     }
 
-    /// Re-key the genesis storage history to hashed keys so v2 archive reads
+    /// Re-key the genesis storage history to hashed keys so v2 reads
     /// reconstruct genesis-seeded storage instead of returning 0x0.
     ///
     /// reth's genesis writer (`insert_storage_history`) keys `StoragesHistory`
@@ -617,13 +623,12 @@ impl RethEnv {
     /// blocks. When prepending would push the earliest shard past
     /// `NUM_OF_INDICES_IN_SHARD` (a hot genesis slot with >= that many
     /// post-genesis changes), the slot's shards are re-chunked so none exceeds
-    /// the limit. Only applicable to v2 (RocksDB) archives. Idempotent.
+    /// the limit. Only applicable to v2 (RocksDB). Idempotent.
     ///
     /// This adds the entry under the hashed key; the original plain-slot entry
     /// written by genesis init is intentionally left in place. It's never read by
     /// v2 (which looks up the hashed key) and deleting it is avoidable risk for no
     /// functional gain, so it's kept as harmless dead weight rather than removed.
-    #[cfg(feature = "archive-replay")]
     pub fn fix_genesis_history(&self) -> eyre::Result<()> {
         Self::fix_genesis_history_with(
             &self.provider_factory,
@@ -634,7 +639,6 @@ impl RethEnv {
 
     /// Testable core of [`Self::fix_genesis_history`]. Returns the number of
     /// storage slots re-keyed (0 when everything is already correct).
-    #[cfg(feature = "archive-replay")]
     pub(crate) fn fix_genesis_history_with(
         provider_factory: &ProviderFactory<RaylsNode>,
         use_hashed_state: bool,

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -129,7 +129,6 @@ impl RethEnv {
         Ok(Self {
             node_config,
             blockchain_provider,
-            #[cfg(feature = "archive-replay")]
             provider_factory,
             evm_config,
             task_spawner,


### PR DESCRIPTION
## Summary

- Apply genesis history fixes (`fix_genesis_history` + `fix_genesis_account_history`) automatically on node startup, so v2 archives boot with correct genesis storage/account history without requiring a separate `rayls-replay --fix-genesis-history` pass.
- Replace the O(billions) full table scan in `fix_genesis_account_history_with` with an O(genesis accounts) per-account lookup using `account_history_shards()`, making startup fast even on large archives.
- Move the fix functions out of the `archive-replay` feature gate so they're available to the shipping node binary.

Closes #

## Surface areas touched

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None.

## Test plan

- `cargo check -p rayls-network -p rayls-replay -p rayls-middleware-orchestrator` — all compile cleanly
- `cargo test -p rayls-execution-evm --lib --features archive-replay -- fix_genesis` — both fix tests pass
- `cargo test -p e2e-tests --test it test_genesis_with_consensus_registry` — e2e genesis test passes
