### PR TITLE
ci(chaos): fix toolchain resolution so Nightly Chaos runs under sudo

### DIFF
--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -60,19 +60,21 @@ jobs:
       - name: Ensure tc / iptables are available
         run: sudo apt-get update && sudo apt-get install -y iproute2 iptables
 
-      # The network-fault scenarios shell out to `tc`/`iptables`, so the test
-      # process must run as root. Do NOT run cargo under sudo: sudo's secure_path
-      # and root's HOME make the rustup shim resolve the wrong toolchain (the
-      # runner image default, not the repo-pinned 1.91.0) and leave target/ owned
-      # by root. Instead build the test binary as the normal runner user (correct
-      # toolchain, clean ownership), then run only the prebuilt binary under sudo.
+      # These tests must run via `cargo test`: cluster.rs reads CARGO_MANIFEST_DIR
+      # at runtime and shells out to cargo (escargot) to build the rayls-network
+      # binary mid-test. They also need root for tc/iptables, so cargo runs under
+      # sudo. sudo's secure_path/HOME otherwise make the rustup shim resolve the
+      # runner image's default toolchain (e.g. 1.83.0) instead of the repo-pinned
+      # one, which breaks the build. Re-inject PATH and pin RUSTUP_TOOLCHAIN, and
+      # use the shim `cargo` (not an absolute binary) so the outer test AND the
+      # inner escargot build both route through rustup at the pinned toolchain.
       # Pass the dispatch input via env (not templated into the script) so it's
       # treated as data, not shell code. Left unquoted so empty = run all.
       - name: Run chaos scenarios
         env:
           TEST: ${{ github.event.inputs.test }}
         run: |
-          bin=$(cargo test -p chaos-framework --test chaos_scenarios --no-run --message-format=json \
-            | jq -r 'select(.reason == "compiler-artifact" and .target.name == "chaos_scenarios" and .executable != null) | .executable')
-          if [ -z "$bin" ]; then echo "could not locate chaos_scenarios test binary" >&2; exit 1; fi
-          sudo -E "$bin" --ignored --exact --test-threads 1 $TEST
+          toolchain=$(rustup show active-toolchain | cut -d' ' -f1)
+          sudo -E env "PATH=$PATH" "RUSTUP_TOOLCHAIN=$toolchain" cargo test \
+            -p chaos-framework --test chaos_scenarios \
+            -- --ignored --exact --test-threads 1 $TEST

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -62,13 +62,17 @@ jobs:
 
       # The network-fault scenarios shell out to `tc`/`iptables` (no sudo of
       # their own), so the test process itself must be root. `rustup which cargo`
-      # resolves the toolchain binary as the runner user; sudo -E then runs it
-      # as root with the environment (PATH, HOME, CARGO_HOME) preserved.
+      # resolves the real toolchain binary as the runner user, but sudo applies
+      # its `secure_path`, which overrides PATH (even with -E) and drops
+      # ~/.cargo/bin — so the invoked cargo can't find `rustc` and aborts with
+      # "could not execute process `rustc -vV`". Re-inject the runner's PATH via
+      # `env` (which sudo finds on secure_path) so the toolchain resolves inside
+      # the sudo'd process.
       # Pass the dispatch input via env (not templated into the script) so it's
       # treated as data, not shell code. Left unquoted so empty = run all.
       - name: Run chaos scenarios
         env:
           TEST: ${{ github.event.inputs.test }}
         run: |
-          sudo -E "$(rustup which cargo)" test -p chaos-framework --test chaos_scenarios \
+          sudo -E env "PATH=$PATH" "$(rustup which cargo)" test -p chaos-framework --test chaos_scenarios \
             -- --ignored --exact --test-threads 1 $TEST

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -54,25 +54,25 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: nightly-chaos
+          shared-key: nightly-chaos-2
           cache-on-failure: true
 
       - name: Ensure tc / iptables are available
         run: sudo apt-get update && sudo apt-get install -y iproute2 iptables
 
