### PR TITLE
feat(rewards): hybrid participation + anchor + stake reward model (computation only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8204,6 +8204,7 @@ dependencies = [
 name = "rayls-middleware-rewards"
 version = "1.2.2"
 dependencies = [
+ "alloy",
  "eyre",
  "indexmap 2.13.0",
  "parking_lot",

--- a/bin/rayls-replay/src/rewards.rs
+++ b/bin/rayls-replay/src/rewards.rs
@@ -6,7 +6,7 @@
 
 use parking_lot::Mutex;
 use rayls_infrastructure_types::{
-    rewards::{NoopRewardsBackend, RewardsBackend, RewardsCounter, RewardsError},
+    rewards::{HybridEpochTally, NoopRewardsBackend, RewardsBackend, RewardsCounter, RewardsError},
     Address, AuthorityIdentifier, Committee, Epoch,
 };
 use std::{collections::BTreeMap, sync::Arc};
@@ -58,6 +58,24 @@ impl RewardsBackend for SnapshotRewardsBackend {
         Ok(self.tallies.get(epoch))
     }
 
+    fn tally_hybrid(
+        &self,
+        epoch: Epoch,
+        _last_executed_round: u32,
+    ) -> Result<HybridEpochTally, RewardsError> {
+        // A `Withdrawal` (what a snapshot preserves) carries one `u32` per
+        // validator; a snapshot alone cannot recover per-validator
+        // `participation_rounds`. Fail loudly rather than silently
+        // reconstructing a wrong tally; archive-replay support for
+        // hybrid-reward epochs is a deferred follow-up (as is the hybrid
+        // activation itself). `Unsupported`, not `Database` - this is a
+        // permanent capability gap, not a retryable read failure.
+        Err(RewardsError::Unsupported(format!(
+            "hybrid-reward archive replay not implemented: snapshot epoch {epoch} cannot \
+             recover per-validator participation_rounds from Withdrawal.amount alone"
+        )))
+    }
+
     fn get_authority_address(&self, id: &AuthorityIdentifier) -> Option<Address> {
         self.committee.get_authority_address(id)
     }
@@ -99,6 +117,16 @@ mod tests {
 
         let backend = SnapshotRewardsBackend::new(store);
         assert_eq!(backend.tally(7, 0).unwrap(), expected);
+    }
+
+    #[test]
+    fn tally_hybrid_errors_loudly_instead_of_returning_wrong_data() {
+        let backend = SnapshotRewardsBackend::new(SnapshotTallyStore::default());
+        let err = backend.tally_hybrid(7, 0).expect_err("must not silently succeed");
+        assert!(
+            !err.is_transient(),
+            "this is a permanent capability gap, not a retryable DB error"
+        );
     }
 
     #[test]

--- a/crates/infrastructure/types/src/primary/mod.rs
+++ b/crates/infrastructure/types/src/primary/mod.rs
@@ -8,6 +8,7 @@ mod header;
 mod header_meta;
 mod info;
 mod output;
+mod participation_meta;
 mod reputation;
 mod vote;
 
@@ -18,6 +19,7 @@ pub use header::*;
 pub use header_meta::*;
 pub use info::*;
 pub use output::*;
+pub use participation_meta::*;
 pub use reputation::*;
 pub use vote::*;
 

--- a/crates/infrastructure/types/src/primary/participation_meta.rs
+++ b/crates/infrastructure/types/src/primary/participation_meta.rs
@@ -1,0 +1,183 @@
+//! Participation projection over a stored `ConsensusHeader`: which authorities
+//! contributed a certificate to the committed sub-dag, decoded without fully
+//! deserializing each certificate's payload, parents, or signature bytes.
+//!
+//! [`ConsensusHeaderMeta`] `skip`s the `sub_dag.certificates` vector entirely
+//! because it only needs the leader. This module reads the same bytes but
+//! projects out each certificate's `header.author` instead of skipping it —
+//! the participation signal for the hybrid reward tally
+//! (`rayls_middleware_rewards::ConsensusRewardsCounter::tally_hybrid`) is
+//! already on disk in every `ConsensusBlocks` entry, requiring no
+//! consensus/networking change.
+
+use crate::{
+    bcs_layout::{BcsCursor, BcsLayoutError},
+    AuthorityIdentifier, Certificate, Epoch, Round, B256,
+};
+
+/// Leader + participant projection of a stored `ConsensusHeader`.
+#[derive(Debug, Clone)]
+pub struct ConsensusHeaderParticipation {
+    /// Identifier of the leader that committed the sub-dag.
+    pub leader_author: AuthorityIdentifier,
+    /// Leader certificate's round number.
+    pub leader_round: Round,
+    /// Leader certificate's epoch.
+    pub leader_epoch: Epoch,
+    /// Authors of every certificate included in the committed sub-dag, in
+    /// on-disk order (may repeat an author across the flattened DAG history;
+    /// callers wanting a per-round participant set should dedupe).
+    pub participants: Vec<AuthorityIdentifier>,
+}
+
+impl ConsensusHeaderParticipation {
+    /// Decode the leader + participants projection from a BCS-encoded
+    /// `ConsensusHeader`.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, BcsLayoutError> {
+        let mut c = BcsCursor::new(bytes);
+        // parent_hash
+        c.skip::<B256>()?;
+        // sub_dag.certificates: Vec<Certificate>, author-projected per element.
+        let n = c.read_len()?;
+        let mut participants = Vec::with_capacity(n);
+        for _ in 0..n {
+            participants.push(read_certificate_author(&mut c)?);
+        }
+        // sub_dag.leader: read the first three header fields, stop early.
+        let leader_author = c.read::<AuthorityIdentifier>()?;
+        let leader_round = c.read::<Round>()?;
+        let leader_epoch = c.read::<Epoch>()?;
+        Ok(Self { leader_author, leader_round, leader_epoch, participants })
+    }
+}
+
+/// Project a single BCS-encoded `Certificate` down to its `header.author`,
+/// advancing the cursor exactly as far as `Certificate::skip` would.
+///
+/// Delegates to the ONE canonical [`Certificate::skip_with_header_span`] —
+/// pinned by the `bcs_layout` skip-consumes-exact tests and the
+/// `ConsensusHeaderChainMeta` digest round-trip tests — rather than
+/// re-listing the `Header`/`Certificate` fields here. A field added to
+/// either struct updates that canonical skip (and its pins) without any
+/// change to this decode; a hand-rolled copy would silently desync and
+/// corrupt the tally, which feeds both the state root (via `applyIncentives`)
+/// and `withdrawals_root`. The author is the first field of the header, so it
+/// sits at the start of the returned header span.
+fn read_certificate_author(c: &mut BcsCursor<'_>) -> Result<AuthorityIdentifier, BcsLayoutError> {
+    let header_span = Certificate::skip_with_header_span(c)?;
+    BcsCursor::new(header_span).read::<AuthorityIdentifier>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        CertificateDigest, CommittedSubDag, ConsensusHeader, HeaderBuilder, ReputationScores,
+        WorkerId,
+    };
+    use alloy::primitives::BlockHash as AlloyBlockHash;
+    use indexmap::IndexMap;
+    use std::collections::BTreeSet;
+
+    fn make_cert(
+        author: u8,
+        round: u32,
+        epoch: u32,
+        payload: Vec<(AlloyBlockHash, WorkerId)>,
+        parents: usize,
+    ) -> crate::Certificate {
+        let mut p = IndexMap::<AlloyBlockHash, WorkerId>::new();
+        for (d, w) in payload {
+            p.insert(d, w);
+        }
+        let mut parents_set = BTreeSet::<CertificateDigest>::new();
+        for i in 0..parents {
+            parents_set.insert(CertificateDigest::new([i as u8; 32]));
+        }
+        let header = HeaderBuilder::default()
+            .author(AuthorityIdentifier::dummy_for_test(author))
+            .round(round)
+            .epoch(epoch)
+            .created_at(0)
+            .payload(p)
+            .parents(parents_set)
+            .build();
+        let mut cert = crate::Certificate::default();
+        cert.update_header_for_test(header);
+        cert
+    }
+
+    fn make_header(leader: crate::Certificate, certs: Vec<crate::Certificate>) -> ConsensusHeader {
+        let sub_dag = CommittedSubDag::new(certs, leader, 0, ReputationScores::default(), None);
+        ConsensusHeader {
+            parent_hash: AlloyBlockHash::repeat_byte(0xAB),
+            sub_dag,
+            number: 100,
+            extra: AlloyBlockHash::ZERO,
+        }
+    }
+
+    #[test]
+    fn extracts_leader_and_participants() {
+        let leader = make_cert(0x77, 9, 3, vec![], 0);
+        let certs = vec![
+            make_cert(0x01, 8, 3, vec![(AlloyBlockHash::repeat_byte(2), 1)], 0),
+            make_cert(0x02, 8, 3, vec![(AlloyBlockHash::repeat_byte(3), 2)], 1),
+            make_cert(0x03, 8, 3, vec![], 4),
+        ];
+        let h = make_header(leader, certs);
+        let bytes = crate::encode(&h);
+
+        let m = ConsensusHeaderParticipation::from_bytes(&bytes).unwrap();
+        assert_eq!(m.leader_author, AuthorityIdentifier::dummy_for_test(0x77));
+        assert_eq!(m.leader_round, 9);
+        assert_eq!(m.leader_epoch, 3);
+        assert_eq!(
+            m.participants,
+            vec![
+                AuthorityIdentifier::dummy_for_test(0x01),
+                AuthorityIdentifier::dummy_for_test(0x02),
+                AuthorityIdentifier::dummy_for_test(0x03),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_sub_dag_has_no_participants() {
+        let leader = make_cert(0xEE, 14, 1, vec![(AlloyBlockHash::repeat_byte(1), 0)], 2);
+        let h = make_header(leader, vec![]);
+        let bytes = crate::encode(&h);
+
+        let m = ConsensusHeaderParticipation::from_bytes(&bytes).unwrap();
+        assert_eq!(m.leader_author, AuthorityIdentifier::dummy_for_test(0xEE));
+        assert!(m.participants.is_empty());
+    }
+
+    /// Same fixture as `ConsensusHeaderMeta`'s test of the same name: proves
+    /// the two projections agree on the leader fields when reading identical
+    /// bytes, one skipping the certs vector and one decoding it.
+    #[test]
+    fn agrees_with_leader_only_projection() {
+        let leader = make_cert(0xEE, 14, 1, vec![(AlloyBlockHash::repeat_byte(1), 0)], 2);
+        let certs = vec![
+            make_cert(0x01, 13, 1, vec![(AlloyBlockHash::repeat_byte(2), 1)], 0),
+            make_cert(0x02, 13, 1, vec![(AlloyBlockHash::repeat_byte(3), 2)], 1),
+        ];
+        let h = make_header(leader, certs);
+        let bytes = crate::encode(&h);
+
+        let leader_only = crate::ConsensusHeaderMeta::from_bytes(&bytes).unwrap();
+        let with_participants = ConsensusHeaderParticipation::from_bytes(&bytes).unwrap();
+
+        assert_eq!(leader_only.leader_author, with_participants.leader_author);
+        assert_eq!(leader_only.leader_round, with_participants.leader_round);
+        assert_eq!(leader_only.leader_epoch, with_participants.leader_epoch);
+        assert_eq!(
+            with_participants.participants,
+            vec![
+                AuthorityIdentifier::dummy_for_test(0x01),
+                AuthorityIdentifier::dummy_for_test(0x02),
+            ]
+        );
+    }
+}

--- a/crates/infrastructure/types/src/rewards.rs
+++ b/crates/infrastructure/types/src/rewards.rs
@@ -173,9 +173,9 @@ impl RewardsBackend for NoopRewardsBackend {
         let mut guard = self.leader_counts.lock();
         *guard = leader_counts;
     }
-    fn inc_leader_count(&self, _leader: &AuthorityIdentifier) {
+    fn inc_leader_count(&self, leader: &AuthorityIdentifier) {
         let mut guard = self.leader_counts.lock();
-        *guard.entry(_leader.clone()).or_insert(0) += 1;
+        *guard.entry(leader.clone()).or_insert(0) += 1;
     }
 
     fn clear(&self) {

--- a/crates/infrastructure/types/src/rewards.rs
+++ b/crates/infrastructure/types/src/rewards.rs
@@ -5,6 +5,28 @@ use alloy::rpc::types::{Withdrawal, Withdrawals};
 use parking_lot::{Mutex, RwLock};
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
+/// Per-validator round counts feeding the hybrid (participation + anchor) reward tally.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ValidatorRoundTally {
+    /// Distinct committed rounds whose sub-dag included this validator's certificate.
+    pub participation_rounds: u32,
+    /// Committed rounds this validator led ("Anchor Commit Share" component;
+    /// identical signal to what [`RewardsBackend::tally`] counts today).
+    pub leader_rounds: u32,
+}
+
+/// Per-epoch hybrid reward tally: every validator's round counts plus the
+/// epoch-wide committed-round count (the anchor-share/floor denominator).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HybridEpochTally {
+    /// Per-validator counts, keyed by execution address.
+    pub per_address: BTreeMap<Address, ValidatorRoundTally>,
+    /// Total committed rounds walked for the epoch (same denominator for
+    /// every validator; exactly one leader per round, so `leader_rounds`
+    /// summed across `per_address` equals this).
+    pub total_rounds: u32,
+}
+
 /// Compute per-address leader-execution counts for closing-epoch withdrawals.
 pub trait RewardsBackend: Debug + Send + Sync + 'static {
     /// Tally leader counts for `epoch` over rounds `1..=last_executed_round`,
@@ -17,6 +39,17 @@ pub trait RewardsBackend: Debug + Send + Sync + 'static {
         epoch: Epoch,
         last_executed_round: u32,
     ) -> Result<BTreeMap<Address, u32>, RewardsError>;
+
+    /// Tally participation + leader rounds for `epoch` over rounds
+    /// `1..=last_executed_round`, in one walk. This is the input for the hybrid
+    /// reward blend; `tally` above remains the leader-only tally and is untouched
+    /// by this method's existence. (Wiring this into block execution — deciding
+    /// when a block uses the hybrid vs. leader-only path — is a separate change.)
+    fn tally_hybrid(
+        &self,
+        epoch: Epoch,
+        last_executed_round: u32,
+    ) -> Result<HybridEpochTally, RewardsError>;
 
     /// Resolve an authority identifier to its execution address using the
     /// current committee. Used for empty-block beneficiary assignment.
@@ -46,6 +79,14 @@ pub enum RewardsError {
         /// Epoch the caller requested.
         epoch: Epoch,
     },
+
+    /// The requested tally is a known, permanent capability gap (not a
+    /// transient failure) - e.g. `SnapshotRewardsBackend::tally_hybrid` can't
+    /// recover per-validator participation rounds from a plain withdrawals
+    /// snapshot. Retrying will never succeed; distinct from [`Self::Database`]
+    /// specifically so callers don't loop retrying something that can't work.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
 }
 
 impl RewardsError {
@@ -90,6 +131,14 @@ impl RewardsBackend for NoopRewardsBackend {
         _last_executed_round: u32,
     ) -> Result<BTreeMap<Address, u32>, RewardsError> {
         Ok(BTreeMap::new())
+    }
+
+    fn tally_hybrid(
+        &self,
+        _epoch: Epoch,
+        _last_executed_round: u32,
+    ) -> Result<HybridEpochTally, RewardsError> {
+        Ok(HybridEpochTally::default())
     }
 
     fn get_authority_address(&self, id: &AuthorityIdentifier) -> Option<Address> {
@@ -161,6 +210,15 @@ impl RewardsCounter {
         last_executed_round: u32,
     ) -> Result<BTreeMap<Address, u32>, RewardsError> {
         self.0.tally(epoch, last_executed_round)
+    }
+
+    /// Compute the close-epoch hybrid (participation + anchor) tally.
+    pub fn tally_hybrid(
+        &self,
+        epoch: Epoch,
+        last_executed_round: u32,
+    ) -> Result<HybridEpochTally, RewardsError> {
+        self.0.tally_hybrid(epoch, last_executed_round)
     }
 
     /// Resolve an authority identifier to its execution address.

--- a/crates/middleware/rewards/Cargo.toml
+++ b/crates/middleware/rewards/Cargo.toml
@@ -16,6 +16,7 @@ rayls-infrastructure-types = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+alloy = { workspace = true }
 eyre = { workspace = true }
 indexmap = { workspace = true }
 rand = { workspace = true }

--- a/crates/middleware/rewards/src/lib.rs
+++ b/crates/middleware/rewards/src/lib.rs
@@ -9,11 +9,14 @@
 use parking_lot::{Mutex, RwLock};
 use rayls_infrastructure_storage::tables::ConsensusBlocks;
 use rayls_infrastructure_types::{
-    rewards::{RewardsBackend, RewardsError},
-    Address, AuthorityIdentifier, Committee, ConsensusHeaderMeta, Database, DbTx, Epoch,
-    WALK_PROGRESS_LOG_EVERY,
+    rewards::{HybridEpochTally, RewardsBackend, RewardsError, ValidatorRoundTally},
+    Address, AuthorityIdentifier, Committee, ConsensusHeaderMeta, ConsensusHeaderParticipation,
+    Database, DbTx, Epoch, WALK_PROGRESS_LOG_EVERY,
 };
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 use tracing::{debug, info, warn};
 
 pub use rayls_infrastructure_types::rewards::{NoopRewardsBackend, RewardsCounter};
@@ -155,6 +158,95 @@ impl<DB: Database> RewardsBackend for ConsensusRewardsCounter<DB> {
         Ok(counts)
     }
 
+    fn tally_hybrid(
+        &self,
+        epoch: Epoch,
+        last_executed_round: u32,
+    ) -> Result<HybridEpochTally, RewardsError> {
+        let committee = self
+            .inner
+            .committee
+            .read()
+            .as_ref()
+            .cloned()
+            .ok_or(RewardsError::MissingCommittee { epoch })?;
+
+        self.inner
+            .consensus_db
+            .with_read_txn(|txn| {
+                // See the identical comment in `tally()`: this walk is bounded by the
+                // epoch length and reads only immutable historical headers, so opting
+                // out of the 30s read-txn safety window is acceptable here too.
+                txn.disable_long_read_safety();
+                info!(target: "rewards", ?epoch, "tally_hybrid: read txn opened");
+
+                let mut per_address: BTreeMap<Address, ValidatorRoundTally> = BTreeMap::new();
+                let mut total_rounds: u32 = 0;
+                let mut walked: u64 = 0;
+                for (_key_bytes, value_bytes) in txn.reverse_raw_iter::<ConsensusBlocks>() {
+                    walked += 1;
+                    let meta = ConsensusHeaderParticipation::from_bytes(&value_bytes)?;
+                    let header_epoch = meta.leader_epoch;
+                    let header_round = meta.leader_round;
+
+                    if walked == 1 || walked.is_multiple_of(WALK_PROGRESS_LOG_EVERY) {
+                        info!(
+                            target: "rewards",
+                            ?epoch,
+                            walked,
+                            cur_epoch = header_epoch,
+                            cur_round = header_round,
+                            "tally_hybrid: walk progress",
+                        );
+                    }
+
+                    // subscriber raced past the boundary - future epoch, not ours.
+                    if header_epoch > epoch {
+                        continue;
+                    }
+                    // crossed below current epoch - reverse-iter is done.
+                    if header_epoch < epoch {
+                        break;
+                    }
+                    // round not yet executed by the engine.
+                    if header_round > last_executed_round {
+                        continue;
+                    }
+                    // genesis has no leader / participants.
+                    if header_round == 0 {
+                        continue;
+                    }
+
+                    total_rounds += 1;
+
+                    if let Some(authority) = committee.authority(&meta.leader_author) {
+                        per_address
+                            .entry(authority.execution_address())
+                            .or_default()
+                            .leader_rounds += 1;
+                    }
+
+                    // Dedup on the resolved execution address, not the pre-resolution
+                    // authority id: a round credits each address at most once, so two
+                    // distinct authority ids that resolve to the same execution address
+                    // (invariant-precluded, but defended for symmetry with the legacy
+                    // `get_address_counts` merge) can't double-count within one sub-dag.
+                    let mut seen = BTreeSet::new();
+                    for author in &meta.participants {
+                        if let Some(authority) = committee.authority(author) {
+                            let address = authority.execution_address();
+                            if seen.insert(address) {
+                                per_address.entry(address).or_default().participation_rounds += 1;
+                            }
+                        }
+                    }
+                }
+                info!(target: "rewards", ?epoch, walked, total_rounds, "tally_hybrid: walk done");
+                Ok(HybridEpochTally { per_address, total_rounds })
+            })
+            .map_err(RewardsError::Database)
+    }
+
     fn get_authority_address(&self, id: &AuthorityIdentifier) -> Option<Address> {
         self.inner
             .committee
@@ -212,24 +304,32 @@ pub fn from_db<DB: Database>(db: DB) -> RewardsCounter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::primitives::BlockHash;
+    use indexmap::IndexMap;
     use rand::{rngs::StdRng, SeedableRng};
-    use rayls_infrastructure_storage::{cold_archiver_for, open_db, SealOutcome};
+    use rayls_infrastructure_storage::{
+        cold_archiver_for, mem_db::MemDatabase, open_db, SealOutcome,
+    };
     use rayls_infrastructure_types::{
-        BlsKeypair, Certificate, CommittedSubDag, CommitteeBuilder, ConsensusHeader, DbTxMut,
-        Header, ReputationScores, Round,
+        BlsKeypair, Certificate, CertificateDigest, CommittedSubDag, CommitteeBuilder,
+        ConsensusHeader, DbTxMut, Header, HeaderBuilder, ReputationScores, Round, WorkerId,
     };
     use tempfile::TempDir;
 
-    /// Builds a committee of `n` authorities with distinct execution addresses.
-    fn committee_with(n: usize) -> (Committee, Vec<AuthorityIdentifier>) {
-        let mut rng = StdRng::seed_from_u64(7);
+    /// Build an `n`-authority committee with real BLS-derived identifiers
+    /// (`Committee::authority` looks up by `Authority::id()`, a hash of the
+    /// protocol key - `dummy_for_test` ids never resolve). Returns the
+    /// committee plus each authority's id and execution address, in the order
+    /// added.
+    fn test_committee(n: u8) -> (Committee, Vec<(AuthorityIdentifier, Address)>) {
+        let mut rng = StdRng::seed_from_u64(0x633);
         let mut builder = CommitteeBuilder::new(0);
-        let mut ids = Vec::with_capacity(n);
+        let mut ids = Vec::with_capacity(n as usize);
         for i in 0..n {
             let keypair = BlsKeypair::generate(&mut rng);
-            let key = *keypair.public();
-            builder.add_authority(key, 1, Address::repeat_byte(i as u8 + 1));
-            ids.push(AuthorityIdentifier::from(key));
+            let address = Address::with_last_byte(i + 1);
+            builder.add_authority(*keypair.public(), 1, address);
+            ids.push((AuthorityIdentifier::from(*keypair.public()), address));
         }
         (builder.build(), ids)
     }
@@ -239,10 +339,10 @@ mod tests {
         number: u64,
         epoch: Epoch,
         round: Round,
-        author: AuthorityIdentifier,
+        author: &AuthorityIdentifier,
     ) -> ConsensusHeader {
         let mut leader = Certificate::default();
-        leader.header = Header { author, round, epoch, ..Default::default() };
+        leader.header = Header { author: author.clone(), round, epoch, ..Default::default() };
         let sub_dag = CommittedSubDag::new(vec![], leader, 0, ReputationScores::default(), None);
         ConsensusHeader { sub_dag, number, ..Default::default() }
     }
@@ -258,21 +358,21 @@ mod tests {
     /// empties); the cutoff-policy red/green tests live in the storage crate's cold tests.
     #[test]
     fn tally_survives_cold_archival_at_anchor_floor() {
-        let (committee, ids) = committee_with(3);
+        let (committee, ids) = test_committee(3);
         let tmp = TempDir::new().unwrap();
         let db = open_db(tmp.path().join("consensus"));
 
         // Epoch 0 (sealable), the closing epoch 1, and a first epoch-2 row modeling a subscriber
         // that raced past the boundary before the epoch-1 tally ran.
         let blocks = [
-            block(0, 0, 0, ids[0].clone()), // genesis round 0: never counted
-            block(1, 0, 1, ids[1].clone()),
-            block(2, 0, 2, ids[2].clone()),
-            block(3, 1, 3, ids[0].clone()),
-            block(4, 1, 4, ids[1].clone()),
-            block(5, 1, 5, ids[2].clone()),
-            block(6, 1, 6, ids[0].clone()),
-            block(7, 2, 7, ids[1].clone()),
+            block(0, 0, 0, &ids[0].0), // genesis round 0: never counted
+            block(1, 0, 1, &ids[1].0),
+            block(2, 0, 2, &ids[2].0),
+            block(3, 1, 3, &ids[0].0),
+            block(4, 1, 4, &ids[1].0),
+            block(5, 1, 5, &ids[2].0),
+            block(6, 1, 6, &ids[0].0),
+            block(7, 2, 7, &ids[1].0),
         ];
         db.with_write_txn(|txn| {
             for b in &blocks {
@@ -297,5 +397,134 @@ mod tests {
 
         let after = counter.tally(1, 6).expect("post-archival tally");
         assert_eq!(after, before, "the closing epoch's tally must survive archival at the floor");
+    }
+
+    fn make_cert(author: &AuthorityIdentifier, round: u32, epoch: u32) -> Certificate {
+        let header = HeaderBuilder::default()
+            .author(author.clone())
+            .round(round)
+            .epoch(epoch)
+            .created_at(0)
+            .payload(IndexMap::<BlockHash, WorkerId>::new())
+            .parents(std::collections::BTreeSet::<CertificateDigest>::new())
+            .build();
+        let mut cert = Certificate::default();
+        cert.update_header_for_test(header);
+        cert
+    }
+
+    /// Encode a `ConsensusHeader` for one committed round: `leader_author`
+    /// leads at `leader_round`, and every address in `participant_authors`
+    /// (which may include the leader) has a certificate in the sub-dag.
+    fn make_bytes(
+        leader_author: &AuthorityIdentifier,
+        leader_round: u32,
+        epoch: u32,
+        participant_authors: &[&AuthorityIdentifier],
+    ) -> Vec<u8> {
+        let leader = make_cert(leader_author, leader_round, epoch);
+        let certs = participant_authors
+            .iter()
+            .map(|a| make_cert(a, leader_round.saturating_sub(1), epoch))
+            .collect();
+        let sub_dag = CommittedSubDag::new(certs, leader, 0, ReputationScores::default(), None);
+        let header = ConsensusHeader {
+            parent_hash: BlockHash::repeat_byte(0xAB),
+            sub_dag,
+            number: leader_round as u64,
+            extra: BlockHash::ZERO,
+        };
+        rayls_infrastructure_types::encode(&header)
+    }
+
+    /// The scenario from axyl-private#633: a US validator (`ids[0]`) leads
+    /// every round and is the only one credited under the leader-only tally
+    /// (`tally()`). A latency-distant validator (`ids[1]`,
+    /// "Tokyo") never leads but its certificate is included in every
+    /// committed sub-dag. `tally_hybrid` should credit all three roughly
+    /// equally on participation, while crediting only `ids[0]` on
+    /// leader/anchor rounds - in one single walk, not two.
+    #[test]
+    fn tally_hybrid_credits_participation_and_leader_rounds_in_one_walk() {
+        let (committee, ids) = test_committee(3);
+        let (leader_id, leader_addr) = &ids[0];
+        let (_, tokyo_addr) = &ids[1];
+        let (_, third_addr) = &ids[2];
+        let all_ids: Vec<&AuthorityIdentifier> = ids.iter().map(|(id, _)| id).collect();
+
+        let db = MemDatabase::default();
+        for (i, round) in [2u32, 4, 6, 8].into_iter().enumerate() {
+            let bytes = make_bytes(leader_id, round, 0, &all_ids);
+            let header: ConsensusHeader = rayls_infrastructure_types::decode(&bytes);
+            db.insert::<ConsensusBlocks>(&(i as u64), &header).unwrap();
+        }
+
+        let counter = ConsensusRewardsCounter::new(db);
+        counter.set_committee(committee);
+        let tally = counter.tally_hybrid(0, u32::MAX).unwrap();
+
+        assert_eq!(tally.total_rounds, 4);
+        // Leader-only tally() would show leader_addr=4, tokyo_addr=0, third_addr=0.
+        // Both other addresses still get a `per_address` entry (created by the
+        // participation side of the walk), just with leader_rounds at its
+        // `ValidatorRoundTally::default()` of 0 - not absent from the map.
+        assert_eq!(tally.per_address[leader_addr].leader_rounds, 4);
+        assert_eq!(tally.per_address[tokyo_addr].leader_rounds, 0);
+        assert_eq!(tally.per_address[third_addr].leader_rounds, 0);
+        // tally_hybrid credits all three on participation, unlike tally().
+        for (_, address) in &ids {
+            assert_eq!(tally.per_address[address].participation_rounds, 4);
+        }
+    }
+
+    #[test]
+    fn tally_hybrid_dedupes_repeated_author_within_one_subdag() {
+        // order_dag can flatten multiple underlying DAG rounds into one
+        // committed sub-dag, so the same author's cert can appear twice.
+        let (committee, ids) = test_committee(2);
+        let (id_a, _) = &ids[0];
+        let (id_b, addr_b) = &ids[1];
+        let leader = make_cert(id_a, 4, 0);
+        let certs = vec![make_cert(id_b, 2, 0), make_cert(id_b, 3, 0)];
+        let sub_dag = CommittedSubDag::new(certs, leader, 0, ReputationScores::default(), None);
+        let header = ConsensusHeader {
+            parent_hash: BlockHash::repeat_byte(0xAB),
+            sub_dag,
+            number: 4,
+            extra: BlockHash::ZERO,
+        };
+
+        let db = MemDatabase::default();
+        db.insert::<ConsensusBlocks>(&0u64, &header).unwrap();
+
+        let counter = ConsensusRewardsCounter::new(db);
+        counter.set_committee(committee);
+        let tally = counter.tally_hybrid(0, u32::MAX).unwrap();
+
+        assert_eq!(tally.per_address[addr_b].participation_rounds, 1);
+    }
+
+    #[test]
+    fn tally_hybrid_excludes_genesis_and_out_of_range_rounds() {
+        // CommitteeBuilder requires size > 1; only id_a's rounds are exercised.
+        let (committee, ids) = test_committee(2);
+        let (id_a, _) = &ids[0];
+
+        let db = MemDatabase::default();
+        // genesis: leader_round == 0
+        let genesis_bytes = make_bytes(id_a, 0, 0, &[id_a]);
+        let genesis_header: ConsensusHeader = rayls_infrastructure_types::decode(&genesis_bytes);
+        db.insert::<ConsensusBlocks>(&0u64, &genesis_header).unwrap();
+        // not yet executed (round 100 > last_executed_round 10)
+        let future_bytes = make_bytes(id_a, 100, 0, &[id_a]);
+        let future_header: ConsensusHeader = rayls_infrastructure_types::decode(&future_bytes);
+        db.insert::<ConsensusBlocks>(&1u64, &future_header).unwrap();
+
+        let counter = ConsensusRewardsCounter::new(db);
+        counter.set_committee(committee);
+        let tally = counter.tally_hybrid(0, 10).unwrap();
+
+        assert_eq!(tally.total_rounds, 0);
+        assert!(tally.per_address.is_empty());
     }
 }

--- a/crates/middleware/rewards/src/lib.rs
+++ b/crates/middleware/rewards/src/lib.rs
@@ -183,6 +183,9 @@ impl<DB: Database> RewardsBackend for ConsensusRewardsCounter<DB> {
                 let mut per_address: BTreeMap<Address, ValidatorRoundTally> = BTreeMap::new();
                 let mut total_rounds: u32 = 0;
                 let mut walked: u64 = 0;
+                // Reused across rounds (cleared each round) to avoid a per-round heap
+                // allocation in this once-per-epoch-close walk.
+                let mut seen: BTreeSet<Address> = BTreeSet::new();
                 for (_key_bytes, value_bytes) in txn.reverse_raw_iter::<ConsensusBlocks>() {
                     walked += 1;
                     let meta = ConsensusHeaderParticipation::from_bytes(&value_bytes)?;
@@ -217,13 +220,11 @@ impl<DB: Database> RewardsBackend for ConsensusRewardsCounter<DB> {
                         continue;
                     }
 
-                    total_rounds += 1;
+                    total_rounds = total_rounds.saturating_add(1);
 
                     if let Some(authority) = committee.authority(&meta.leader_author) {
-                        per_address
-                            .entry(authority.execution_address())
-                            .or_default()
-                            .leader_rounds += 1;
+                        let tally = per_address.entry(authority.execution_address()).or_default();
+                        tally.leader_rounds = tally.leader_rounds.saturating_add(1);
                     }
 
                     // Dedup on the resolved execution address, not the pre-resolution
@@ -231,12 +232,14 @@ impl<DB: Database> RewardsBackend for ConsensusRewardsCounter<DB> {
                     // distinct authority ids that resolve to the same execution address
                     // (invariant-precluded, but defended for symmetry with the legacy
                     // `get_address_counts` merge) can't double-count within one sub-dag.
-                    let mut seen = BTreeSet::new();
+                    seen.clear();
                     for author in &meta.participants {
                         if let Some(authority) = committee.authority(author) {
                             let address = authority.execution_address();
                             if seen.insert(address) {
-                                per_address.entry(address).or_default().participation_rounds += 1;
+                                let tally = per_address.entry(address).or_default();
+                                tally.participation_rounds =
+                                    tally.participation_rounds.saturating_add(1);
                             }
                         }
                     }

--- a/docs/reward-distribution/README.md
+++ b/docs/reward-distribution/README.md
@@ -21,8 +21,9 @@ Reward distribution happens in two stages that run on a different schedule:
 │                        EPOCH END (Automatic)                        │
 │                                                                     │
 │  Rust Client (block.rs::finish)                                     │
-│    ├─ applyIncentives(RewardInfo[])  → ConsensusRegistry            │
-│    │    Records stake × headerCount per validator as performance    │
+│    ├─ applyIncentives(RewardInfo[], totalRounds) → ConsensusRegistry│
+│    │    Records a hybrid blend (participation 80% + Anchor Commit   │
+│    │    Share 10% + stake tier 10%) per validator as performance     │
 │    │    weights for the completed epoch                             │
 │    │                                                                │
 │    └─ concludeEpoch(newCommittee[])  → ConsensusRegistry            │
@@ -44,7 +45,7 @@ Reward distribution happens in two stages that run on a different schedule:
 │                                                                     │
 │  Step 2: RewardDistributor.distributeRewards()                      │
 │    ├─ Reads performance weights from ConsensusRegistry              │
-│    ├─ Distributes RLS proportionally: stake × headerCount           │
+│    ├─ Distributes RLS proportionally to the recorded weights        │
 │    └─ Splits between validator own stake and delegation pool        │
 │                                                                     │
 │  Step 3: Validators call claimRewards() (permissionless)            │
@@ -80,9 +81,23 @@ All values are in basis points (1 bps = 0.01%). Total must equal 10,000 (100%).
 
 At each epoch boundary, the Rust execution layer makes two system calls:
 
-**`applyIncentives(RewardInfo[])`** — Records which validators produced blocks and how many:
-- Input: array of `(validatorAddress, consensusHeaderCount)` pairs
-- Computes `weight = stakeAmount × consensusHeaderCount` per validator
+**`applyIncentives(RewardInfo[], totalRounds)`** — Records each validator's hybrid performance weight:
+- Input: array of `(validatorAddress, participationRounds, anchorRounds)` triples, plus the
+  epoch-wide `totalRounds` committed
+- Computes a blended weight per validator: 80% normalized participation share (rounds whose
+  committed sub-dag included the validator's certificate), 10% Anchor Commit Share (rounds the
+  validator led — the sole signal in the pre-hybrid model), 10% stake tier (own required stake +
+  delegated stake, tiered above a configurable minimum)
+- A validator that contributed no certificate this epoch (`participationRounds == 0`) earns
+  nothing from any component; validators above zero but below an optional participation floor
+  (`participationFloorBps`, disabled by default) are also excluded
+- Stores in `_performanceWeights` for RewardDistributor to consume
+- Called with `SYSTEM_ADDRESS` as msg.sender
+
+> **Activation is out of scope for this change.** The blend above is implemented and tested, but
+> when/how it activates on a network (fork schedule, and how the contract carrying it is
+> deployed or upgraded) is a separate follow-up — see `src/consensus/design.md` ("Rollout is
+> intentionally out of scope").
 - Stores in `_performanceWeights` for RewardDistributor to consume
 - Called with `SYSTEM_ADDRESS` as msg.sender
 

--- a/rayls-contracts/src/consensus/ConsensusRegistry.sol
+++ b/rayls-contracts/src/consensus/ConsensusRegistry.sol
@@ -155,7 +155,7 @@ contract ConsensusRegistry is
     function applyIncentives(
         RewardInfo[] calldata rewardInfos,
         uint256 totalRounds
-    ) public override onlySystemCall {
+    ) external override onlySystemCall {
         // clear previous epoch's performance weights
         delete _performanceWeights;
 

--- a/rayls-contracts/src/consensus/ConsensusRegistry.sol
+++ b/rayls-contracts/src/consensus/ConsensusRegistry.sol
@@ -43,6 +43,20 @@ contract ConsensusRegistry is
     uint256 private constant ANCHOR_BPS = 1_000;
     uint256 private constant STAKE_BPS = 1_000;
 
+    /// @dev Fixed-point scale applied to every weight component before the
+    /// truncating integer division that normalizes it. Each component is at most
+    /// its `*_BPS` share (<= `MAX_BPS`), so with a large committee splitting that
+    /// share, a per-validator numerator like `PARTICIPATION_BPS * rounds` can round
+    /// down to 0 (e.g. one round out of a >8000-round submitted sum), silently
+    /// dropping a validator that did contribute. Scaling the numerator by
+    /// `WEIGHT_PRECISION` preserves sub-bps resolution; because RewardDistributor
+    /// consumes weights purely as ratios (`weight / totalWeight`), scaling every
+    /// weight by the same constant leaves the distribution unchanged. `1e18` keeps
+    /// the largest possible weight (`MAX_BPS * WEIGHT_PRECISION`, times per-epoch
+    /// round counts) far inside uint256 - and well below the pre-hybrid
+    /// `stake * headerCount` weights this contract already stored without overflow.
+    uint256 private constant WEIGHT_PRECISION = 1e18;
+
     /// @dev Stake-tier bonus: own required stake (`getBalanceBreakdown` position 1,
     /// not position 0 which is contaminated by accrued rewards) plus delegated
     /// stake, tiered every `STAKE_TIER_STEP` above `STAKE_TIER_MIN`, capped at
@@ -134,7 +148,10 @@ contract ConsensusRegistry is
     /// anchor/leader-round share of `totalRounds` (a true committee-wide share,
     /// since exactly one leader commits per round), and `STAKE_BPS` by stake-tier
     /// share. Mirrors `RewardDistributor.sol`'s own "sum totals, then proportional
-    /// split" idiom one level deeper.
+    /// split" idiom one level deeper. Each share is scaled by `WEIGHT_PRECISION`
+    /// before its truncating division so a contributing validator's weight can't
+    /// round to 0 in a large committee (ratios, and thus the distribution, are
+    /// unchanged - see `WEIGHT_PRECISION`).
     function applyIncentives(
         RewardInfo[] calldata rewardInfos,
         uint256 totalRounds
@@ -190,14 +207,22 @@ contract ConsensusRegistry is
             if (stakeWeight[i] == 0) continue;
             RewardInfo calldata reward = rewardInfos[i];
 
+            // Numerators are scaled by WEIGHT_PRECISION so an eligible validator's
+            // share can't truncate to 0 under a large committee (see the constant's
+            // doc). Distribution is unaffected - RewardDistributor uses weight/totalWeight.
             uint256 weight;
             if (totalParticipationRounds > 0) {
-                weight += (PARTICIPATION_BPS * reward.participationRounds) / totalParticipationRounds;
+                weight +=
+                    (PARTICIPATION_BPS * WEIGHT_PRECISION * reward.participationRounds) /
+                    totalParticipationRounds;
             }
             if (totalRounds > 0) {
-                weight += (ANCHOR_BPS * reward.anchorRounds) / totalRounds;
+                weight += (ANCHOR_BPS * WEIGHT_PRECISION * reward.anchorRounds) / totalRounds;
             }
-            weight += (STAKE_BPS * stakeWeight[i]) / totalStakeWeight;
+            weight += (STAKE_BPS * WEIGHT_PRECISION * stakeWeight[i]) / totalStakeWeight;
+            // Defensive only: with WEIGHT_PRECISION scaling and stakeWeight[i] > 0
+            // (guaranteed for every Pass-1-eligible validator), the stake term alone is
+            // already > 0, so an eligible validator can no longer be silently dropped here.
             if (weight == 0) continue;
 
             tmpValidators[validatorCount] = reward.validatorAddress;
@@ -249,6 +274,15 @@ contract ConsensusRegistry is
 
     /// @notice Governance sets the minimum participation share (bps) required for
     /// eligibility; `0` disables the floor.
+    /// @dev The floor is a *minimum-attendance* gate measured against `totalRounds`
+    /// (committed rounds): a validator is excluded when
+    /// `participationRounds * MAX_BPS / totalRounds < newFloorBps`. This denominator
+    /// is deliberately different from the one used to size the participation *weight*
+    /// (`totalParticipationRounds`, the committee-wide submitted sum). So passing the
+    /// floor does not imply a participation weight of at least `newFloorBps` bps: the
+    /// floor answers "was this validator present enough to be eligible?", the weight
+    /// answers "how large is its slice of the committee's total contribution?". The
+    /// two are distinct by design and must not be read as the same threshold.
     /// @param newFloorBps New floor, in bps of `totalRounds`. Must be `<= MAX_BPS`.
     function setParticipationFloorBps(uint256 newFloorBps) external onlyOwner {
         if (newFloorBps > MAX_BPS) revert InvalidParticipationFloor(newFloorBps);

--- a/rayls-contracts/src/consensus/ConsensusRegistry.sol
+++ b/rayls-contracts/src/consensus/ConsensusRegistry.sol
@@ -32,6 +32,28 @@ contract ConsensusRegistry is
     using BlsG1 for bytes;
     using SafeERC20 for IERC20;
 
+    /// @dev Basis-points denominator (1 bps = 0.01%), mirrors the `MAX_BPS` idiom
+    /// used elsewhere in this contract family (e.g. `FeeAggregator.MAX_BPS`)
+    uint256 private constant MAX_BPS = 10_000;
+
+    /// @dev Hybrid weight split between participation, anchor (leader), and stake -
+    /// must sum to `MAX_BPS`. Fixed for this deployment; retuning requires a new
+    /// hardfork-gated bytecode swap, same as any other change to this contract.
+    uint256 private constant PARTICIPATION_BPS = 8_000;
+    uint256 private constant ANCHOR_BPS = 1_000;
+    uint256 private constant STAKE_BPS = 1_000;
+
+    /// @dev Stake-tier bonus: own required stake (`getBalanceBreakdown` position 1,
+    /// not position 0 which is contaminated by accrued rewards) plus delegated
+    /// stake, tiered every `STAKE_TIER_STEP` above `STAKE_TIER_MIN`, capped at
+    /// `STAKE_TIER_MAX_TIERS` tiers. With the current 5M-RLS minimum this is a 5M
+    /// baseline (everyone) plus up to 25M delegated (5 tiers), capping combined
+    /// stake consideration at 30M.
+    uint256 private constant STAKE_TIER_MIN = 5_000_000e18;
+    uint256 private constant STAKE_TIER_STEP = 5_000_000e18;
+    uint256 private constant STAKE_TIER_MAX_TIERS = 5;
+    uint256 private constant STAKE_TIER_BONUS_BPS = 200;
+
     uint32 internal currentEpoch;
     uint8 internal epochPointer;
     EpochInfo[4] public epochInfo;
@@ -47,6 +69,17 @@ contract ConsensusRegistry is
 
     /// @dev Performance weights recorded by applyIncentives for fee-based reward distribution
     PerformanceWeights internal _performanceWeights;
+
+    /// @notice Minimum participation share (in bps of `totalRounds`) a validator must
+    /// meet to be eligible for any reward this epoch; `0` disables the floor.
+    /// @dev Governance-settable without a new hardfork, unlike the reward-split
+    /// constants above - starts disabled pending real post-activation participation
+    /// data to tune it. MUST stay at the end of storage (appended after the prior
+    /// last var `_performanceWeights`): the `HybridRewards` hardfork installs this
+    /// contract's bytecode over an EXISTING `ConsensusRegistry`'s storage via a
+    /// bytecode swap, so every pre-existing slot must keep its offset and new state
+    /// may only be appended, never inserted.
+    uint256 public participationFloorBps;
 
     /// @dev Signals a validator's pending status until activation/exit to correctly apply incentives
     uint32 internal constant PENDING_EPOCH = type(uint32).max;
@@ -95,29 +128,77 @@ contract ConsensusRegistry is
     }
 
     /// @inheritdoc IConsensusRegistry
+    /// @dev Blends three normalized per-validator shares into one weight:
+    /// `PARTICIPATION_BPS` of the pool by participation-round share (of the
+    /// *submitted* total, not `totalRounds` - see note below), `ANCHOR_BPS` by
+    /// anchor/leader-round share of `totalRounds` (a true committee-wide share,
+    /// since exactly one leader commits per round), and `STAKE_BPS` by stake-tier
+    /// share. Mirrors `RewardDistributor.sol`'s own "sum totals, then proportional
+    /// split" idiom one level deeper.
     function applyIncentives(
-        RewardInfo[] calldata rewardInfos
+        RewardInfo[] calldata rewardInfos,
+        uint256 totalRounds
     ) public override onlySystemCall {
         // clear previous epoch's performance weights
         delete _performanceWeights;
 
-        // compute performance weights: stake × consensusHeaderCount per validator
+        uint256 n = rewardInfos.length;
+        // `stakeWeight[i] == 0` doubles as "ineligible" - `_stakeTierWeightOf`
+        // never returns 0 for an eligible validator, since it floors at `MAX_BPS`.
+        uint256[] memory stakeWeight = new uint256[](n);
+        uint256 totalParticipationRounds;
+        uint256 totalStakeWeight;
+        uint256 eligibleCount;
+
+        // Pass 1: eligibility (absent / retired / below the participation floor) + totals.
+        for (uint256 i; i < n; ++i) {
+            RewardInfo calldata reward = rewardInfos[i];
+            if (isRetired(reward.validatorAddress)) continue;
+            // Absent -> 0: a validator that contributed no certificate to any
+            // committed sub-dag this epoch earns nothing from any component,
+            // independent of the floor. `order_dag` always includes a leader's own
+            // certificate in the sub-dag it commits, so `participationRounds >=
+            // anchorRounds`; `participationRounds == 0` therefore also implies
+            // `anchorRounds == 0` - the validator neither participated nor led.
+            if (reward.participationRounds == 0) continue;
+            if (
+                participationFloorBps > 0 &&
+                totalRounds > 0 &&
+                (reward.participationRounds * MAX_BPS) / totalRounds < participationFloorBps
+            ) continue;
+
+            stakeWeight[i] = _stakeTierWeightOf(reward.validatorAddress);
+            totalParticipationRounds += reward.participationRounds;
+            totalStakeWeight += stakeWeight[i];
+            eligibleCount++;
+        }
+
+        if (eligibleCount == 0) return;
+
+        // Pass 2: blend each eligible validator's normalized shares into one weight.
+        // Note: participation normalizes against `totalParticipationRounds` (the
+        // *submitted* sum), not `totalRounds` - unlike anchor rounds, participation
+        // rounds don't sum to `totalRounds` across the committee (every live
+        // validator can participate in every round simultaneously), so submitted-sum
+        // normalization is what turns it into a true "slice of the 80% pool".
+        address[] memory tmpValidators = new address[](eligibleCount);
+        uint256[] memory tmpWeights = new uint256[](eligibleCount);
         uint256 totalWeight;
         uint256 validatorCount;
-        address[] memory tmpValidators = new address[](rewardInfos.length);
-        uint256[] memory tmpWeights = new uint256[](rewardInfos.length);
 
-        for (uint256 i; i < rewardInfos.length; ++i) {
+        for (uint256 i; i < n; ++i) {
+            if (stakeWeight[i] == 0) continue;
             RewardInfo calldata reward = rewardInfos[i];
-            if (reward.consensusHeaderCount == 0) continue;
 
-            // skip forcibly retired validators
-            if (isRetired(reward.validatorAddress)) continue;
-
-            uint8 rewardeeVersion = validators[reward.validatorAddress]
-                .stakeVersion;
-            uint256 stakeAmount = versions[rewardeeVersion].stakeAmount;
-            uint256 weight = stakeAmount * reward.consensusHeaderCount;
+            uint256 weight;
+            if (totalParticipationRounds > 0) {
+                weight += (PARTICIPATION_BPS * reward.participationRounds) / totalParticipationRounds;
+            }
+            if (totalRounds > 0) {
+                weight += (ANCHOR_BPS * reward.anchorRounds) / totalRounds;
+            }
+            weight += (STAKE_BPS * stakeWeight[i]) / totalStakeWeight;
+            if (weight == 0) continue;
 
             tmpValidators[validatorCount] = reward.validatorAddress;
             tmpWeights[validatorCount] = weight;
@@ -140,6 +221,40 @@ contract ConsensusRegistry is
             weights: finalWeights,
             totalWeight: totalWeight
         });
+    }
+
+    /// @dev Stake-tier weight multiplier (in bps, `MAX_BPS` baseline) for
+    /// `validatorAddress`: own required stake (`getBalanceBreakdown` position 1 -
+    /// see `RewardDistributor.sol`'s identical destructuring - not position 0,
+    /// which is contaminated by accrued rewards) plus delegated stake, tiered
+    /// above `STAKE_TIER_MIN` and capped at `STAKE_TIER_MAX_TIERS` tiers.
+    function _stakeTierWeightOf(address validatorAddress) internal view returns (uint256) {
+        (, uint256 requiredStake, ) = getBalanceBreakdown(validatorAddress);
+        address pool = delegationPool;
+        uint256 delegated = pool != address(0)
+            ? IDelegationPool(pool).getTotalDelegatedStake(validatorAddress)
+            : 0;
+        uint256 totalStake = requiredStake + delegated;
+
+        if (totalStake <= STAKE_TIER_MIN) {
+            return MAX_BPS;
+        }
+        uint256 maxStake = STAKE_TIER_MIN + STAKE_TIER_STEP * STAKE_TIER_MAX_TIERS;
+        if (totalStake > maxStake) {
+            totalStake = maxStake;
+        }
+        uint256 tiers = (totalStake - STAKE_TIER_MIN) / STAKE_TIER_STEP;
+        return MAX_BPS + tiers * STAKE_TIER_BONUS_BPS;
+    }
+
+    /// @notice Governance sets the minimum participation share (bps) required for
+    /// eligibility; `0` disables the floor.
+    /// @param newFloorBps New floor, in bps of `totalRounds`. Must be `<= MAX_BPS`.
+    function setParticipationFloorBps(uint256 newFloorBps) external onlyOwner {
+        if (newFloorBps > MAX_BPS) revert InvalidParticipationFloor(newFloorBps);
+        uint256 oldFloorBps = participationFloorBps;
+        participationFloorBps = newFloorBps;
+        emit ParticipationFloorUpdated(oldFloorBps, newFloorBps);
     }
 
     /// @inheritdoc IConsensusRegistry

--- a/rayls-contracts/src/consensus/design.md
+++ b/rayls-contracts/src/consensus/design.md
@@ -54,6 +54,14 @@ starved latency-distant validators and pushed operators to cluster nodes) to a h
   the tally → calldata → contract path). `applyIncentives` runs as an EVM system call whose
   result feeds both `state_root` and `withdrawals_root`, so it must be bit-for-bit identical on
   every node.
+- **Weight precision.** Each of the three normalized shares is scaled by `WEIGHT_PRECISION`
+  (`1e18`) before its truncating integer division. Without it, a per-validator numerator such as
+  `PARTICIPATION_BPS * participationRounds` can round down to zero once a large committee splits
+  the ~10 000-bps pool (one round out of a >8 000-round submitted sum), silently dropping a
+  validator that did contribute. Scaling preserves sub-bps resolution; because `RewardDistributor`
+  consumes weights purely as ratios (`weight / totalWeight`), scaling every weight by the same
+  constant leaves the distribution unchanged — and the scaled weights stay well below the
+  pre-hybrid `stake × headerCount` magnitudes this contract already stored.
 - **Anchor Commit Share (10%, capped)** preserves the incentive to run competitive
   infrastructure — a validator that wins the latency-sensitive fast path still earns more —
   without letting geography dominate rewards.

--- a/rayls-contracts/src/consensus/design.md
+++ b/rayls-contracts/src/consensus/design.md
@@ -13,7 +13,7 @@ The Rayls Network leverages Bullshark and Narwhal protocols, enabling nodes to b
 At the epoch boundary, the protocol performs gasless system calls to the ConsensusRegistry to update its state with epoch, validator, and rewards information. System call logic is abstracted into the `SystemCallable` module.
 
 - **Epoch Conclusion (`concludeEpoch()`)**: Finalizes the previous epoch, updates the voting committee and validator set, and stores new epoch information. Validator committees are protocol-managed and stored historically and for future epochs using ring buffers.
-- **Performance Tracking (`applyIncentives()`)**: Records block production performance weights (stake x consensusHeaderCount) for each validator. These weights are stored on-chain and consumed by the RewardDistributor to proportionally distribute fee-based rewards. Must be called before slashing and epoch conclusion.
+- **Performance Tracking (`applyIncentives()`)**: Records block production performance weights for each validator as a hybrid blend of participation share (80%, distinct committed rounds a validator's certificate was included in), Anchor Commit Share (10%, committed rounds led - the sole signal before the HybridRewards upgrade), and a stake tier (10%, own required stake plus delegated stake, tiered above a configurable minimum). Validators below an optional participation floor are excluded entirely. These weights are stored on-chain and consumed by the RewardDistributor to proportionally distribute fee-based rewards. Must be called before slashing and epoch conclusion.
 - **Slashing (`applySlashes()`)**: Proportionally slashes validator stake and delegated stake. When a validator's balance is fully depleted, triggers a consensus burn that ejects the validator from all committees and retires them. Slashed funds from DelegationPool are accumulated in the registry and withdrawable by governance.This is not live yet but has a preliminary implementation.
 
 ## Staking and Delegation
@@ -27,6 +27,74 @@ At the epoch boundary, the protocol performs gasless system calls to the Consens
 
 - **No Token Issuance**: No new tokens are minted at block production. Rewards are sourced entirely from transaction fees.
 - **Fee Flow**: Transaction gas fees are paid in the native token (USDr). The FeeAggregator collects accumulated USDr, swaps it to RLS via the Algebra DEX, and distributes the resulting RLS to configured recipients (validator pool via RewardDistributor, ecosystem treasury, and burn).
-- **RewardDistributor**: Receives the validator pool share of RLS from FeeAggregator. Distributes to validators weighted by performance data (stake x consensusHeaderCount) recorded by `applyIncentives()`. Falls back to pure stake-proportional distribution if no performance data exists.
+- **RewardDistributor**: Receives the validator pool share of RLS from FeeAggregator. Distributes to validators weighted by the hybrid performance data (participation + Anchor Commit Share + stake tier) recorded by `applyIncentives()`. Falls back to pure stake-proportional distribution if no performance data exists.
 - **Rewards Claiming**: Pull-only claim flow. Validators claim pending rewards from the RewardDistributor and pool commission from DelegationPool. Delegators claim their proportional share from DelegationPool. Both may set custom reward recipients.
 - **Balance Tracking**: Validator stake balances use a uint256 ledger in the StakeManager. Reward balances are tracked separately in the RewardDistributor.
+
+## Hybrid Reward Model — Design Decisions & Rollout
+
+The reward tally moved from `stake × committed-leader-count` (a hard zero-count cliff that
+starved latency-distant validators and pushed operators to cluster nodes) to a hybrid blend:
+**80% participation + 10% Anchor Commit Share + 10% stake tier**, computed on-chain in
+`applyIncentives`.
+
+- **Participation is measured by certificate inclusion, not the reputation score.** The 80%
+  component is `participation_rounds / Σ participation_rounds`, where a validator's
+  `participation_rounds` is the number of committed rounds whose sub-DAG included its
+  certificate. This is read from data **already persisted** in `ConsensusBlocks`
+  (`CommittedSubDag.certificates`, the flattened `order_dag` output) — the reward tally simply
+  stops skipping the certificate authors it previously ignored. **No consensus- or
+  networking-layer change, and no post-quorum vote tracking, is required** — the central
+  objection raised in review. The `reputation_score` (floated as a possible "Leader Hit Ratio"
+  proxy) is deliberately **not** used: it is itself latency-sensitive (a validator only earns
+  it when its round+1 certificate references the leader *in time* — the exact geographic bias
+  being removed), and it is advisory data excluded from the consensus digest. Raw
+  cert-inclusion is a direct, deterministic liveness signal instead.
+- **Determinism.** The blend is integer/basis-point math only (no floating point anywhere in
+  the tally → calldata → contract path). `applyIncentives` runs as an EVM system call whose
+  result feeds both `state_root` and `withdrawals_root`, so it must be bit-for-bit identical on
+  every node.
+- **Anchor Commit Share (10%, capped)** preserves the incentive to run competitive
+  infrastructure — a validator that wins the latency-sensitive fast path still earns more —
+  without letting geography dominate rewards.
+- **Stake tier (10%, capped).** Weight is `own required stake + delegated stake`, tiered at 5M
+  RLS minimum, +2% per additional 5M, capped at 30M (5 tiers). Because the own required stake
+  is uniform per stake-version, the differentiation is driven by delegation; the 10% cap keeps
+  a large validator from buying a dominant reward share.
+- **Absent → 0 (unconditional).** A validator that contributed no certificate to any committed
+  sub-DAG in the epoch (`participationRounds == 0`) earns nothing from *any* component,
+  regardless of the floor. Because `order_dag` always includes a leader's own certificate in
+  the sub-DAG it commits, `participationRounds ≥ anchorRounds`, so zero participation also means
+  zero leadership — the validator neither participated nor led. This keeps the stake component
+  from leaking to fully-down validators and preserves the liveness incentive.
+- **Participation floor.** `participationFloorBps` additionally excludes validators *above* zero
+  but below a liveness bar (share of committed rounds participated) — the "up but chronically
+  under-participating" band. It is **governance-settable and disabled (0) by default**: the
+  exact threshold is a policy decision best made against real post-activation participation
+  data, and disabling it initially excludes no one beyond the absent-→-0 rule while remaining
+  tunable without a new hardfork.
+- **Storage is append-only for a future in-place upgrade.** The only added state variable,
+  `participationFloorBps`, is appended after all pre-existing storage (guarded by the
+  `test_storageLayout_participationFloorBps_appendOnly_migrationSafe` test), so a later bytecode
+  swap onto an existing `ConsensusRegistry`'s storage cannot shift any live validator state.
+
+### Rollout is intentionally out of scope for this change
+
+This change lands the **reward computation only** — the on-chain hybrid `applyIncentives` blend
+and the off-chain participation tally (`ConsensusHeaderParticipation` + `tally_hybrid`), with
+their tests. It does **not** wire activation: no fork schedule, no change to which contract
+genesis deploys, and no in-place upgrade path. That activation/rollout wiring is a separate
+follow-up, for two reasons surfaced during review:
+- **Deployment/upgrade of `ConsensusRegistry` is non-trivial.** It is a directly-deployed
+  (non-proxy) contract that links the external `BlsG1` library at `owner.create(0)` — a
+  *per-network* address filled in at genesis. A naive bytecode swap would carry a wrong,
+  code-less library address and revert; the upgrade must re-link `BlsG1` for the target network
+  (or the network must re-genesis). This is an e2e-verified constraint, not a theoretical one.
+- **The activation ABI must match the deployed contract at every block.** The pre-hybrid
+  contract serves a 1-arg `applyIncentives`; the hybrid contract a 2-arg one. The follow-up must
+  keep the deployed bytecode and the node's reward-call path consistent across the activation
+  boundary (fresh genesis vs. in-place upgrade).
+
+Pre-activation, the hybrid tally can be computed against a real consensus DB and compared to the
+current leader-only split (the PoC measured a latency-injected validator going from 5.7% to
+19.8%).

--- a/rayls-contracts/src/interfaces/IConsensusRegistry.sol
+++ b/rayls-contracts/src/interfaces/IConsensusRegistry.sol
@@ -56,6 +56,7 @@ interface IConsensusRegistry {
     error IneligibleUnstake(ValidatorInfo validator);
     error NotAllowlisted(address validatorAddress);
     error AllowlistBatchLengthMismatch();
+    error InvalidParticipationFloor(uint256 providedFloorBps);
 
     event ValidatorStaked(ValidatorInfo validator);
     event ValidatorPendingActivation(ValidatorInfo validator);
@@ -69,6 +70,7 @@ interface IConsensusRegistry {
     event ValidatorAllowlisted(address indexed validatorAddress);
     event ValidatorDelisted(address indexed validatorAddress);
     event DelegationPoolUpdated(address indexed oldPool, address indexed newPool);
+    event ParticipationFloorUpdated(uint256 oldFloorBps, uint256 newFloorBps);
 
     /// @dev Validators marked `Active || PendingActivation || PendingExit` are still operational
     /// and thus eligible for committees. Queriable via `getValidators(Active)` status
@@ -97,9 +99,13 @@ interface IConsensusRegistry {
     function concludeEpoch(address[] calldata newCommittee) external;
 
     /// @dev Records block production performance weights for the current epoch
-    /// @notice Weights are computed as stake × consensusHeaderCount per validator
+    /// @notice Weights are a hybrid blend of participation share, anchor (leader) commit
+    /// share, and a stake tier per validator - see `ConsensusRegistry.applyIncentives`
     /// @notice Called just before concludeEpoch; weights are consumed by RewardDistributor
-    function applyIncentives(RewardInfo[] calldata rewardInfos) external;
+    /// @param rewardInfos Per-validator round counts for the closing epoch
+    /// @param totalRounds Total committed rounds walked for the closing epoch (the shared
+    /// anchor-share and participation-floor denominator)
+    function applyIncentives(RewardInfo[] calldata rewardInfos, uint256 totalRounds) external;
 
     /// @dev Returns the performance weights recorded by the most recent applyIncentives call
     /// @notice Used by RewardDistributor to distribute fee-based rewards proportionally

--- a/rayls-contracts/src/interfaces/IStakeManager.sol
+++ b/rayls-contracts/src/interfaces/IStakeManager.sol
@@ -12,10 +12,14 @@ import {BlsG1} from "../consensus/BlsG1.sol";
  */
 
 /// @notice Protocol info for system calls to record block production performance
-/// @notice Used to weight fee-based reward distribution by consensus header count
+/// @notice Used to weight fee-based reward distribution by a hybrid of participation,
+/// anchor (leader) commit share, and a stake tier - see `ConsensusRegistry.applyIncentives`
 struct RewardInfo {
     address validatorAddress;
-    uint256 consensusHeaderCount;
+    /// @notice Distinct committed rounds this validator's certificate was included in
+    uint256 participationRounds;
+    /// @notice Committed rounds this validator led (formerly `consensusHeaderCount`)
+    uint256 anchorRounds;
 }
 
 /// @notice Slash information for system calls to decrement outstanding validator balances

--- a/rayls-contracts/test/consensus/ConsensusRegistryTestFuzz.t.sol
+++ b/rayls-contracts/test/consensus/ConsensusRegistryTestFuzz.t.sol
@@ -106,6 +106,10 @@ contract ConsensusRegistryTestFuzz is ConsensusRegistryTestUtils {
         }
     }
 
+    /// @dev Invariant-style rather than re-deriving the full blended formula in
+    /// test code (fragile/circular, since totals depend on the same random set
+    /// being generated) - see `test_applyIncentives_hybridBlend_tokyoScenario`
+    /// below for an exact hand-computed check of the formula itself.
     function testFuzz_applyIncentives(
         uint24 numValidators,
         uint24 numRewardees
@@ -116,30 +120,41 @@ contract ConsensusRegistryTestFuzz is ConsensusRegistryTestUtils {
         _fuzz_stake(numValidators, stakeAmount_);
 
         vm.startPrank(sysAddress);
-        // apply incentives — now only records performance weights
-        (
-            RewardInfo[] memory rewardInfos,
-            uint256[] memory expectedWeights
-        ) = _fuzz_createRewardInfos(numRewardees);
-        consensusRegistry.applyIncentives(rewardInfos);
+        (RewardInfo[] memory rewardInfos, uint256 totalRounds) = _fuzz_createRewardInfos(numRewardees);
+        consensusRegistry.applyIncentives(rewardInfos, totalRounds);
         vm.stopPrank();
 
-        // assert performance weights were recorded correctly
         IConsensusRegistry.PerformanceWeights memory perf = consensusRegistry.getEpochPerformanceWeights();
 
-        // count non-zero weight entries
-        uint256 nonZeroCount;
-        for (uint256 i; i < expectedWeights.length; ++i) {
-            if (expectedWeights[i] > 0) nonZeroCount++;
+        // Invariant: recorded weights sum exactly to totalWeight.
+        uint256 summedWeight;
+        for (uint256 i; i < perf.weights.length; ++i) {
+            assertTrue(perf.weights[i] > 0, "recorded entries must have positive weight");
+            summedWeight += perf.weights[i];
         }
-        assertEq(perf.validators.length, nonZeroCount);
+        assertEq(summedWeight, perf.totalWeight);
 
-        // verify total weight
-        uint256 expectedTotalWeight;
-        for (uint256 i; i < expectedWeights.length; ++i) {
-            expectedTotalWeight += expectedWeights[i];
+        // Invariant: with no retirements and the participation floor disabled
+        // (default), exactly the rewardees with participationRounds > 0 are
+        // weighted - absent validators (participationRounds == 0) earn nothing and
+        // are dropped; nothing else is silently dropped.
+        uint256 expectedEligible;
+        for (uint256 i; i < rewardInfos.length; ++i) {
+            if (rewardInfos[i].participationRounds > 0) expectedEligible++;
         }
-        assertEq(perf.totalWeight, expectedTotalWeight);
+        assertEq(perf.validators.length, expectedEligible, "only participating validators weighted");
+
+        // Invariant: every recorded validator was actually submitted (no phantom entries).
+        for (uint256 i; i < perf.validators.length; ++i) {
+            bool found;
+            for (uint256 j; j < rewardInfos.length; ++j) {
+                if (rewardInfos[j].validatorAddress == perf.validators[i]) {
+                    found = true;
+                    break;
+                }
+            }
+            assertTrue(found, "recorded validator not in submitted rewardInfos");
+        }
 
         // applyIncentives no longer credits balances, so getRewards should be 0
         for (uint256 i; i < rewardInfos.length; ++i) {
@@ -161,10 +176,8 @@ contract ConsensusRegistryTestFuzz is ConsensusRegistryTestUtils {
 
         vm.startPrank(sysAddress);
         // apply incentives — only records performance weights, no balance credits
-        (
-            RewardInfo[] memory rewardInfos,
-        ) = _fuzz_createRewardInfos(numRewardees);
-        consensusRegistry.applyIncentives(rewardInfos);
+        (RewardInfo[] memory rewardInfos, uint256 totalRounds) = _fuzz_createRewardInfos(numRewardees);
+        consensusRegistry.applyIncentives(rewardInfos, totalRounds);
         vm.stopPrank();
 
         // claiming should always revert since applyIncentives no longer credits rewards
@@ -174,5 +187,249 @@ contract ConsensusRegistryTestFuzz is ConsensusRegistryTestUtils {
             vm.expectRevert();
             consensusRegistry.claimStakeRewards(validator);
         }
+    }
+
+    /// @dev Ports the PoC's `hybrid_model_closes_the_zero_reward_cliff` scenario
+    /// (participation.rs/hybrid.rs in the Rust PoC) to exact integer bps math: a
+    /// US validator leads every round (100% anchor share, 0% for everyone else
+    /// today); a Tokyo-like validator never leads but participates in every
+    /// round; a third validator does neither. Everyone at the same (baseline)
+    /// stake tier, so the stake component splits evenly three ways.
+    function test_applyIncentives_hybridBlend_tokyoScenario() public {
+        // `_fuzz_stake` derives each staked validator's address from secret `i + 5`.
+        _fuzz_stake(3, stakeAmount_);
+        address usLeader = _addressFromPrivateKey(5);
+        address tokyo = _addressFromPrivateKey(6);
+        address third = _addressFromPrivateKey(7);
+
+        uint256 totalRounds = 100;
+        RewardInfo[] memory rewardInfos = new RewardInfo[](3);
+        // US leader: leads every round, and (like everyone) participates in every round.
+        rewardInfos[0] = RewardInfo(usLeader, totalRounds, totalRounds);
+        // Tokyo: never leads, but participates (its cert is included) every round.
+        rewardInfos[1] = RewardInfo(tokyo, totalRounds, 0);
+        // Third validator: participates every round too, never leads.
+        rewardInfos[2] = RewardInfo(third, totalRounds, 0);
+
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos, totalRounds);
+
+        IConsensusRegistry.PerformanceWeights memory perf = consensusRegistry.getEpochPerformanceWeights();
+        assertEq(perf.validators.length, 3);
+
+        uint256[] memory weightOf = new uint256[](3);
+        for (uint256 i; i < perf.validators.length; ++i) {
+            if (perf.validators[i] == usLeader) weightOf[0] = perf.weights[i];
+            else if (perf.validators[i] == tokyo) weightOf[1] = perf.weights[i];
+            else if (perf.validators[i] == third) weightOf[2] = perf.weights[i];
+        }
+
+        // Participation share is equal across all three (each submitted totalRounds
+        // participationRounds out of a 3*totalRounds submitted sum) -> 8_000/3 bps each.
+        // Anchor share: usLeader gets the full 1_000 bps (100% of totalRounds); the
+        // other two get 0. Stake share splits evenly at baseline -> 1_000/3 bps each.
+        // Cast forces normal truncating integer division; bare literal/literal
+        // division is exact-rational at compile time in Solidity and rejects
+        // non-whole results (e.g. plain `8_000 / 3` fails to compile).
+        uint256 participationShare = uint256(8_000) / 3;
+        uint256 stakeShare = uint256(1_000) / 3;
+        uint256 expectedUsLeader = participationShare + 1_000 + stakeShare;
+        uint256 expectedTokyo = participationShare + stakeShare;
+        uint256 expectedThird = participationShare + stakeShare;
+
+        assertEq(weightOf[0], expectedUsLeader);
+        assertEq(weightOf[1], expectedTokyo);
+        assertEq(weightOf[2], expectedThird);
+
+        // The whole point of #633: today, Tokyo would earn exactly 0 (anchor-only
+        // model). Under the hybrid blend it earns the large majority of what the
+        // leader earns instead of nothing.
+        assertTrue(weightOf[1] > 0);
+        assertTrue(weightOf[1] > weightOf[0] / 2);
+    }
+
+    /// @dev A validator below the participation floor is excluded entirely (not
+    /// just from the participation component) once the floor is enabled -
+    /// disabled (0) is the default, so this exercises `setParticipationFloorBps`.
+    function test_applyIncentives_participationFloor_excludesBelowThreshold() public {
+        _fuzz_stake(2, stakeAmount_);
+        address reliable = _addressFromPrivateKey(5);
+        address unreliable = _addressFromPrivateKey(6);
+
+        vm.prank(crOwner);
+        consensusRegistry.setParticipationFloorBps(3_000); // 30% floor
+
+        uint256 totalRounds = 100;
+        RewardInfo[] memory rewardInfos = new RewardInfo[](2);
+        rewardInfos[0] = RewardInfo(reliable, 90, 10); // 90% participation, well above floor
+        rewardInfos[1] = RewardInfo(unreliable, 10, 0); // 10% participation, below the 30% floor
+
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos, totalRounds);
+
+        IConsensusRegistry.PerformanceWeights memory perf = consensusRegistry.getEpochPerformanceWeights();
+        assertEq(perf.validators.length, 1);
+        assertEq(perf.validators[0], reliable);
+    }
+
+    /// Reproduction of the e2e halt: the real node calls applyIncentives with the
+    /// genesis COMMITTEE validators (Active status, set in the constructor), not
+    /// freshly-staked ones. Mirror that exactly.
+    function test_applyIncentives_genesisCommitteeValidators_doesNotRevert() public {
+        // validator1..4 are the constructor's initialValidators, already Active.
+        RewardInfo[] memory rewardInfos = new RewardInfo[](4);
+        rewardInfos[0] = RewardInfo(validator1, 100, 40);
+        rewardInfos[1] = RewardInfo(validator2, 100, 30);
+        rewardInfos[2] = RewardInfo(validator3, 90, 20);
+        rewardInfos[3] = RewardInfo(validator4, 80, 10);
+
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos, 100);
+
+        IConsensusRegistry.PerformanceWeights memory perf =
+            consensusRegistry.getEpochPerformanceWeights();
+        assertEq(perf.validators.length, 4, "all genesis committee validators should be weighted");
+    }
+
+    /// @dev A fully-absent validator (0 participation, hence 0 anchor) earns
+    /// nothing even with the participation floor disabled - the 10% stake
+    /// component must not leak to validators that contributed no certificate this
+    /// epoch. This is the unconditional "absent -> 0" rule, independent of the floor.
+    function test_applyIncentives_absentValidator_earnsZero() public {
+        _fuzz_stake(2, stakeAmount_);
+        address active = _addressFromPrivateKey(5);
+        address absent = _addressFromPrivateKey(6);
+
+        // Floor stays at its 0 default; only the absent-gate excludes `absent`.
+        assertEq(consensusRegistry.participationFloorBps(), 0, "precondition: floor disabled");
+
+        RewardInfo[] memory rewardInfos = new RewardInfo[](2);
+        rewardInfos[0] = RewardInfo(active, 100, 40);
+        rewardInfos[1] = RewardInfo(absent, 0, 0); // contributed nothing this epoch
+
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos, 100);
+
+        IConsensusRegistry.PerformanceWeights memory perf = consensusRegistry.getEpochPerformanceWeights();
+        assertEq(perf.validators.length, 1, "only the active validator earns");
+        assertEq(perf.validators[0], active, "absent-but-staked validator must be excluded entirely");
+    }
+
+    function testRevert_setParticipationFloorBps_aboveMax() public {
+        vm.prank(crOwner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IConsensusRegistry.InvalidParticipationFloor.selector, 10_001)
+        );
+        consensusRegistry.setParticipationFloorBps(10_001);
+    }
+
+    /// @dev Delegated stake pushes a validator into a higher stake tier, strictly
+    /// increasing its weight relative to an identical validator with no delegation
+    /// - exercised through a minimal mock `IDelegationPool`, not the full
+    /// signature-based real `DelegationPool` (out of scope for this weight-math test).
+    function test_applyIncentives_stakeTier_delegationIncreasesWeight() public {
+        _fuzz_stake(2, stakeAmount_);
+        address baseline = _addressFromPrivateKey(5);
+        address delegated = _addressFromPrivateKey(6);
+
+        MockDelegationPoolForRewards mockPool = new MockDelegationPoolForRewards();
+        // stakeAmount_ (own/required stake) is 1_000_000e18, below the 5M-RLS tier
+        // minimum, so the fixed own-stake component alone never crosses a tier -
+        // delegating 29M brings `delegated`'s total (own + delegated) to exactly
+        // the 30M cap (5 tiers, +10%).
+        mockPool.setDelegated(delegated, 29_000_000e18);
+        vm.prank(crOwner);
+        consensusRegistry.setDelegationPool(address(mockPool));
+
+        uint256 totalRounds = 100;
+        RewardInfo[] memory rewardInfos = new RewardInfo[](2);
+        rewardInfos[0] = RewardInfo(baseline, 50, 50);
+        rewardInfos[1] = RewardInfo(delegated, 50, 50); // identical round counts
+
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos, totalRounds);
+
+        IConsensusRegistry.PerformanceWeights memory perf = consensusRegistry.getEpochPerformanceWeights();
+        uint256 baselineWeight;
+        uint256 delegatedWeight;
+        for (uint256 i; i < perf.validators.length; ++i) {
+            if (perf.validators[i] == baseline) baselineWeight = perf.weights[i];
+            else if (perf.validators[i] == delegated) delegatedWeight = perf.weights[i];
+        }
+
+        // Identical participation/anchor rounds -> the entire weight difference
+        // comes from the stake-tier component (1.10x vs 1.00x baseline weight).
+        assertTrue(delegatedWeight > baselineWeight, "delegated stake must increase weight");
+    }
+
+    /// @notice Migration safety. The `HybridRewards` hardfork installs this
+    /// contract's bytecode over an EXISTING `ConsensusRegistry`'s storage (a
+    /// bytecode swap that preserves storage), so the one state variable this
+    /// change adds - `participationFloorBps` - MUST occupy a fresh slot appended
+    /// after all pre-existing state, never overlapping it. This test populates
+    /// every pre-existing storage region (validators, balances, allowlist, and
+    /// `_performanceWeights` - the immediate layout neighbor, hence highest-risk),
+    /// writes the new var, and asserts no pre-existing slot moved. A layout
+    /// regression (inserting the var mid-struct) would corrupt live validator
+    /// state on mainnet activation and fail here.
+    function test_storageLayout_participationFloorBps_appendOnly_migrationSafe() public {
+        // Populate pre-existing storage: stake writes validators/balances/allowlist;
+        // applyIncentives writes _performanceWeights (the last pre-existing var,
+        // declared immediately before participationFloorBps).
+        _fuzz_stake(2, stakeAmount_);
+        address v = _addressFromPrivateKey(5);
+
+        RewardInfo[] memory rewardInfos = new RewardInfo[](1);
+        rewardInfos[0] = RewardInfo(v, 50, 20);
+        vm.prank(sysAddress);
+        consensusRegistry.applyIncentives(rewardInfos, 100);
+
+        // Snapshot pre-existing state.
+        uint32 epochBefore = consensusRegistry.getCurrentEpoch();
+        IConsensusRegistry.ValidatorInfo memory vBefore = consensusRegistry.getValidator(v);
+        bool allowlistedBefore = consensusRegistry.validatorAllowlist(v);
+        (uint256 balBefore, uint256 stakeBefore, ) = consensusRegistry.getBalanceBreakdown(v);
+        IConsensusRegistry.PerformanceWeights memory perfBefore =
+            consensusRegistry.getEpochPerformanceWeights();
+        assertGt(perfBefore.totalWeight, 0, "precondition: performance weights populated");
+
+        // The new var must default to 0 (a fresh, never-written slot).
+        assertEq(consensusRegistry.participationFloorBps(), 0, "new var must default to 0");
+
+        // Write the new var to a sentinel value.
+        vm.prank(crOwner);
+        consensusRegistry.setParticipationFloorBps(3_000);
+
+        // Every pre-existing storage region must be byte-identical: no slot overlap.
+        assertEq(consensusRegistry.getCurrentEpoch(), epochBefore, "currentEpoch slot moved");
+        IConsensusRegistry.ValidatorInfo memory vAfter = consensusRegistry.getValidator(v);
+        assertEq(vAfter.validatorAddress, vBefore.validatorAddress, "validators slot moved");
+        assertEq(uint8(vAfter.currentStatus), uint8(vBefore.currentStatus), "validator status slot moved");
+        assertEq(vAfter.stakeVersion, vBefore.stakeVersion, "validator stakeVersion slot moved");
+        assertEq(consensusRegistry.validatorAllowlist(v), allowlistedBefore, "allowlist slot moved");
+        (uint256 balAfter, uint256 stakeAfter, ) = consensusRegistry.getBalanceBreakdown(v);
+        assertEq(balAfter, balBefore, "balance slot moved");
+        assertEq(stakeAfter, stakeBefore, "stake slot moved");
+        IConsensusRegistry.PerformanceWeights memory perfAfter =
+            consensusRegistry.getEpochPerformanceWeights();
+        assertEq(perfAfter.totalWeight, perfBefore.totalWeight, "_performanceWeights.totalWeight slot moved");
+        assertEq(perfAfter.validators.length, perfBefore.validators.length, "_performanceWeights.validators slot moved");
+
+        // And the new var holds exactly what we wrote.
+        assertEq(consensusRegistry.participationFloorBps(), 3_000, "new var not persisted at its own slot");
+    }
+}
+
+/// @notice Minimal `IDelegationPool.getTotalDelegatedStake` double for testing the
+/// stake-tier component in isolation, without the full signature-based delegation flow.
+contract MockDelegationPoolForRewards {
+    mapping(address => uint256) private _delegated;
+
+    function setDelegated(address validatorAddress, uint256 amount) external {
+        _delegated[validatorAddress] = amount;
+    }
+
+    function getTotalDelegatedStake(address validatorAddress) external view returns (uint256) {
+        return _delegated[validatorAddress];
     }
 }

--- a/rayls-contracts/test/consensus/ConsensusRegistryTestFuzz.t.sol
+++ b/rayls-contracts/test/consensus/ConsensusRegistryTestFuzz.t.sol
@@ -224,16 +224,21 @@ contract ConsensusRegistryTestFuzz is ConsensusRegistryTestUtils {
             else if (perf.validators[i] == third) weightOf[2] = perf.weights[i];
         }
 
-        // Participation share is equal across all three (each submitted totalRounds
-        // participationRounds out of a 3*totalRounds submitted sum) -> 8_000/3 bps each.
-        // Anchor share: usLeader gets the full 1_000 bps (100% of totalRounds); the
-        // other two get 0. Stake share splits evenly at baseline -> 1_000/3 bps each.
-        // Cast forces normal truncating integer division; bare literal/literal
-        // division is exact-rational at compile time in Solidity and rejects
-        // non-whole results (e.g. plain `8_000 / 3` fails to compile).
-        uint256 participationShare = uint256(8_000) / 3;
-        uint256 stakeShare = uint256(1_000) / 3;
-        uint256 expectedUsLeader = participationShare + 1_000 + stakeShare;
+        // Each share mirrors the contract's WEIGHT_PRECISION-scaled truncating
+        // division exactly - scale THEN divide (not divide-then-scale), so the
+        // retained sub-bps resolution matches. Participation: each of the 3 validators
+        // submitted `totalRounds` out of a `3*totalRounds` submitted sum. Anchor:
+        // usLeader led every round (full 1_000-bps share of `totalRounds`), the other
+        // two led none. Stake: equal baseline stake weight -> 1/3 each. Casts force
+        // runtime truncating division (bare literal/literal is exact-rational at
+        // compile time and rejects non-whole results).
+        uint256 precision = 1e18; // WEIGHT_PRECISION mirror
+        uint256 baselineStakeWeight = 10_000; // MAX_BPS baseline, no delegation
+        uint256 participationShare = (uint256(8_000) * precision * totalRounds) / (3 * totalRounds);
+        uint256 anchorFull = (uint256(1_000) * precision * totalRounds) / totalRounds;
+        uint256 stakeShare =
+            (uint256(1_000) * precision * baselineStakeWeight) / (3 * baselineStakeWeight);
+        uint256 expectedUsLeader = participationShare + anchorFull + stakeShare;
         uint256 expectedTokyo = participationShare + stakeShare;
         uint256 expectedThird = participationShare + stakeShare;
 

--- a/rayls-contracts/test/consensus/ConsensusRegistryTestUtils.sol
+++ b/rayls-contracts/test/consensus/ConsensusRegistryTestUtils.sol
@@ -277,9 +277,14 @@ contract ConsensusRegistryTestUtils is ConsensusRegistry, BlsG1Harness, GenesisP
     /// sums (e.g. anchor rounds summing to exactly `totalRounds`) - the blended
     /// weight formula doesn't require that invariant to hold to compute a result,
     /// and per-validator round counts are exactly what `applyIncentives` trusts.
+    /// It does enforce the one *per-validator* invariant production always upholds:
+    /// `anchorRounds <= participationRounds` (a leader's own certificate is always in
+    /// the sub-dag it commits, so `order_dag` yields `participationRounds >=
+    /// anchorRounds`). Drawing them independently would routinely produce impossible
+    /// `anchorRounds > participationRounds` inputs, so anchor is clamped below.
     function _fuzz_createRewardInfos(
         uint24 numRewardees
-    ) internal view returns (RewardInfo[] memory, uint256 totalRounds) {
+    ) internal pure returns (RewardInfo[] memory, uint256 totalRounds) {
         totalRounds = 10_000;
         RewardInfo[] memory rewardInfos = new RewardInfo[](numRewardees);
         for (uint256 i; i < numRewardees; ++i) {
@@ -288,9 +293,11 @@ contract ConsensusRegistryTestUtils is ConsensusRegistry, BlsG1Harness, GenesisP
             uint256 participationRounds = uint256(
                 keccak256(abi.encode(uniqueSeed, "participation"))
             ) % (totalRounds + 1);
-            uint256 anchorRounds = uint256(
-                keccak256(abi.encode(uniqueSeed, "anchor"))
-            ) % (totalRounds + 1);
+            // Clamp anchor to the per-validator invariant `anchorRounds <=
+            // participationRounds` (0 when a validator participated in no round).
+            uint256 anchorRounds = participationRounds == 0
+                ? 0
+                : uint256(keccak256(abi.encode(uniqueSeed, "anchor"))) % (participationRounds + 1);
 
             rewardInfos[i] = RewardInfo(rewardee, participationRounds, anchorRounds);
         }

--- a/rayls-contracts/test/consensus/ConsensusRegistryTestUtils.sol
+++ b/rayls-contracts/test/consensus/ConsensusRegistryTestUtils.sol
@@ -271,29 +271,30 @@ contract ConsensusRegistryTestUtils is ConsensusRegistry, BlsG1Harness, GenesisP
         return committee;
     }
 
+    /// @dev `totalRounds` bounds both `participationRounds` and `anchorRounds` per
+    /// rewardee (`[0, totalRounds]`, as a validator can participate/lead at most
+    /// once per round) but the fixture does not constrain their cross-validator
+    /// sums (e.g. anchor rounds summing to exactly `totalRounds`) - the blended
+    /// weight formula doesn't require that invariant to hold to compute a result,
+    /// and per-validator round counts are exactly what `applyIncentives` trusts.
     function _fuzz_createRewardInfos(
         uint24 numRewardees
-    ) internal view returns (RewardInfo[] memory, uint256[] memory) {
+    ) internal view returns (RewardInfo[] memory, uint256 totalRounds) {
+        totalRounds = 10_000;
         RewardInfo[] memory rewardInfos = new RewardInfo[](numRewardees);
-        uint256 totalWeight;
         for (uint256 i; i < numRewardees; ++i) {
             address rewardee = _addressFromPrivateKey(i + 1);
-            // 0-10000 is reasonable range of consensus blocks leaders can authorize per epoch
             uint256 uniqueSeed = i + numRewardees;
-            uint256 consensusHeaderCount = uint256(
-                uint256(keccak256(abi.encode(uniqueSeed))) % 10_000
-            );
+            uint256 participationRounds = uint256(
+                keccak256(abi.encode(uniqueSeed, "participation"))
+            ) % (totalRounds + 1);
+            uint256 anchorRounds = uint256(
+                keccak256(abi.encode(uniqueSeed, "anchor"))
+            ) % (totalRounds + 1);
 
-            rewardInfos[i] = RewardInfo(rewardee, consensusHeaderCount);
-            totalWeight += stakeAmount_ * consensusHeaderCount;
-        }
-        // applyIncentives now only records performance weights, not distributing rewards
-        // expected weights are returned for assertion against getEpochPerformanceWeights()
-        uint256[] memory expectedWeights = new uint256[](numRewardees);
-        for (uint256 i; i < rewardInfos.length; ++i) {
-            expectedWeights[i] = stakeAmount_ * rewardInfos[i].consensusHeaderCount;
+            rewardInfos[i] = RewardInfo(rewardee, participationRounds, anchorRounds);
         }
 
-        return (rewardInfos, expectedWeights);
+        return (rewardInfos, totalRounds);
     }
 }


### PR DESCRIPTION
## What

Replaces the leader-only validator reward tally — `stake × committed-leader-count` — with a hybrid blend computed on-chain in `ConsensusRegistry.applyIncentives`:

- **80% participation** — share of committed rounds whose sub-DAG included the validator's certificate
- **10% Anchor Commit Share** — committed rounds the validator led (the sole signal in the pre-hybrid model, renamed)
- **10% stake tier** — own required stake + delegated stake, tiered above a configurable minimum

## Why

Validators far from the US cluster (e.g. Tokyo) earn near-zero rewards today: *leading* a committed round is latency-sensitive, so a chronically-distant validator rarely wins the fast path and hits a hard zero-count cliff. Root cause is traced in `doc/design/rewards-fairness-across-validators.md` (issue raylsnetwork/axyl-private#633). The hybrid model was approved verbally with Meg + team; this PR turns the PoC (raylsnetwork/axyl-private#693) into a production-grade path.

## The linchpin: no consensus- or networking-layer change

The participation signal is read from certificate authors **already persisted** in `ConsensusBlocks` (`CommittedSubDag.certificates`, the flattened `order_dag` output). The tally simply stops skipping the cert authors it previously ignored (`ConsensusHeaderParticipation` vs. `ConsensusHeaderMeta`). **No consensus change, no networking change, no post-quorum vote tracking** — the central objection raised in review. `reputation_score` is deliberately not used (itself latency-sensitive, and advisory/excluded from the consensus digest).

## Determinism

`applyIncentives` runs as an EVM system call whose result feeds both `state_root` and `withdrawals_root`, so it must be bit-for-bit identical on every node. The blend is **integer/basis-point math only — no floating point anywhere** in the tally → calldata → contract path.

## In scope vs. deferred

**In scope (this PR):** the reward *computation* — the on-chain hybrid `applyIncentives` blend and the off-chain participation tally (`ConsensusHeaderParticipation` + `tally_hybrid`), with tests.

**Deferred (tracked in #79; see `rayls-contracts/src/consensus/design.md` → "Rollout is intentionally out of scope"):** activation wiring — no fork schedule, no change to which contract genesis deploys, no in-place upgrade path. Two review/e2e-surfaced reasons: (1) `ConsensusRegistry` links the external `BlsG1` library at a per-network address filled in at genesis, so a naive bytecode swap reverts and the upgrade must re-link per network; (2) the activation ABI (1-arg vs. 2-arg `applyIncentives`) must stay consistent with the deployed contract at every block, or the first epoch close halts the chain.

## Behaviour notes

- **Absent → 0.** A validator that contributed no certificate to any committed sub-DAG (`participationRounds == 0`) earns nothing from *any* component. Because `order_dag` always includes a leader's own certificate, `participation_rounds ≥ leader_rounds`, so zero participation ⟹ zero leadership.
- **Participation floor** (`participationFloorBps`) additionally excludes above-zero-but-chronically-under-participating validators. **Governance-settable, disabled (`0`) by default** — the threshold is a policy call best made against real post-activation data.
- **Stake tier** reads `getBalanceBreakdown` position 1 (own required stake, *not* position 0 which is contaminated by accrued rewards) + `getTotalDelegatedStake` — the exact pattern `RewardDistributor.sol` already uses. 5M min, +2% per 5M, capped 30M (5 tiers).
- **Storage append-only.** The one added state variable (`participationFloorBps`) is appended after all pre-existing storage (guarded by `test_storageLayout_participationFloorBps_appendOnly_migrationSafe`), so a later in-place bytecode swap can't shift live validator state.
- **Archive replay** of hybrid epochs is deferred: `SnapshotRewardsBackend::tally_hybrid` hard-errors (a `Withdrawal` carries one `u32`/validator and can't recover `participation_rounds`) rather than returning wrong data. Affects only the offline `rayls-replay` tool, never production nodes.

## Tests

- **Rust:** `ConsensusHeaderParticipation` BCS decode (incl. cross-check against `ConsensusHeaderMeta` on identical bytes); `tally_hybrid` single-walk / per-sub-dag dedupe / genesis+range exclusion; `SnapshotRewardsBackend::tally_hybrid` loud-error; plus the full existing suites for the touched crates.
- **Solidity** (`ConsensusRegistryTestFuzz.t.sol`): hybrid-blend invariant fuzz, hand-computed Tokyo scenario, participation-floor exclusion, stake-tier delegation, genesis-committee no-revert, absent-earns-zero, storage-layout append-only, floor-above-max revert.

## Verification run

- `cargo test -p rayls-infrastructure-types -p rayls-middleware-rewards -p rayls-replay` — pass
- `cd rayls-contracts && forge test --match-contract ConsensusRegistry` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
