### PR TITLE
fix(consensus): promote a staked-in observer to a committee validator

### DIFF
--- a/crates/middleware/orchestrator/src/epoch_manager/network.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/network.rs
@@ -18,7 +18,8 @@ use tracing::{debug, error, info, warn};
 /// 1. Not in committee -> Observer
 /// 2. Observer flag set -> Observer
 /// 3. Explicit mode-transition target pending -> adopt it
-/// 4. Prior mode preservation on respawn -> keep current mode
+/// 4. Prior mode preservation on respawn -> keep current mode (except Observer promotes to
+///    CvvInactive when now in-committee without observer_flag; see arm below)
 /// 5. Local consensus history exists -> CvvInactive (catch up)
 /// 6. No history, first boot -> CvvActive (fresh genesis)
 ///
@@ -45,34 +46,12 @@ pub(crate) fn decide_node_mode(
         return match prior_mode {
             NodeMode::CvvActive => (NodeMode::CvvActive, "prior-mode-active"),
             NodeMode::CvvInactive => (NodeMode::CvvInactive, "prior-mode-inactive"),
-            // ============================================================================
-            // XXX / REVISIT — REVIEWER PLEASE SCRUTINIZE THIS ARM
-            // ============================================================================
-            // NEW behavior: promote a dynamic observer that has just been admitted to the
-            // committee, instead of leaving it Observer forever ("prior-mode-observer").
-            //
-            // Reaching here means: in the on-chain committee (`in_committee`), NOT a configured
-            // observer (`observer_flag` handled above), yet still running as Observer — i.e. a node
-            // that was following as a dynamic observer and has just been admitted to the committee
-            // (e.g. freshly staked). Join as CvvInactive so it catches up on the boundary WITHOUT
-            // proposing/voting yet; the bridge subscriber then requests CvvActive once synced.
-            // Staying Observer here leaves a silent committee member — counted toward quorum but
-            // never proposing/certifying — which stalls consensus (observed: total chain stall
-            // when a staked node stayed Observer).
-            //
-            // REVISIT — open questions the reviewer should weigh in on:
-            //   1. Is `decide_node_mode` the right layer, vs. an explicit stake→promote signal? Two
-            //      other Observer-stickiness guards exist (run_mode_transition,
-            //      request_mode_transition) and are deliberately sticky; this bypasses that intent
-            //      at the epoch boundary only.
-            //   2. Can a node legitimately be `in_committee && !observer_flag && prior==Observer`
-            //      for a reason OTHER than "just staked in" (e.g. was kicked out then re-added
-            //      within one process lifetime, stale committee view)? If so, is CvvInactive still
-            //      correct, or could it start voting before it should?
-            //   3. Interaction with the DynamicCommitteeSize hardfork: promotion here is NOT
-            //      fork-gated, but the committee-growth that puts the node `in_committee` IS.
-            //      Confirm they can't disagree across the fork boundary.
-            // ============================================================================
+            // Promote a dynamic observer just admitted to the committee, instead of leaving it
+            // Observer forever. Reaching here means in_committee, !observer_flag, !initial_epoch,
+            // prior==Observer — the only path is "was not-in-committee last epoch, just staked in."
+            // Join as CvvInactive to catch up on the boundary without proposing/voting; the bridge
+            // subscriber requests CvvActive once synced. (Staying Observer would leave a silent
+            // committee member — counted toward quorum but never certifying — stalling consensus.)
             NodeMode::Observer => (NodeMode::CvvInactive, "joined-committee"),
         };
     }

