### PR TITLE
chore(toolchain): add rust-analyzer component so VS Code uses a matching analyzer

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,5 +3,5 @@
 # README.md, and the toolchain installed in CI (.github/workflows/pr.yaml).
 [toolchain]
 channel = "1.91.0"
-components = ["rustfmt", "rust-src", "clippy"]
+components = ["rustfmt", "rust-src", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
**The problem**

Opening the repo in VS Code shows:

> Your workspace uses a rust-toolchain file with a toolchain too old for the
> extension shipped rust-analyzer to work properly. Consider adding the
> rust-analyzer component to the toolchain file to use a compatible
> rust-analyzer version. 

**What's changed**

Adds `rust-analyzer` to `components` in `rust-toolchain.toml`.
We pin Rust 1.91.0, and the analyzer bundled with the extension has moved ahead
of it. With the component declared, rustup provides the 1.91.0-matching
rust-analyzer and the extension uses that instead — no warning, and the analyzer
stays in lockstep on future toolchain bumps. This is the fix the extension
itself recommends.