### PR TITLE
fix(ci): chaos harness nodes using storage v2

### DIFF
--- a/crates/testing/chaos-framework/src/cluster.rs
+++ b/crates/testing/chaos-framework/src/cluster.rs
@@ -3,9 +3,10 @@
 use crate::node::NodeHandle;
 use escargot::CargoRun;
 use std::{
-    net::TcpListener,
+    net::{TcpListener, UdpSocket},
     path::{Path, PathBuf},
     sync::OnceLock,
+    time::{Duration, Instant},
 };
 use tracing::info;
 
@@ -14,6 +15,9 @@ pub const DEFAULT_VALIDATOR_COUNT: usize = 4;
 
 /// Default passphrase for test nodes.
 pub const TEST_PASSPHRASE: &str = "chaos_test";
+
+/// How long `spawn` waits for every validator to come up and start advancing.
+const STARTUP_HEALTH_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Only compile the main binary once across all tests.
 static CHAOS_BINARY: OnceLock<CargoRun> = OnceLock::new();
@@ -56,7 +60,8 @@ pub struct TestCluster {
 impl TestCluster {
     /// Spawn a new test cluster with `count` validators.
     ///
-    /// This runs the genesis ceremony and starts all validator processes.
+    /// Runs the genesis ceremony, starts all validator processes, and returns only
+    /// once every one of them is alive, serving RPC, and advancing.
     pub fn spawn(count: usize) -> eyre::Result<Self> {
         // The genesis ceremony below is hardcoded to build exactly
         // DEFAULT_VALIDATOR_COUNT validator directories. A different count would
@@ -72,8 +77,17 @@ impl TestCluster {
         let base_dir = tmp_dir.path().to_path_buf();
         let passphrase = TEST_PASSPHRASE.to_string();
 
+        // Reserve the consensus p2p ports before the ceremony and hold them until the
+        // nodes are about to start. Left to itself the keytool picks each primary/worker
+        // address with a bind-then-free helper, one address at a time, so two nodes can
+        // be handed the SAME udp port — the loser dies at startup with "Address already
+        // in use", the cluster runs at 3/4 (exactly quorum), and the first kill silently
+        // drops consensus below 2f+1 and halts the chain.
+        // Two ports per node (primary + worker), plus two for the observer.
+        let p2p_reservation = reserve_distinct_udp_ports((count + 1) * 2)?;
+
         // Run genesis ceremony.
-        e2e_tests_config_local_testnet(&base_dir, passphrase.clone())?;
+        e2e_tests_config_local_testnet(&base_dir, passphrase.clone(), &p2p_reservation.ports)?;
 
         let bin = get_binary();
         let mut validators = Vec::with_capacity(count);
@@ -82,13 +96,79 @@ impl TestCluster {
         // per validator hands back the SAME port each time (it binds then frees
         // immediately), so the second node failed with "address already in use".
         let rpc_ports = reserve_distinct_ports(count)?;
+
+        // Release the p2p ports so the nodes themselves can bind them.
+        drop(p2p_reservation);
+
         for (i, &rpc_port) in rpc_ports.iter().enumerate() {
             let node = NodeHandle::spawn_validator(i, bin, &base_dir, rpc_port, &passphrase);
             validators.push(node);
         }
 
+        let mut cluster = Self { validators, _tmp_dir: tmp_dir, base_dir, bin, passphrase };
+        cluster.wait_until_healthy(STARTUP_HEALTH_TIMEOUT)?;
+
         info!(target: "chaos", count, "test cluster spawned");
-        Ok(Self { validators, _tmp_dir: tmp_dir, base_dir, bin, passphrase })
+        Ok(cluster)
+    }
+
+    /// Wait until every validator is alive, serving RPC, and producing blocks.
+    ///
+    /// A cluster that comes up degraded otherwise looks healthy: the survivors keep
+    /// producing blocks at exactly quorum, and the first injected fault pushes
+    /// consensus below 2f+1. Gating here names the validator that never joined
+    /// instead of surfacing 60s into a scenario as "chain did not advance".
+    pub fn wait_until_healthy(&mut self, timeout: Duration) -> eyre::Result<()> {
+        let deadline = Instant::now() + timeout;
+        let mut first_seen: Vec<Option<u64>> = vec![None; self.validators.len()];
+        let mut advanced = vec![false; self.validators.len()];
+        let mut status: Vec<String> =
+            vec!["no RPC response yet".to_string(); self.validators.len()];
+
+        loop {
+            for i in 0..self.validators.len() {
+                if advanced[i] {
+                    continue;
+                }
+                if !self.validators[i].is_alive() {
+                    eyre::bail!(
+                        "validator {i} exited during startup — check its log for a bind \
+                         (\"Address already in use\") or genesis error"
+                    );
+                }
+                match crate::rpc::get_block_number(self.validators[i].rpc_url()) {
+                    Ok(height) => match first_seen[i] {
+                        Some(start) if height > start => advanced[i] = true,
+                        Some(start) => status[i] = format!("stuck at block {start}"),
+                        None => {
+                            first_seen[i] = Some(height);
+                            status[i] = format!("at block {height}, not advancing yet");
+                        }
+                    },
+                    Err(e) => status[i] = format!("RPC error: {e}"),
+                }
+            }
+
+            if advanced.iter().all(|&ok| ok) {
+                return Ok(());
+            }
+
+            if Instant::now() >= deadline {
+                let stalled: Vec<String> = advanced
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, &ok)| !ok)
+                    .map(|(i, _)| format!("validator {i} ({})", status[i]))
+                    .collect();
+                eyre::bail!(
+                    "cluster unhealthy after {timeout:?}: {} — refusing to inject faults \
+                     into a cluster that is already below full participation",
+                    stalled.join(", ")
+                );
+            }
+
+            std::thread::sleep(Duration::from_secs(1));
+        }
     }
 
     /// Spawn a default 4-validator cluster.
@@ -185,11 +265,39 @@ fn reserve_distinct_ports(n: usize) -> eyre::Result<Vec<u16>> {
     Ok(ports)
 }
 
+/// `n` distinct ephemeral UDP ports, held open until the reservation is dropped.
+///
+/// Unlike [`reserve_distinct_ports`], the sockets stay bound: the genesis ceremony
+/// bakes these ports into each `node-info.yaml` and the nodes only bind them later,
+/// so holding them keeps anything else on the host from taking one in between.
+struct UdpPortReservation {
+    /// Kept alive purely to hold the ports; dropping this frees them.
+    _sockets: Vec<UdpSocket>,
+    ports: Vec<u16>,
+}
+
+/// Reserve `n` distinct ephemeral UDP ports on localhost simultaneously.
+fn reserve_distinct_udp_ports(n: usize) -> eyre::Result<UdpPortReservation> {
+    let sockets: Vec<UdpSocket> =
+        (0..n).map(|_| UdpSocket::bind("127.0.0.1:0")).collect::<Result<_, _>>()?;
+    let ports =
+        sockets.iter().map(|s| Ok(s.local_addr()?.port())).collect::<eyre::Result<Vec<u16>>>()?;
+    Ok(UdpPortReservation { _sockets: sockets, ports })
+}
+
 /// Run the genesis ceremony to configure a local testnet.
 ///
 /// This replicates the logic from `e2e_tests::config_local_testnet` but is
 /// self-contained to avoid a direct dependency on the e2e-tests crate.
-fn e2e_tests_config_local_testnet(temp_path: &Path, passphrase: String) -> eyre::Result<()> {
+///
+/// `p2p_ports` holds one primary and one worker port per node, in order: validator
+/// 1's primary and worker, validator 2's, ..., then the observer's. They are passed
+/// explicitly so no two nodes can be assigned the same port (see `spawn`).
+fn e2e_tests_config_local_testnet(
+    temp_path: &Path,
+    passphrase: String,
+    p2p_ports: &[u16],
+) -> eyre::Result<()> {
     use clap::Parser as _;
     use rayls_infrastructure_types::test_utils::CommandParser;
     use rayls_network_cli::{genesis::GenesisArgs, keytool::KeyArgs};
@@ -201,19 +309,34 @@ fn e2e_tests_config_local_testnet(temp_path: &Path, passphrase: String) -> eyre:
         ("validator-4", "0x4444444444444444444444444444444444444444"),
     ];
 
+    // Validators plus the observer, two ports each.
+    let expected_ports = (validators.len() + 1) * 2;
+    eyre::ensure!(
+        p2p_ports.len() == expected_ports,
+        "expected {expected_ports} p2p ports, got {}",
+        p2p_ports.len()
+    );
+    let multiaddr = |port: u16| format!("/ip4/127.0.0.1/udp/{port}/quic-v1");
+
     // Create shared genesis directory.
     let shared_genesis_dir = temp_path.join("shared-genesis");
     let copy_path = shared_genesis_dir.join("genesis/validators");
     std::fs::create_dir_all(&copy_path)?;
 
-    for (v, addr) in validators.iter() {
+    for (i, (v, addr)) in validators.iter().enumerate() {
         let dir = temp_path.join(v);
+        let primary_addr = multiaddr(p2p_ports[i * 2]);
+        let worker_addr = multiaddr(p2p_ports[i * 2 + 1]);
         let keys_command = CommandParser::<KeyArgs>::parse_from([
             "rl",
             "generate",
             "validator",
             "--address",
             addr,
+            "--external-primary-addr",
+            primary_addr.as_str(),
+            "--external-worker-addrs",
+            worker_addr.as_str(),
         ]);
         keys_command.args.execute(dir.clone(), passphrase.clone())?;
         std::fs::copy(dir.join("node-info.yaml"), copy_path.join(format!("{v}.yaml")))?;
@@ -221,12 +344,18 @@ fn e2e_tests_config_local_testnet(temp_path: &Path, passphrase: String) -> eyre:
 
     // Create observer config.
     let dir = temp_path.join("observer");
+    let observer_primary_addr = multiaddr(p2p_ports[validators.len() * 2]);
+    let observer_worker_addr = multiaddr(p2p_ports[validators.len() * 2 + 1]);
     let keys_command = CommandParser::<KeyArgs>::parse_from([
         "rl",
         "generate",
         "observer",
         "--address",
         "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        "--external-primary-addr",
+        observer_primary_addr.as_str(),
+        "--external-worker-addrs",
+        observer_worker_addr.as_str(),
     ]);
     keys_command.args.execute(dir, passphrase)?;
 

--- a/crates/testing/chaos-framework/src/node.rs
+++ b/crates/testing/chaos-framework/src/node.rs
@@ -201,7 +201,9 @@ fn spawn_validator_process(
         .arg("--ipcdisable")
         .arg("--http")
         .arg("--http.port")
-        .arg(format!("{rpc_port}"));
+        .arg(format!("{rpc_port}"))
+        // v1 (plain) storage is no longer supported -- the node refuses to start without this
+        .arg("--storage.v2");
 
     command.spawn().expect("failed to spawn validator process")
 }
@@ -231,7 +233,9 @@ fn spawn_observer_process(
         .arg("--ipcdisable")
         .arg("--http")
         .arg("--http.port")
-        .arg(format!("{rpc_port}"));
+        .arg(format!("{rpc_port}"))
+        // v1 (plain) storage is no longer supported -- the node refuses to start without this
+        .arg("--storage.v2");
 
     command.spawn().expect("failed to spawn observer process")
 }


### PR DESCRIPTION
Starts the chaos harness nodes with `--storage.v2`, reserves distinct p2p ports for every node so a startup port collision cannot silently leave the cluster below quorum, and gates cluster startup on all validators advancing.