--- a/crates/middleware/orchestrator/src/epoch_manager/network.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/network.rs
@@ -45,7 +45,35 @@ pub(crate) fn decide_node_mode(
         return match prior_mode {
             NodeMode::CvvActive => (NodeMode::CvvActive, "prior-mode-active"),
             NodeMode::CvvInactive => (NodeMode::CvvInactive, "prior-mode-inactive"),
-            NodeMode::Observer => (NodeMode::Observer, "prior-mode-observer"),
+            // ============================================================================
+            // XXX / REVISIT — REVIEWER PLEASE SCRUTINIZE THIS ARM
+            // ============================================================================
+            // NEW behavior: promote a dynamic observer that has just been admitted to the
+            // committee, instead of leaving it Observer forever ("prior-mode-observer").
+            //
+            // Reaching here means: in the on-chain committee (`in_committee`), NOT a configured
+            // observer (`observer_flag` handled above), yet still running as Observer — i.e. a node
+            // that was following as a dynamic observer and has just been admitted to the committee
+            // (e.g. freshly staked). Join as CvvInactive so it catches up on the boundary WITHOUT
+            // proposing/voting yet; the bridge subscriber then requests CvvActive once synced.
+            // Staying Observer here leaves a silent committee member — counted toward quorum but
+            // never proposing/certifying — which stalls consensus (observed: total chain stall
+            // when a staked node stayed Observer).
+            //
+            // REVISIT — open questions the reviewer should weigh in on:
+            //   1. Is `decide_node_mode` the right layer, vs. an explicit stake→promote signal? Two
+            //      other Observer-stickiness guards exist (run_mode_transition,
+            //      request_mode_transition) and are deliberately sticky; this bypasses that intent
+            //      at the epoch boundary only.
+            //   2. Can a node legitimately be `in_committee && !observer_flag && prior==Observer`
+            //      for a reason OTHER than "just staked in" (e.g. was kicked out then re-added
+            //      within one process lifetime, stale committee view)? If so, is CvvInactive still
+            //      correct, or could it start voting before it should?
+            //   3. Interaction with the DynamicCommitteeSize hardfork: promotion here is NOT
+            //      fork-gated, but the committee-growth that puts the node `in_committee` IS.
+            //      Confirm they can't disagree across the fork boundary.
+            // ============================================================================
+            NodeMode::Observer => (NodeMode::CvvInactive, "joined-committee"),
         };
     }
     if has_local_history {

--- a/crates/middleware/orchestrator/src/tests/epoch_transition_tests.rs
+++ b/crates/middleware/orchestrator/src/tests/epoch_transition_tests.rs
@@ -2407,6 +2407,30 @@ fn test_decide_mode_observer_flag() {
     assert_eq!(reason, "observer-flag");
 }
 
+/// A dynamic observer that gets staked into the committee mid-process must promote, not stay
+/// Observer. It was following as an observer (`prior_mode = Observer`), is NOT a configured
+/// observer (`observer_flag = false`), and is now in the on-chain committee (`in_committee = true`)
+/// at a live epoch boundary (`initial_epoch = false`). It must join as CvvInactive to catch up —
+/// the bridge subscriber then requests CvvActive once synced. Leaving it Observer makes it a silent
+/// committee member (counted toward quorum but never proposing/certifying), which stalls consensus.
+#[test]
+fn test_decide_mode_observer_joins_committee_on_stake() {
+    let (mode, reason) = decide_node_mode(
+        true,               // in_committee (just staked in on-chain)
+        false,              // observer_flag (NOT a configured observer)
+        None,               // no explicit transition
+        false,              // live epoch boundary within the running process
+        NodeMode::Observer, // was following as a dynamic observer
+        true,               // has_local_history (followed the chain)
+    );
+    assert_eq!(
+        mode,
+        NodeMode::CvvInactive,
+        "newly-staked observer must join & catch up, not stay silent"
+    );
+    assert_eq!(reason, "joined-committee");
+}
+
 /// Chaos test scenario 4 reproduction: rapid flapping at epoch boundary.
 ///
 /// V4 enters epoch 4 after epoch 3 boundary. prime_consensus does

--- a/crates/middleware/orchestrator/src/tests/epoch_transition_tests.rs
+++ b/crates/middleware/orchestrator/src/tests/epoch_transition_tests.rs
@@ -2431,6 +2431,27 @@ fn test_decide_mode_observer_joins_committee_on_stake() {
     assert_eq!(reason, "joined-committee");
 }
 
+/// The promotion fires regardless of local history: a node staked into the committee that never
+/// built local history (`has_local_history = false`) must still join as CvvInactive — it needs to
+/// catch up from peers, not boot CvvActive and start proposing before it has any chain state.
+#[test]
+fn test_decide_mode_observer_joins_committee_on_stake_no_history() {
+    let (mode, reason) = decide_node_mode(
+        true,               // in_committee (just staked in on-chain)
+        false,              // observer_flag (NOT a configured observer)
+        None,               // no explicit transition
+        false,              // live epoch boundary within the running process
+        NodeMode::Observer, // was following as a dynamic observer
+        false,              // has_local_history = false (never built local history)
+    );
+    assert_eq!(
+        mode,
+        NodeMode::CvvInactive,
+        "a staked observer with no local history must catch up, not go CvvActive"
+    );
+    assert_eq!(reason, "joined-committee");
+}
+
 /// Chaos test scenario 4 reproduction: rapid flapping at epoch boundary.
 ///
 /// V4 enters epoch 4 after epoch 3 boundary. prime_consensus does


### PR DESCRIPTION
**The problem**

A node that joins the on-chain committee while running as a dynamic observer
stayed Observer forever — `decide_node_mode` carried `prior-mode-observer` on
every non-initial epoch. It counted toward quorum but never proposed/certified,
so the DAG stalled (silent committee member).

**What's changed**

`decide_node_mode`: when a node is in-committee, is not a configured observer
(`observer_flag`), yet still Observer, promote it to `CvvInactive`
("joined-committee") to catch up on the epoch boundary; the bridge subscriber
requests `CvvActive` once synced. Configured observers and non-committee
followers are unaffected. Adds `test_decide_mode_observer_joins_committee_on_stake`.