### PR TITLE
feat: does not allow node with storage v1

### DIFF
--- a/bin/rayls-replay/src/main.rs
+++ b/bin/rayls-replay/src/main.rs
@@ -181,7 +181,6 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         cli.chain,
         basefee_address,
         Some(min_base_fee),
-        cli.storage_v2,
         Some(cli.persistence_threshold),
         archive_rewards.clone(),
     )
@@ -229,7 +228,6 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         cli.chain,
         basefee_address,
         Some(min_base_fee),
-        cli.storage_v2,
         None,
         RewardsCounter::default(),
     )

--- a/bin/rayls-replay/src/main.rs
+++ b/bin/rayls-replay/src/main.rs
@@ -181,6 +181,7 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         cli.chain,
         basefee_address,
         Some(min_base_fee),
+        cli.storage_v2,
         Some(cli.persistence_threshold),
         archive_rewards.clone(),
     )
@@ -228,6 +229,7 @@ async fn run(cli: Cli) -> eyre::Result<()> {
         cli.chain,
         basefee_address,
         Some(min_base_fee),
+        cli.storage_v2,
         None,
         RewardsCounter::default(),
     )

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -260,10 +260,7 @@ impl RethEnv {
         // V1 (plain) storage is no longer supported — forbid it at startup.
         let storage_settings = node_config.storage_settings();
         if !storage_settings.storage_v2 && !allow_v1 {
-            panic!(
-                "V1 (plain) storage is no longer supported. \
-                 Restart with `--storage.v2`."
-            );
+            eyre::bail!("V1 (plain) storage is no longer supported. Restart with `--storage.v2`.");
         }
 
         let datadir = node_config.datadir();

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -22,8 +22,8 @@ use reth_engine_tree::tree::{precompile_cache::PrecompileCacheMap, PayloadProces
 use reth_node_core::args::{EngineArgs, StorageArgs};
 use reth_provider::{
     providers::{BlockchainProvider, RocksDBBuilder, StaticFileProvider},
-    BlockNumReader, ChainSpecProvider, DatabaseProviderFactory, MetadataProvider, ProviderFactory,
-    RocksDBProviderFactory, StorageSettings, StorageSettingsCache,
+    BlockNumReader, ChainSpecProvider, DatabaseProviderFactory, ProviderFactory,
+    RocksDBProviderFactory, StorageSettingsCache,
 };
 use reth_prune_types::PruneModes;
 use reth_stages::{sets::DefaultStages, PipelineBuilder, PipelineTarget};
@@ -166,6 +166,7 @@ impl RethEnv {
                 pprof_dumps_path: None,
             },
             chain,
+            storage: StorageArgs { v2: true },
             ..NodeConfig::default()
         };
         let reth_config = RethConfig(node_config);
@@ -308,16 +309,12 @@ impl RethEnv {
             init_genesis_with_settings(&provider_factory, node_config.storage_settings())?;
         debug!(target: "rayls::execution", chain=%node_config.chain.chain, ?genesis_hash, "Initialized genesis");
 
-        // Hard check: panic if the DB is V2 but the node is started as V1.
-        // A V1 node cannot read V2 hashed state — this is the only dangerous mismatch.
-        // V1→V2 upgrades are the intended migration path, so we allow that direction.
-        let stored = provider_factory.storage_settings()?.unwrap_or_else(StorageSettings::v1);
+        // V1 (plain) storage is no longer supported — forbid it at startup.
         let requested = node_config.storage_settings();
-        if stored.storage_v2 && !requested.storage_v2 {
+        if !requested.storage_v2 {
             panic!(
-                "Database is V2 (hashed state) but the node was started as V1. \
-                 A V1 node cannot read V2 storage — point the node to the \
-                 correct datadir or rebuild with `--storage.v2`."
+                "V1 (plain) storage is no longer supported. \
+                 Restart with `--storage.v2`."
             );
         }
 

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -252,6 +252,15 @@ impl RethEnv {
         runtime: reth_tasks::Runtime,
         rewards_counter: RewardsCounter,
     ) -> eyre::Result<ProviderFactory<RaylsNode>> {
+        // V1 (plain) storage is no longer supported — forbid it at startup.
+        let requested = node_config.storage_settings();
+        if !requested.storage_v2 {
+            panic!(
+                "V1 (plain) storage is no longer supported. \
+                 Restart with `--storage.v2`."
+            );
+        }
+
         let datadir = node_config.datadir();
         // Wrap ChainSpec in RaylsChainSpec for static base fee
         let rocksdb_provider = RocksDBBuilder::new(datadir.rocksdb())
@@ -308,15 +317,6 @@ impl RethEnv {
         let genesis_hash =
             init_genesis_with_settings(&provider_factory, node_config.storage_settings())?;
         debug!(target: "rayls::execution", chain=%node_config.chain.chain, ?genesis_hash, "Initialized genesis");
-
-        // V1 (plain) storage is no longer supported — forbid it at startup.
-        let requested = node_config.storage_settings();
-        if !requested.storage_v2 {
-            panic!(
-                "V1 (plain) storage is no longer supported. \
-                 Restart with `--storage.v2`."
-            );
-        }
 
         Ok(provider_factory)
     }

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -22,8 +22,8 @@ use reth_engine_tree::tree::{precompile_cache::PrecompileCacheMap, PayloadProces
 use reth_node_core::args::{EngineArgs, StorageArgs};
 use reth_provider::{
     providers::{BlockchainProvider, RocksDBBuilder, StaticFileProvider},
-    BlockNumReader, ChainSpecProvider, DatabaseProviderFactory, ProviderFactory,
-    RocksDBProviderFactory, StorageSettingsCache,
+    BlockNumReader, ChainSpecProvider, DatabaseProviderFactory, MetadataProvider, ProviderFactory,
+    RocksDBProviderFactory, StorageSettings, StorageSettingsCache,
 };
 use reth_prune_types::PruneModes;
 use reth_stages::{sets::DefaultStages, PipelineBuilder, PipelineTarget};
@@ -307,6 +307,19 @@ impl RethEnv {
         let genesis_hash =
             init_genesis_with_settings(&provider_factory, node_config.storage_settings())?;
         debug!(target: "rayls::execution", chain=%node_config.chain.chain, ?genesis_hash, "Initialized genesis");
+
+        // Hard check: panic if the DB is V2 but the node is started as V1.
+        // A V1 node cannot read V2 hashed state — this is the only dangerous mismatch.
+        // V1→V2 upgrades are the intended migration path, so we allow that direction.
+        let stored = provider_factory.storage_settings()?.unwrap_or_else(StorageSettings::v1);
+        let requested = node_config.storage_settings();
+        if stored.storage_v2 && !requested.storage_v2 {
+            panic!(
+                "Database is V2 (hashed state) but the node was started as V1. \
+                 A V1 node cannot read V2 storage — point the node to the \
+                 correct datadir or rebuild with `--storage.v2`."
+            );
+        }
 
         Ok(provider_factory)
     }

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -59,6 +59,7 @@ impl RethEnv {
         build_metadata: &BuildMetadata,
         network: Option<RaylsNetwork>,
         min_base_fee: Option<u64>,
+        allow_v1: bool,
     ) -> eyre::Result<Self> {
         let node_config = reth_config.0.clone();
         let mut builder = RaylsChainSpec::builder(Arc::clone(&node_config.chain));
@@ -79,6 +80,7 @@ impl RethEnv {
             &task_spawner,
             runtime.clone(),
             rewards_counter,
+            allow_v1,
         )
         .await?;
         let blockchain_provider = BlockchainProvider::new(provider_factory.clone())?;
@@ -180,6 +182,7 @@ impl RethEnv {
             &BuildMetadata::default(),
             None,
             None,
+            false,
         )
         .await
     }
@@ -239,6 +242,7 @@ impl RethEnv {
             &BuildMetadata::default(),
             Some(network),
             min_base_fee,
+            true,
         )
         .await
     }
@@ -251,10 +255,11 @@ impl RethEnv {
         task_spawner: &TaskSpawner,
         runtime: reth_tasks::Runtime,
         rewards_counter: RewardsCounter,
+        allow_v1: bool,
     ) -> eyre::Result<ProviderFactory<RaylsNode>> {
         // V1 (plain) storage is no longer supported — forbid it at startup.
         let storage_settings = node_config.storage_settings();
-        if !storage_settings.storage_v2 {
+        if !storage_settings.storage_v2 && !allow_v1 {
             panic!(
                 "V1 (plain) storage is no longer supported. \
                  Restart with `--storage.v2`."

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -253,8 +253,8 @@ impl RethEnv {
         rewards_counter: RewardsCounter,
     ) -> eyre::Result<ProviderFactory<RaylsNode>> {
         // V1 (plain) storage is no longer supported — forbid it at startup.
-        let requested = node_config.storage_settings();
-        if !requested.storage_v2 {
+        let storage_settings = node_config.storage_settings();
+        if !storage_settings.storage_v2 {
             panic!(
                 "V1 (plain) storage is no longer supported. \
                  Restart with `--storage.v2`."
@@ -276,7 +276,7 @@ impl RethEnv {
             runtime,
         )?;
 
-        provider_factory.set_storage_settings_cache(node_config.storage_settings());
+        provider_factory.set_storage_settings_cache(storage_settings);
 
         if let Some(prune_config) = node_config.prune_config() {
             provider_factory = provider_factory.with_prune_modes(prune_config.segments);
@@ -313,9 +313,8 @@ impl RethEnv {
 
         // init_genesis_with_settings writes HashedAccounts/HashedStorages via
         // insert_genesis_hashes and derives the trie via compute_state_root,
-        // so no post-init rehashing is needed for v1 or v2.
-        let genesis_hash =
-            init_genesis_with_settings(&provider_factory, node_config.storage_settings())?;
+        // so no post-init rehashing is needed for v2.
+        let genesis_hash = init_genesis_with_settings(&provider_factory, storage_settings)?;
         debug!(target: "rayls::execution", chain=%node_config.chain.chain, ?genesis_hash, "Initialized genesis");
 
         Ok(provider_factory)

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -203,7 +203,6 @@ impl RethEnv {
         network: RaylsNetwork,
         basefee_address: Option<Address>,
         min_base_fee: Option<u64>,
-        storage_v2: bool,
         persistence_threshold: Option<u64>,
         rewards_counter: RewardsCounter,
     ) -> eyre::Result<Self> {
@@ -217,7 +216,7 @@ impl RethEnv {
                 pprof_dumps_path: None,
             },
             chain,
-            storage: StorageArgs { v2: storage_v2 },
+            storage: StorageArgs { v2: true },
             engine: EngineArgs {
                 persistence_threshold: persistence_threshold
                     .unwrap_or(DEFAULT_PERSISTENCE_THRESHOLD),

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -203,6 +203,7 @@ impl RethEnv {
         network: RaylsNetwork,
         basefee_address: Option<Address>,
         min_base_fee: Option<u64>,
+        storage_v2: bool,
         persistence_threshold: Option<u64>,
         rewards_counter: RewardsCounter,
     ) -> eyre::Result<Self> {
@@ -216,7 +217,7 @@ impl RethEnv {
                 pprof_dumps_path: None,
             },
             chain,
-            storage: StorageArgs { v2: true },
+            storage: StorageArgs { v2: storage_v2 },
             engine: EngineArgs {
                 persistence_threshold: persistence_threshold
                     .unwrap_or(DEFAULT_PERSISTENCE_THRESHOLD),

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -74,7 +74,8 @@ impl RethEnv {
             persistence,
             reth_env::RethConfig,
         };
-        use reth_node_core::{args::DatadirArgs, node_config::NodeConfig};
+        use reth_node_core::args::{DatadirArgs, StorageArgs};
+        use reth_node_core::node_config::NodeConfig;
         use reth_provider::providers::BlockchainProvider;
         use reth_storage_api::{BlockNumReader, DatabaseProviderFactory};
 
@@ -88,6 +89,7 @@ impl RethEnv {
                 pprof_dumps_path: None,
             },
             chain,
+            storage: StorageArgs { v2: true },
             ..NodeConfig::default()
         };
         let reth_config = RethConfig(node_config.clone());

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -74,8 +74,10 @@ impl RethEnv {
             persistence,
             reth_env::RethConfig,
         };
-        use reth_node_core::args::{DatadirArgs, StorageArgs};
-        use reth_node_core::node_config::NodeConfig;
+        use reth_node_core::{
+            args::{DatadirArgs, StorageArgs},
+            node_config::NodeConfig,
+        };
         use reth_provider::providers::BlockchainProvider;
         use reth_storage_api::{BlockNumReader, DatabaseProviderFactory};
 

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -107,6 +107,7 @@ impl RethEnv {
             &task_spawner,
             runtime.clone(),
             rewards_counter,
+            false,
         )
         .await?;
         let blockchain_provider = BlockchainProvider::new(provider_factory.clone())?;

--- a/crates/middleware/orchestrator/src/epoch_manager/engine.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/engine.rs
@@ -32,6 +32,7 @@ where
             &self.builder.build_metadata,
             Some(network),
             Some(min_base_fee),
+            false,
         )
         .await?;
         let engine = ExecutionNode::new(&self.builder, reth_env)?;

--- a/crates/testing/e2e-tests/src/lib.rs
+++ b/crates/testing/e2e-tests/src/lib.rs
@@ -150,6 +150,7 @@ pub fn spawn_local_testnet(
         let command = NodeCommand::<rayls_execution_faucet::FaucetArgs>::parse_from([
             "rl",
             "--http",
+            "--storage.v2",
             "--instance",
             &instance,
             "--google-kms",
@@ -157,7 +158,8 @@ pub fn spawn_local_testnet(
             faucet_contract_address,
         ]);
         #[cfg(not(feature = "faucet"))]
-        let command = NodeCommand::parse_from(["rl", "--http", "--instance", &instance]);
+        let command =
+            NodeCommand::parse_from(["rl", "--http", "--storage.v2", "--instance", &instance]);
 
         std::thread::spawn(|| {
             let err = command.execute(

--- a/crates/testing/test-utils/src/execution.rs
+++ b/crates/testing/test-utils/src/execution.rs
@@ -60,7 +60,7 @@ fn execution_builder<CliExt: clap::Args + fmt::Debug>(
     opt_args: Option<Vec<&str>>,
     tmp_dir: &Path,
 ) -> eyre::Result<(RaylsBuilder, CliExt)> {
-    let default_args = ["rayls-network", "--http", "--chain", "testnet"];
+    let default_args = ["rayls-network", "--http", "--chain", "testnet", "--storage.v2"];
 
     // extend faucet args if provided
     let cli_args = if let Some(args) = opt_args {

--- a/crates/testing/test-utils/src/execution.rs
+++ b/crates/testing/test-utils/src/execution.rs
@@ -168,6 +168,7 @@ pub async fn faucet_test_execution_node(
             &BuildMetadata::default(),
             None,
             None,
+            false,
         )
         .await?,
     )?;

--- a/etc/chaos-network/Dockerfile
+++ b/etc/chaos-network/Dockerfile
@@ -56,4 +56,4 @@ COPY --from=builder /tmp/rayls-network /usr/local/bin/rayls
 
 USER $USER_NAME
 
-CMD ["rayls", "node"]
+CMD ["rayls", "node", "--storage.v2"]

--- a/etc/docker-network/Dockerfile
+++ b/etc/docker-network/Dockerfile
@@ -58,4 +58,4 @@ USER $USER_NAME
 COPY --from=builder /tmp/rayls-network /usr/local/bin/rayls
 
 # default
-CMD ["rayls", "node"]
+CMD ["rayls", "node", "--storage.v2"]

--- a/etc/validator/activate-validator.sh
+++ b/etc/validator/activate-validator.sh
@@ -87,6 +87,7 @@ if [ "$START" = true ]; then
         --instance 99 \
         --metrics "127.0.0.1:9109" \
         --log.stdout.format log-fmt \
+        --storage.v2 \
         --txpool.pending-max-count 1000000 \
         --txpool.pending-max-size 1242880000 \
         --txpool.basefee-max-count 1000000 \


### PR DESCRIPTION
## Summary

- V1 (plain) storage is no longer supported — the node now panics at startup if launched without `--storage.v2`.
- All test helpers (`new_for_temp_chain`, `new_for_temp_chain_with_rayls_spec`, `execution_builder`, e2e `spawn_local_testnet`) now explicitly enable V2 storage.
- All operational scripts (`activate-validator.sh`, `create-observer.sh`, `local-testnet.sh`, etc.) that were already passing `--storage.v2` are unchanged; the one missing case (`activate-validator.sh`) has been fixed.

Closes #

## Surface areas touched

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [x] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

Yes — the node will refuse to start without `--storage.v2`. Any deployment, script, or test that omits this flag will panic at startup.

## Test plan

- [x] Run `cargo test` across the workspace — all tests use V2 storage now.
- [x] Start `rayls-network node` without `--storage.v2` — should panic with "V1 (plain) storage is no longer supported".
- [x] Start `rayls-network node --storage.v2` against a fresh datadir — should proceed normally.
