### PR TITLE
fix(ci): e2e tests using storage v2

### DIFF
--- a/crates/testing/e2e-tests/tests/it/epochs.rs
+++ b/crates/testing/e2e-tests/tests/it/epochs.rs
@@ -628,7 +628,9 @@ fn start_nodes(temp_path: &Path, validators: &[(&str, Address)]) -> eyre::Result
             .arg(&*dir.to_string_lossy())
             .arg("--instance")
             .arg(&instance)
-            .arg("--http");
+            .arg("--http")
+            // v1 (plain) storage is no longer supported -- the node refuses to start without this
+            .arg("--storage.v2");
 
         #[cfg(feature = "faucet")]
         command

--- a/crates/testing/e2e-tests/tests/it/restarts.rs
+++ b/crates/testing/e2e-tests/tests/it/restarts.rs
@@ -727,7 +727,9 @@ fn start_validator(
         .arg(format!("{}", instance + 1))
         .arg("--http")
         .arg("--http.port")
-        .arg(format!("{rpc_port}"));
+        .arg(format!("{rpc_port}"))
+        // v1 (plain) storage is no longer supported -- the node refuses to start without this
+        .arg("--storage.v2");
 
     #[cfg(feature = "faucet")]
     command
@@ -758,7 +760,9 @@ fn start_observer(
         .arg(format!("{}", instance + 1))
         .arg("--http")
         .arg("--http.port")
-        .arg(format!("{rpc_port}"));
+        .arg(format!("{rpc_port}"))
+        // v1 (plain) storage is no longer supported -- the node refuses to start without this
+        .arg("--storage.v2");
     command.spawn().expect("failed to execute")
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

- Added storage.v2 argument to test harness.

Closes #

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [X] Tests only

## Breaking / compatibility

<!-- Does this require a node restart, a network upgrade, a hardfork activation block, a contract migration, a config change, or any client coordination? If yes, describe. If no, write "None". -->

None.

## Test plan

<!-- What did you do to convince yourself this works? Commands, scenarios, or links to CI output. -->

- [X] E2E tests are passing with proper storage argument