-      # The network-fault scenarios shell out to `tc`/`iptables` (no sudo of
-      # their own), so the test process itself must be root. `rustup which cargo`
-      # resolves the real toolchain binary as the runner user, but sudo applies
-      # its `secure_path`, which overrides PATH (even with -E) and drops
-      # ~/.cargo/bin — so the invoked cargo can't find `rustc` and aborts with
-      # "could not execute process `rustc -vV`". Re-inject the runner's PATH via
-      # `env` (which sudo finds on secure_path) so the toolchain resolves inside
-      # the sudo'd process.
+      # The network-fault scenarios shell out to `tc`/`iptables`, so the test
+      # process must run as root. Do NOT run cargo under sudo: sudo's secure_path
+      # and root's HOME make the rustup shim resolve the wrong toolchain (the
+      # runner image default, not the repo-pinned 1.91.0) and leave target/ owned
+      # by root. Instead build the test binary as the normal runner user (correct
+      # toolchain, clean ownership), then run only the prebuilt binary under sudo.
       # Pass the dispatch input via env (not templated into the script) so it's
       # treated as data, not shell code. Left unquoted so empty = run all.
       - name: Run chaos scenarios
         env:
           TEST: ${{ github.event.inputs.test }}
         run: |
-          sudo -E env "PATH=$PATH" "$(rustup which cargo)" test -p chaos-framework --test chaos_scenarios \
-            -- --ignored --exact --test-threads 1 $TEST
+          bin=$(cargo test -p chaos-framework --test chaos_scenarios --no-run --message-format=json \
+            | jq -r 'select(.reason == "compiler-artifact" and .target.name == "chaos_scenarios" and .executable != null) | .executable')
+          if [ -z "$bin" ]; then echo "could not locate chaos_scenarios test binary" >&2; exit 1; fi
+          sudo -E "$bin" --ignored --exact --test-threads 1 $TEST


### PR DESCRIPTION
## Summary

Nightly Chaos has failed on every run because the test step ran cargo under `sudo` and cargo couldn't find the compiler. Fixes #56.

**Root cause:** the chaos scenarios need root (they inject faults with `tc`/`iptables`), so the test ran via `sudo`. But sudo's `secure_path` overrides `PATH` (even with `-E`) and drops `~/.cargo/bin`, and root's `HOME` changes the rustup context — so the rustup shim resolved the runner image's default toolchain (1.83.0) instead of the repo-pinned 1.91.0. Early runs died with `could not execute process rustc -vV`; once past that, cargo 1.91 driving rustc 1.83 failed the build outright.

**Fix:** keep running `cargo test` under sudo — the tests require it (`cluster.rs` reads `CARGO_MANIFEST_DIR` at runtime and shells out to cargo via `escargot` to build `rayls-network` mid-test) — but pin the toolchain explicitly:
- re-inject the runner's `PATH` via `env` (which sudo finds on `secure_path`),
- set `RUSTUP_TOOLCHAIN` to the repo's active toolchain, and
- invoke the shim `cargo` (not an absolute binary) so both the outer test and the inner escargot build route through rustup at the pinned toolchain.

Also bumps the `rust-cache` `shared-key` to discard artifacts a failed attempt had cached.

## Verification

Two `workflow_dispatch` runs of this branch, both green — covering both execution paths that were broken:

| Scenario | Exercises | Result |
| --- | --- | --- |
| `test_single_validator_crash_and_recovery` | build + sudo + full testnet crash/recovery | ✅ pass ([run](https://github.com/raylsnetwork/axyl/actions/runs/30002469962)) |
| `test_network_latency_uniform` | `tc` fault injection as root under sudo | ✅ pass ([run](https://github.com/raylsnetwork/axyl/actions/runs/30003938670)) |

Both ran the full 4-validator testnet on `rayls-network 1.2.2` built from this branch and reported `test result: ok. 1 passed; 0 failed`.

## Note for reviewer

Three iteration commits (each documents a step of the diagnosis) — **suggest squash-merge**.

Closes #56.