### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 for GHSA-4w2j-m93h-cj5j

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3553,7 +3553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7499,9 +7499,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -11577,7 +11577,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11701,7 +11701,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12608,7 +12608,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,11 @@ dashmap = "6.0.1"
 parking_lot = "0.12.3"
 scopeguard = "1.1"
 uuid = { version = "1.1.2", features = ["v4", "fast-rng"] }
-quinn-proto = "0.11.8"
+# Floor raised to 0.11.15 for GHSA-4w2j-m93h-cj5j (unbounded out-of-order
+# stream reassembly -> remote memory exhaustion). Reached transitively via
+# libp2p-quic -> quinn; keep this floor so a re-resolve can't pick a fixed-in
+# 0.11.x below the patch.
+quinn-proto = "0.11.15"
 derive_builder = "0.12.0"
 roaring = "0.10.1"
 serde_with = { version = "3.21.0", features = ["hex"] }

--- a/crates/testing/fuzz-targets/fuzz/Cargo.lock
+++ b/crates/testing/fuzz-targets/fuzz/Cargo.lock
@@ -2680,7 +2680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6421,9 +6421,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -9898,7 +9898,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10258,11 +10258,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -10277,9 +10278,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",


### PR DESCRIPTION
## Summary

- Bumps `quinn-proto` **0.11.14 → 0.11.15** to clear [GHSA-4w2j-m93h-cj5j](https://github.com/advisories/GHSA-4w2j-m93h-cj5j) (HIGH, CVSS 7.5, CWE-770): versions `<0.11.15` don't bound buffer overhead when reassembling out-of-order stream fragments, so a malicious peer can drive **remote memory exhaustion**. It reaches us on exactly one path — `libp2p-quic 0.13.0` → `quinn 0.11.9` → `quinn-proto` — and `quinn` itself needs no bump.
- Also bumps the pin in the **isolated `cargo-fuzz` lockfile** (`crates/testing/fuzz-targets/fuzz/Cargo.lock`), which still held 0.11.14. It only surfaces when that file is scanned directly, not via Trivy's repo-root walk, so the Security Scan gate was blind to it.
- Raises the declared workspace floor `quinn-proto = "0.11.8"` → `"0.11.15"` so a future re-resolve can't select a pre-patch 0.11.x. (That entry is currently inert — no member crate consumes it — so this is a guard, not a resolution change.)

No tracking issue; surfaced by the Trivy scan. Advisory: GHSA-4w2j-m93h-cj5j / RUSTSEC-2026-0185.

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

Ticked for consensus because the patched crate *is* the QUIC transport under `crates/consensus/network` (via `libp2p-quic`). No first-party source changed — this PR is lockfiles plus one manifest floor.

## Breaking / compatibility

**No API breakage, and no coordination required** — no hardfork, network upgrade, contract migration, or config change. Nothing in the workspace names `quinn-proto` in code (the only mention is a doc-comment cross-reference at `crates/infrastructure/config/src/network.rs:264`), and every item the patch touches is crate-private: `Assembler::insert` is `pub(super)`, `TooManyChunks` and `QlogSink` are `pub(crate)`, and the removed `instant_saturating_sub` was a private free fn. Public exports (`QlogStream`, `QlogConfig`) are unchanged. No wire-format or consensus-rule change, so 0.11.14 and 0.11.15 nodes interoperate — this takes effect on the next build + rolling restart, no lockstep needed.

`quinn-proto`'s MSRV moves **1.74.1 → 1.85**, comfortably below our pinned 1.91.0.

Four runtime behavior changes ride along in the patch release. Reviewers should be aware of the first two:

1. **Saturated servers now drop Initial packets silently** instead of replying `CONNECTION_REFUSED`. When `cids_exhausted()` or `incoming_buffers.len() >= max_incoming`, the endpoint bails before deriving initial keys. A peer dialing a saturated node now sees a **handshake timeout rather than a fast refusal** — with our `handshake_timeout: 65s` that's a 65-second hang where it previously failed immediately. This is the most likely operationally visible difference.
2. **The fix is a hard, non-configurable 1024-chunk cap** on stream reassembly. It trips only after a defragmentation pass when over-allocation exceeds `max(32 KiB, buffered × 3/2)`, and on trip closes the **whole connection** with `INTERNAL_ERROR("too many gaps in stream buffer")` — not just the offending stream. The same cap now guards the CRYPTO stream during handshake. Worth noting because our `QuicConfig` sets `max_stream_data = 50 MiB` / `max_connection_data = 100 MiB`, far above typical defaults, so a single stream can hold ~43k packets in flight. Legitimately exceeding 1024 *disjoint* post-defragmentation gaps is unlikely but not impossible under extreme loss — worth watching in Nightly Chaos packet-loss scenarios. libp2p redials, so it is recoverable.
3. **CUBIC loss response corrected to RFC 9438** — `ssthresh` now derives from the pre-loss window rather than the already-reduced `W_max`, so fast convergence no longer double-reduces. Cubic is quinn's default controller, so this applies to us: slightly less aggressive backoff after loss.
4. **A latent panic is gone.** Loss detection used `now.checked_sub(loss_delay).unwrap()`, which could panic when `loss_delay` exceeded time since the `Instant` epoch; it is now saturating arithmetic. A genuine robustness win for long-running validators.

Unrelated side effects of re-resolution, both benign: several Windows-only crates re-unified `windows-sys 0.52.0 → 0.59.0` (irrelevant to our Linux/macOS targets), and in the fuzz lockfile cargo repaired two stale pins (`serde_with 3.18.0 → 3.21.0`, `syn 1 → 2`). That fuzz lock was already invalid — `serde_with 3.18.0` never satisfied the workspace's `^3.21.0` — so Nightly Fuzz was silently re-resolving on every run regardless.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean; only pre-existing warnings (unused crate deps), nothing quinn-related.
- [x] `cargo test --workspace --exclude rayls-execution-faucet --exclude e2e-tests -- --quiet --test-threads 1` (the CI default leg) — **exit 0: 668 passed, 0 failed, 28 ignored** across 58 binaries, including all 103 `rayls-consensus-network` tests, which is the crate that owns the QUIC transport.
- [x] CI-equivalent Trivy gate (`trivy fs --scanners vuln,misconfig --ignore-unfixed --severity HIGH,CRITICAL --exit-code 1 .`) — **exit 0**, zero findings across all 9 scanned targets. Confirmed the fuzz lockfile is clear too by scanning it directly.
- [x] `cargo deny check advisories` — errors drop 25 → 24: exactly the quinn finding removed, none introduced. (It still fails overall on ~24 pre-existing advisories in webpki/rustls/hickory/bincode etc.; cargo-deny isn't wired into any workflow, so it is not gating.)
- [x] Both lockfiles verified `--locked`-consistent via `cargo metadata --locked`.
- [x] Reviewed the full 0.11.14→0.11.15 source diff (20 files) from the local registry to confirm the API-visibility and behavior claims above rather than relying on release notes.

Upstream nit spotted while reviewing the diff, **not blocking and not affecting us**: in `qlog.rs:110` the new loss-trigger classification has its operands reversed — `info.time_sent.saturating_duration_since(now)` saturates to zero since `time_sent <= now`, so it always reports `ReorderingThreshold`. `mod.rs:1691` uses the correct `now.saturating_duration_since(info.time_sent)` form. It is cosmetic (a qlog trace field), sits behind `#[cfg(feature = "qlog")]`, and the `qlog` crate is absent from our lockfile, so it is compiled out for us. Worth filing upstream.
