### PR TITLE
fix: unify the ban predicate across admission and disconnect

### DIFF
--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -4,8 +4,12 @@
 //! manager to take. Some actions are propagated up to the swarm level and affect other behaviors.
 
 use super::{
-    banned::BannedPeers, peer::Peer, score::ReputationUpdate, status::ConnectionStatus,
-    types::ConnectionDirection, PeerExchangeMap, Penalty,
+    banned::BannedPeers,
+    peer::Peer,
+    score::ReputationUpdate,
+    status::{ConnectionStatus, DisconnectReason},
+    types::ConnectionDirection,
+    PeerExchangeMap, Penalty,
 };
 use crate::{
     error::NetworkError,
@@ -27,6 +31,9 @@ use tracing::{debug, error, trace, warn};
 #[cfg(test)]
 #[path = "../tests/peers.rs"]
 mod peers;
+#[cfg(test)]
+#[path = "../tests/reputation_invariants.rs"]
+mod reputation_invariants;
 
 /// State for known peers.
 ///
@@ -354,8 +361,8 @@ impl AllPeers {
             NewConnectionStatus::Disconnected => {
                 self.handle_disconnected_transition(peer_id, current_status)
             }
-            NewConnectionStatus::Disconnecting { banned } => {
-                self.handle_disconnecting_transition(peer_id, current_status, banned)
+            NewConnectionStatus::Disconnecting { reason } => {
+                self.handle_disconnecting_transition(peer_id, current_status, reason)
             }
             NewConnectionStatus::Banned => self.handle_banned_transition(peer_id, current_status),
             NewConnectionStatus::Unbanned => {
@@ -444,7 +451,7 @@ impl AllPeers {
         match current_status {
             ConnectionStatus::Banned { .. } => {}
             ConnectionStatus::Disconnected { .. } => {}
-            ConnectionStatus::Disconnecting { banned } if banned => {
+            ConnectionStatus::Disconnecting { reason } if reason.bans_peer() => {
                 return self.handle_disconnected_and_banned(peer_id);
             }
             ConnectionStatus::Disconnecting { .. } => {
@@ -509,11 +516,11 @@ impl AllPeers {
         &mut self,
         peer_id: &PeerId,
         current_state: ConnectionStatus,
-        banned: bool,
+        reason: DisconnectReason,
     ) -> PeerAction {
         // set the peer to disconnecting state
         if let Some(peer) = self.peers.get_mut(peer_id) {
-            peer.set_connection_status(ConnectionStatus::Disconnecting { banned });
+            peer.set_connection_status(ConnectionStatus::Disconnecting { reason });
         }
 
         match current_state {
@@ -527,9 +534,13 @@ impl AllPeers {
                 error!(target: "peer-manager", ?peer_id, "disconnecting from a banned peer - banned peer should already be disconnected");
             }
             ConnectionStatus::Connected { .. } | ConnectionStatus::Dialing { .. } => {
-                // support discovery with peer exchange if the target number of peers is reached
-                let action =
-                    if banned { PeerAction::Disconnect } else { PeerAction::DisconnectWithPX };
+                // only a healthy peer evicted for connection limits is worth helping find
+                // replacements; a peer this node penalized does not receive its peer table
+                let action = if reason.shares_peers() {
+                    PeerAction::DisconnectWithPX
+                } else {
+                    PeerAction::Disconnect
+                };
                 return action;
             }
             _ => {}
@@ -563,7 +574,9 @@ impl AllPeers {
                 ConnectionStatus::Disconnecting { .. } => {
                     // ban the peer once the disconnection process completes
                     debug!(target: "peer-manager", ?peer_id, "banning peer that is currently disconnecting");
-                    peer.set_connection_status(ConnectionStatus::Disconnecting { banned: true });
+                    peer.set_connection_status(ConnectionStatus::Disconnecting {
+                        reason: DisconnectReason::Banned,
+                    });
                     PeerAction::NoAction
                 }
                 ConnectionStatus::Banned { .. } => {
@@ -572,7 +585,9 @@ impl AllPeers {
                     PeerAction::Ban(peer.filter_new_ips_to_ban(&already_banned_ips))
                 }
                 ConnectionStatus::Connected { .. } | ConnectionStatus::Dialing { .. } => {
-                    peer.set_connection_status(ConnectionStatus::Disconnecting { banned: true });
+                    peer.set_connection_status(ConnectionStatus::Disconnecting {
+                        reason: DisconnectReason::Banned,
+                    });
                     PeerAction::Disconnect
                 }
                 ConnectionStatus::Unknown => {
@@ -615,12 +630,12 @@ impl AllPeers {
 
                     return PeerAction::Unban(peer.known_ip_addresses().collect());
                 }
-                ConnectionStatus::Disconnecting { banned } => {
+                ConnectionStatus::Disconnecting { reason } => {
                     debug!(target: "peer-manager", ?peer_id, "unbanning disconnecting peer");
-                    if banned {
-                        // set disconnecting status false
+                    if reason.bans_peer() {
+                        // the disconnect still completes, but no longer as a ban
                         peer.set_connection_status(ConnectionStatus::Disconnecting {
-                            banned: false,
+                            reason: DisconnectReason::Penalized,
                         });
                     }
                 }
@@ -868,9 +883,9 @@ impl AllPeers {
             self.upsert_peer(bls_key, pubkey, addr.clone());
 
             match status {
-                ConnectionStatus::Disconnecting { banned } => {
+                ConnectionStatus::Disconnecting { reason } => {
                     // unban peer
-                    if banned {
+                    if reason.bans_peer() {
                         warn!(target: "peer-manager", ?peer_id, "unbanning committee member that was disconnecting pending ban");
                         let action =
                             self.update_connection_status(&peer_id, NewConnectionStatus::Unbanned);
@@ -941,7 +956,9 @@ fn new_reputation_status(
         }
         Reputation::Disconnected => {
             if peer.connection_status().is_connected_or_dialing() {
-                Some(NewConnectionStatus::Disconnecting { banned: true })
+                // the score crossed the disconnect threshold, not the ban threshold, so the
+                // disconnect must not complete into a ban
+                Some(NewConnectionStatus::Disconnecting { reason: DisconnectReason::Penalized })
             } else {
                 warn!(target: "peer-manager", ?peer_id, ?prior_reputation, "process_penalty for disconnected peer");
                 Some(NewConnectionStatus::Disconnected)

--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -676,10 +676,15 @@ impl AllPeers {
         self.banned_peers.ip_banned(ip)
     }
 
-    /// Boolean indicating if a peer id is banned or associated with any ip addresses.
+    /// Boolean indicating the peer's own score or one of its ip addresses is banned.
+    ///
+    /// This is one ingredient of the admission verdict, not the verdict itself:
+    /// [`super::PeerManager::peer_banned`] is the only caller, and it owns the committee exemption
+    /// and the temporary-ban cache. Calling this directly from a connection gate skips both.
+    ///
     /// NOTE: the peer can still be in a connected status but pending a ban, so the connection
     /// status is not used.
-    pub(super) fn peer_banned(&self, peer_id: &PeerId) -> bool {
+    pub(super) fn score_or_ip_banned(&self, peer_id: &PeerId) -> bool {
         self.peers.get(peer_id).is_some_and(|peer| {
             peer.reputation().banned() || peer.known_ip_addresses().any(|ip| self.ip_banned(&ip))
         })

--- a/crates/consensus/network/src/peers/behavior.rs
+++ b/crates/consensus/network/src/peers/behavior.rs
@@ -16,6 +16,10 @@ use libp2p::{
 use std::task::{Context, Poll};
 use tracing::{debug, error, info, trace};
 
+#[cfg(test)]
+#[path = "../tests/behavior.rs"]
+mod behavior_tests;
+
 impl NetworkBehaviour for PeerManager {
     type ConnectionHandler = ConnectionHandler;
     type ToSwarm = PeerEvent;
@@ -229,24 +233,30 @@ impl PeerManager {
 
         // register peers as connected by this point
         // even if the peer is to be immediately disconnected with peer-exchange (PX)
-        let multiaddr = match endpoint {
-            ConnectedPoint::Listener { send_back_addr, .. } => {
+        let (multiaddr, registered) = match endpoint {
+            ConnectedPoint::Listener { send_back_addr, .. } => (
+                send_back_addr.clone(),
                 self.register_peer_connection(
                     &peer_id,
                     ConnectionType::IncomingConnection { multiaddr: send_back_addr.clone() },
-                );
-                send_back_addr.clone()
-            }
-            ConnectedPoint::Dialer { address, .. } => {
+                ),
+            ),
+            ConnectedPoint::Dialer { address, .. } => (
+                address.clone(),
                 self.register_peer_connection(
                     &peer_id,
                     ConnectionType::OutgoingConnection { multiaddr: address.clone() },
-                );
-                address.clone()
-            }
+                ),
+            ),
         };
 
         // TODO: Issue #254 update metrics
+
+        // a peer this node refused to track must not be announced as connected, or the
+        // application routes requests to a peer the manager holds no state for
+        if !registered {
+            return;
+        }
 
         self.push_event(PeerEvent::PeerConnected(peer_id, multiaddr));
 

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -4,7 +4,7 @@ use super::{
     all_peers::AllPeers,
     cache::BannedPeerCache,
     score::init_peer_score_config,
-    status::NewConnectionStatus,
+    status::{DisconnectReason, NewConnectionStatus},
     types::{ConnectionDirection, ConnectionType, DialRequest, PeerAction},
     PeerEvent, PeerExchangeMap, Penalty,
 };
@@ -462,7 +462,7 @@ impl PeerManager {
         self.events.push_back(event);
         let action = self.peers.update_connection_status(
             &peer_id,
-            NewConnectionStatus::Disconnecting { banned: false },
+            NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
         );
 
         debug!(target: "peer-manager", ?action, "disconnect peer results in:");

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -473,14 +473,18 @@ impl PeerManager {
     ///
     /// Returns a boolean if the peer was successfully registered. This is the initial
     /// method to call for registering a new peer through dialing or incoming connections.
+    ///
+    /// A refusal closes the connection: the admission gates share this method's predicate, so a
+    /// peer reaching here banned means the ban landed mid-handshake, and leaving that connection
+    /// open would route application traffic to a peer this manager does not track.
     pub(super) fn register_peer_connection(
         &mut self,
         peer_id: &PeerId,
         connection: ConnectionType,
     ) -> bool {
         if self.peer_banned(peer_id) {
-            // log error if the peer is banned
             error!(target: "peer-manager", ?peer_id, "connected with banned peer");
+            self.push_event(PeerEvent::DisconnectPeer(*peer_id));
             return false;
         }
 

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -379,7 +379,7 @@ impl PeerManager {
             ?peer_id,
             "checking if peer banned"
         );
-        temp_banned || self.peers.peer_banned(peer_id)
+        temp_banned || self.peers.score_or_ip_banned(peer_id)
     }
 
     #[cfg(test)]
@@ -478,7 +478,7 @@ impl PeerManager {
         peer_id: &PeerId,
         connection: ConnectionType,
     ) -> bool {
-        if self.peers.peer_banned(peer_id) {
+        if self.peer_banned(peer_id) {
             // log error if the peer is banned
             error!(target: "peer-manager", ?peer_id, "connected with banned peer");
             return false;

--- a/crates/consensus/network/src/peers/peer.rs
+++ b/crates/consensus/network/src/peers/peer.rs
@@ -264,7 +264,7 @@ impl Peer {
     /// of being banned (connected/disconnecting).
     pub(super) fn can_dial(&self) -> bool {
         match self.connection_status {
-            ConnectionStatus::Disconnecting { banned } => !banned,
+            ConnectionStatus::Disconnecting { reason } => !reason.bans_peer(),
             ConnectionStatus::Connected { .. }
             | ConnectionStatus::Dialing { .. }
             | ConnectionStatus::Banned { .. } => false,

--- a/crates/consensus/network/src/peers/status.rs
+++ b/crates/consensus/network/src/peers/status.rs
@@ -6,6 +6,39 @@ use super::types::ConnectionDirection;
 use libp2p::Multiaddr;
 use std::time::Instant;
 
+/// Why this node is disconnecting from a peer.
+///
+/// The reason decides two independent things: whether this node shares its peer table on the way
+/// out, and whether the completed disconnect becomes a ban. A single boolean cannot express the
+/// middle case, where a peer has earned a disconnect but not a ban.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum DisconnectReason {
+    /// Connection limits were reached and this peer was chosen to make room.
+    ///
+    /// The peer is healthy, so peer-exchange data is shared to help it find other peers.
+    ExcessPeers,
+    /// The peer's score crossed the disconnect threshold.
+    ///
+    /// No peer exchange, and no ban: the score is expected to decay back into range.
+    Penalized,
+    /// The peer's score crossed the ban threshold.
+    ///
+    /// No peer exchange, and the disconnect completes into a ban.
+    Banned,
+}
+
+impl DisconnectReason {
+    /// Whether the completed disconnect bans the peer.
+    pub(super) fn bans_peer(&self) -> bool {
+        matches!(self, Self::Banned)
+    }
+
+    /// Whether to share peer-exchange data with the peer on the way out.
+    pub(super) fn shares_peers(&self) -> bool {
+        matches!(self, Self::ExcessPeers)
+    }
+}
+
 /// Connection status of the peer.
 #[derive(Debug, Copy, Clone, Default)]
 pub(super) enum ConnectionStatus {
@@ -18,8 +51,8 @@ pub(super) enum ConnectionStatus {
     },
     /// The peer is in the process of disconnecing.
     Disconnecting {
-        // Indicates if the peer is banned after disconnection.
-        banned: bool,
+        /// Why the peer is being disconnected.
+        reason: DisconnectReason,
     },
     /// The peer has disconnected.
     Disconnected {
@@ -75,8 +108,9 @@ pub(super) enum NewConnectionStatus {
     },
     /// The peer is being disconnected.
     Disconnecting {
-        /// Whether the peer should be banned after the disconnect occurs.
-        banned: bool,
+        /// Why the peer is being disconnected, which decides peer exchange and whether the
+        /// completed disconnect bans the peer.
+        reason: DisconnectReason,
     },
     /// A peer is being dialed.
     Dialing,

--- a/crates/consensus/network/src/tests/behavior.rs
+++ b/crates/consensus/network/src/tests/behavior.rs
@@ -1,0 +1,42 @@
+//! Unit tests for the `NetworkBehaviour` connection hooks.
+
+use super::*;
+use crate::{common::create_multiaddr, Penalty};
+use rayls_infrastructure_config::PeerConfig;
+
+/// Build a `PeerManager` with the default operator config.
+fn peer_manager() -> PeerManager {
+    PeerManager::new(&PeerConfig::default())
+}
+
+/// An inbound connection endpoint from `addr`.
+fn inbound(addr: &Multiaddr) -> ConnectedPoint {
+    ConnectedPoint::Listener { local_addr: create_multiaddr(None), send_back_addr: addr.clone() }
+}
+
+/// A connection the manager refuses to track must not reach the application as connected, or the
+/// application routes requests to a peer that has no state in `AllPeers`.
+#[tokio::test]
+async fn refused_registration_is_not_announced_as_connected() {
+    let mut manager = peer_manager();
+    let addr = create_multiaddr(None);
+    let peer_id = PeerId::random();
+
+    // establish, ban, and disconnect so the peer is genuinely banned
+    manager.on_connection_established(peer_id, &inbound(&addr), 0);
+    manager.process_penalty(peer_id, Penalty::Fatal);
+    manager.register_disconnected(&peer_id);
+    while manager.poll_events().is_some() {}
+
+    // the ban landed mid-handshake, so the admission gate passed but registration refuses
+    manager.on_connection_established(peer_id, &inbound(&addr), 0);
+
+    let mut events = Vec::new();
+    while let Some(event) = manager.poll_events() {
+        events.push(event);
+    }
+    assert!(
+        !events.iter().any(|e| matches!(e, PeerEvent::PeerConnected(id, _) if *id == peer_id)),
+        "announced a peer the manager refused to track: {events:?}"
+    );
+}

--- a/crates/consensus/network/src/tests/peer_manager.rs
+++ b/crates/consensus/network/src/tests/peer_manager.rs
@@ -563,6 +563,74 @@ async fn test_is_validator() {
     assert!(!peer_manager.is_peer_validator(&random_peer_id));
 }
 
+/// The admission check and the registration check must use the same ban predicate. If the swarm
+/// admits a connection that `register_peer_connection` then refuses, the node holds an open
+/// connection it does not track.
+///
+/// This is the path that emits `error ... "connected with banned peer"` in production.
+#[tokio::test]
+async fn test_admitted_connection_is_registered_under_the_same_ban_predicate() {
+    let all_nodes = CommitteeFixture::builder(MemDatabase::default).build();
+    let mut authorities = all_nodes.authorities();
+    let authority_1 = authorities.next().expect("first authority");
+    let config = authority_1.consensus_config();
+    let mut peer_manager = PeerManager::new(config.network_config().peer_config());
+
+    let blocklisted = create_multiaddr(Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 200))));
+    let clean = create_multiaddr(Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 201))));
+
+    // the validator is connected, so its record exists and `upsert_peer` will take the
+    // `update_net` branch rather than filing addresses under `listening_addrs`
+    let validator: PeerId = config.key_config().primary_network_public_key().into();
+    assert!(peer_manager.register_peer_connection(
+        &validator,
+        ConnectionType::IncomingConnection { multiaddr: clean.clone() }
+    ));
+
+    // the validator advertises a second address in its record, and joins the committee
+    peer_manager.add_known_peer(
+        *authority_1.authority().protocol_key(),
+        NetworkInfo {
+            pubkey: config.key_config().primary_network_public_key(),
+            multiaddrs: vec![blocklisted.clone()],
+            timestamp: now(),
+        },
+    );
+    peer_manager.new_epoch(config.committee_pub_keys());
+    assert!(peer_manager.is_peer_validator(&validator), "precondition: validator is in committee");
+
+    // two unrelated peers are banned at the advertised address, blocklisting it
+    for _ in 0..2 {
+        let other = PeerId::random();
+        assert!(peer_manager.register_peer_connection(
+            &other,
+            ConnectionType::IncomingConnection { multiaddr: blocklisted.clone() }
+        ));
+        peer_manager.process_penalty(other, Penalty::Fatal);
+        peer_manager.register_disconnected(&other);
+    }
+
+    // the validator reconnects from its clean address. `sanitize_ip_addr` passes (that address is
+    // not blocklisted) and `PeerManager::peer_banned` exempts it as a committee member, so the
+    // swarm admits the connection.
+    assert!(
+        !peer_manager.peer_banned(&validator),
+        "precondition: the swarm admits this connection"
+    );
+
+    // INVARIANT: a connection the admission checks accepted is registered.
+    // CURRENT: `register_peer_connection` gates on `AllPeers::peer_banned`, which has no committee
+    // exemption, so it refuses and logs `error "connected with banned peer"` - while
+    // `on_connection_established` discards the `false` and still emits `PeerEvent::PeerConnected`.
+    assert!(
+        peer_manager.register_peer_connection(
+            &validator,
+            ConnectionType::IncomingConnection { multiaddr: clean }
+        ),
+        "the swarm admitted this connection but the peer manager refused to register it"
+    );
+}
+
 #[tokio::test]
 async fn test_register_outgoing_connection() {
     let mut peer_manager = create_test_peer_manager(None);

--- a/crates/consensus/network/src/tests/peer_manager.rs
+++ b/crates/consensus/network/src/tests/peer_manager.rs
@@ -1142,3 +1142,34 @@ async fn test_discovery_heartbeat_removes_banned_ip_peers() {
     // discovery peer with banned ip should be removed
     assert!(!peer_manager.discovery_peers.contains_key(&discovery_peer));
 }
+
+/// A connection this node refuses to track must be closed, not announced upward. Announcing it
+/// leaves the application routing consensus traffic to a peer the manager does not manage.
+#[tokio::test]
+async fn test_refused_registration_disconnects_instead_of_announcing_the_peer() {
+    let mut peer_manager = create_test_peer_manager(None);
+    let peer_id = register_peer(&mut peer_manager, None);
+
+    peer_manager.process_penalty(peer_id, Penalty::Fatal);
+    peer_manager.register_disconnected(&peer_id);
+    collect_all_events(&mut peer_manager);
+    assert!(peer_manager.peer_banned(&peer_id), "precondition: the peer is banned");
+
+    // the ban landed between the admission hook and this callback, which is the only way a banned
+    // peer reaches registration now that both gates share one predicate
+    let registered = peer_manager.register_peer_connection(
+        &peer_id,
+        ConnectionType::IncomingConnection { multiaddr: create_multiaddr(None) },
+    );
+    assert!(!registered, "precondition: registration refuses a banned peer");
+
+    let events = collect_all_events(&mut peer_manager);
+    assert!(
+        !events.iter().any(|e| matches!(e, PeerEvent::PeerConnected(id, _) if *id == peer_id)),
+        "announced a peer it refused to track"
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, PeerEvent::DisconnectPeer(id) if *id == peer_id)),
+        "refused registration left the connection open"
+    );
+}

--- a/crates/consensus/network/src/tests/peers.rs
+++ b/crates/consensus/network/src/tests/peers.rs
@@ -364,7 +364,7 @@ fn test_ip_and_peer_banned() {
     );
     let action = all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
     assert!(matches!(action, PeerAction::Ban(_)));
-    let banned = all_peers.peer_banned(&peer_id);
+    let banned = all_peers.score_or_ip_banned(&peer_id);
     assert!(!banned);
 
     // check if IP is banned
@@ -387,12 +387,12 @@ fn test_ip_and_peer_banned() {
     );
     let action = all_peers.update_connection_status(&new_peer, NewConnectionStatus::Disconnected);
     assert!(matches!(action, PeerAction::Ban(_)));
-    let banned = all_peers.peer_banned(&new_peer);
+    let banned = all_peers.score_or_ip_banned(&new_peer);
     assert!(banned);
 
     // Check if peer is banned
-    assert!(all_peers.peer_banned(&peer_id));
-    assert!(!all_peers.peer_banned(&PeerId::random()));
+    assert!(all_peers.score_or_ip_banned(&peer_id));
+    assert!(!all_peers.score_or_ip_banned(&PeerId::random()));
 }
 
 #[test]

--- a/crates/consensus/network/src/tests/peers.rs
+++ b/crates/consensus/network/src/tests/peers.rs
@@ -305,7 +305,7 @@ fn test_pruning_logic() {
         // Need to go through disconnecting first
         all_peers.update_connection_status(
             &peer_id,
-            NewConnectionStatus::Disconnecting { banned: true },
+            NewConnectionStatus::Disconnecting { reason: DisconnectReason::Banned },
         );
         all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
         all_peers.update_connection_status(&peer_id, NewConnectionStatus::Banned);
@@ -358,8 +358,10 @@ fn test_ip_and_peer_banned() {
             direction: ConnectionDirection::Incoming,
         },
     );
-    all_peers
-        .update_connection_status(&peer_id, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::Banned },
+    );
     let action = all_peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
     assert!(matches!(action, PeerAction::Ban(_)));
     let banned = all_peers.peer_banned(&peer_id);
@@ -379,8 +381,10 @@ fn test_ip_and_peer_banned() {
         },
     );
 
-    all_peers
-        .update_connection_status(&new_peer, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(
+        &new_peer,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::Banned },
+    );
     let action = all_peers.update_connection_status(&new_peer, NewConnectionStatus::Disconnected);
     assert!(matches!(action, PeerAction::Ban(_)));
     let banned = all_peers.peer_banned(&new_peer);
@@ -415,7 +419,7 @@ fn test_connected_peer_methods() {
 
     all_peers.update_connection_status(
         &disconnecting_peer_id,
-        NewConnectionStatus::Disconnecting { banned: false },
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
     );
 
     // Test connected_peer_ids
@@ -473,13 +477,15 @@ fn test_connected_to_disconnecting_transition() {
     );
 
     // Test Connected -> Disconnecting
-    let action = all_peers
-        .update_connection_status(&peer_id, NewConnectionStatus::Disconnecting { banned: false });
+    let action = all_peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
 
     assert!(matches!(action, PeerAction::DisconnectWithPX));
     let peer = all_peers.get_peer(&peer_id).unwrap();
-    assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnecting { banned }
-            if !(*banned)));
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnecting { reason }
+            if !reason.bans_peer()));
 }
 
 #[test]
@@ -496,8 +502,10 @@ fn test_disconnecting_to_disconnected_transition() {
             direction: ConnectionDirection::Incoming,
         },
     );
-    let action = all_peers
-        .update_connection_status(&peer_id, NewConnectionStatus::Disconnecting { banned: false });
+    let action = all_peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
     assert!(matches!(action, PeerAction::DisconnectWithPX));
 
     // Test Disconnecting -> Disconnected
@@ -607,8 +615,8 @@ fn test_connected_to_banned_transition() {
 
     assert!(matches!(action, PeerAction::Disconnect));
     let peer = all_peers.get_peer(&peer_id).unwrap();
-    assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnecting { banned }
-            if *banned));
+    assert!(matches!(peer.connection_status(), ConnectionStatus::Disconnecting { reason }
+            if reason.bans_peer()));
 }
 
 #[test]
@@ -629,7 +637,10 @@ fn test_ban_action_returns_only_unbanned_ips() {
             direction: ConnectionDirection::Incoming,
         },
     );
-    all_peers.update_connection_status(&peer1, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(
+        &peer1,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::Banned },
+    );
     all_peers.update_connection_status(&peer1, NewConnectionStatus::Disconnected);
 
     // second peer also from ip1 - this should trigger IP ban
@@ -641,7 +652,10 @@ fn test_ban_action_returns_only_unbanned_ips() {
             direction: ConnectionDirection::Incoming,
         },
     );
-    all_peers.update_connection_status(&peer2, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(
+        &peer2,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::Banned },
+    );
     all_peers.update_connection_status(&peer2, NewConnectionStatus::Disconnected);
 
     // at this point, ip1 should be banned (2 peers banned from this IP)
@@ -663,8 +677,10 @@ fn test_ban_action_returns_only_unbanned_ips() {
     );
 
     // disconnect and reconnect from ip1 to add it to known addresses
-    all_peers
-        .update_connection_status(&peer3, NewConnectionStatus::Disconnecting { banned: false });
+    all_peers.update_connection_status(
+        &peer3,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
     all_peers.update_connection_status(&peer3, NewConnectionStatus::Disconnected);
     all_peers.update_connection_status(
         &peer3,
@@ -676,7 +692,10 @@ fn test_ban_action_returns_only_unbanned_ips() {
 
     // now peer3 has both ip1 (banned) and ip2 (not banned) in its history
     // ban peer3
-    all_peers.update_connection_status(&peer3, NewConnectionStatus::Disconnecting { banned: true });
+    all_peers.update_connection_status(
+        &peer3,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::Banned },
+    );
     let action = all_peers.update_connection_status(&peer3, NewConnectionStatus::Disconnected);
 
     if let PeerAction::Ban(ips) = action {

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -1,0 +1,373 @@
+//! Invariant tests for `Reputation` and `ConnectionStatus`.
+//!
+//! Each test states one proposition that must hold for any sequence of penalties and status
+//! transitions. Tests are written against the public seams of `AllPeers` - `process_penalty`,
+//! `update_connection_status` and `heartbeat_maintenance` - never against a hand-set internal
+//! state, so that a refactor of the transition table cannot make them vacuous.
+//!
+//! Where a test currently fails, the invariant it states is the intended behavior and the failure
+//! is the bug. Such tests carry an `INVARIANT`/`CURRENT` comment pair naming both.
+
+use super::*;
+use crate::common::{create_multiaddr, ensure_score_config};
+use libp2p::PeerId;
+use rand::{rngs::StdRng, SeedableRng as _};
+use rayls_infrastructure_config::{PeerConfig, ScoreConfig};
+use rayls_infrastructure_types::{now, BlsKeypair, NetworkKeypair};
+use std::net::{IpAddr, Ipv4Addr};
+
+/// Build an `AllPeers` from an operator config, installing its `ScoreConfig` globally.
+///
+/// `ScoreConfig` lands in a process-wide `OnceLock`; nextest runs one process per test, so each
+/// test gets its own. Under `cargo test` this would be order-dependent.
+fn all_peers_with(config: PeerConfig) -> AllPeers {
+    ensure_score_config(Some(config.score_config));
+    AllPeers::new(Duration::from_secs(5), config.max_banned_peers, config.max_disconnected_peers)
+}
+
+/// Build an `AllPeers` with the default operator config.
+fn all_peers() -> AllPeers {
+    all_peers_with(PeerConfig::default())
+}
+
+/// A stable IPv4 address, so a test can assert against the exact IP it charged.
+fn ip(last_octet: u8) -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(203, 0, 113, last_octet))
+}
+
+/// A deterministic BLS key paired with a fresh network key, as `upsert_peer` expects.
+fn random_keys(seed: u8) -> (BlsPublicKey, NetworkPublicKey) {
+    let mut rng = StdRng::from_seed([seed; 32]);
+    let bls = *BlsKeypair::generate(&mut rng).public();
+    let network_key: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
+    (bls, network_key)
+}
+
+/// Register an inbound connection from `addr`, creating the peer at the default score.
+fn connect_from(all_peers: &mut AllPeers, addr: IpAddr) -> PeerId {
+    let peer_id = PeerId::random();
+    all_peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Connected {
+            multiaddr: create_multiaddr(Some(addr)),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    peer_id
+}
+
+/// The current aggregate score for a known peer.
+fn score_of(all_peers: &AllPeers, peer_id: &PeerId) -> f64 {
+    all_peers.get_peer(peer_id).expect("peer is known").score().aggregate_score()
+}
+
+/// Apply `Medium` penalties until the peer's score reaches the disconnect threshold, returning the
+/// last action. Deliberately stops short of the ban threshold.
+fn penalize_to_disconnect_threshold(all_peers: &mut AllPeers, peer_id: &PeerId) -> PeerAction {
+    let config = PeerConfig::default();
+    let mut action = PeerAction::NoAction;
+    while score_of(all_peers, peer_id) > config.min_score_for_disconnect {
+        action = all_peers.process_penalty(peer_id, Penalty::Medium);
+    }
+    assert!(
+        score_of(all_peers, peer_id) > config.min_score_for_ban,
+        "helper must stop between the disconnect and ban thresholds"
+    );
+    action
+}
+
+/// Number of peers currently held in `ConnectionStatus::Banned`.
+fn peers_in_banned_status(all_peers: &AllPeers) -> usize {
+    all_peers.peers.values().filter(|peer| peer.connection_status().is_banned()).count()
+}
+
+/// The two conservation laws of the ban accounting, checkable after any mutation:
+///
+/// 1. `BannedPeers::total` equals the number of peers in `ConnectionStatus::Banned`.
+/// 2. Every per-IP charge is backed by a peer in `ConnectionStatus::Banned` holding that IP.
+///
+/// Law 2 is checked in the direction that matters for admission: an IP the node refuses
+/// connections from must be an IP that at least two currently-banned peers hold.
+fn assert_ban_accounting_conserved(all_peers: &AllPeers, context: &str) {
+    assert_eq!(
+        all_peers.banned_peers.total(),
+        peers_in_banned_status(all_peers),
+        "{context}: banned total drifted from the set of peers in ConnectionStatus::Banned"
+    );
+
+    for ip in all_peers.banned_peers.banned_ips() {
+        let holders = all_peers
+            .peers
+            .values()
+            .filter(|peer| {
+                peer.connection_status().is_banned() && peer.known_ip_addresses().any(|i| i == ip)
+            })
+            .count();
+        assert!(
+            holders > 1,
+            "{context}: {ip} is blocklisted but only {holders} banned peer(s) hold it"
+        );
+    }
+}
+
+// Threshold arithmetic: what crossing each threshold is allowed to do
+
+/// The two score thresholds must produce two distinct outcomes: crossing the disconnect threshold
+/// disconnects, crossing the ban threshold bans.
+#[test]
+fn crossing_disconnect_threshold_does_not_ban() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(1));
+
+    let action = penalize_to_disconnect_threshold(&mut peers, &peer_id);
+    assert!(matches!(action, PeerAction::Disconnect | PeerAction::DisconnectWithPX));
+
+    // the swarm reports the connection closed
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+
+    // guards the `DisconnectReason::Penalized` arm: a disconnect earned at this threshold must
+    // not carry the ban flag through to `handle_disconnected_and_banned`
+    let status = *peers.get_peer(&peer_id).expect("peer is known").connection_status();
+    assert!(
+        matches!(status, ConnectionStatus::Disconnected { .. }),
+        "peer between the thresholds ended in {status:?}, expected Disconnected"
+    );
+    assert_eq!(peers.banned_peers.total(), 0, "no ban was earned, so nothing may be charged");
+}
+
+/// Charging the IP ban table is a consequence of a ban. A peer that was never banned must leave the
+/// table untouched, otherwise two such peers blocklist an IP that no banned peer ever used.
+#[test]
+fn crossing_disconnect_threshold_does_not_charge_the_ip_table() {
+    let mut peers = all_peers();
+    let shared = ip(2);
+
+    for _ in 0..2 {
+        let peer_id = connect_from(&mut peers, shared);
+        penalize_to_disconnect_threshold(&mut peers, &peer_id);
+        peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    }
+
+    // two peers is the blocklist threshold, so this is the smallest case that would trip it
+    assert!(
+        !peers.ip_banned(&shared),
+        "an IP was blocklisted by two peers that never reached the ban threshold"
+    );
+}
+
+/// `Reputation` is the authority on whether a peer is banned. Every store that records a ban must
+/// agree with it, otherwise an admission check reads one store and an eviction check reads another.
+#[test]
+fn ban_stores_agree_after_crossing_disconnect_threshold() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(3));
+
+    penalize_to_disconnect_threshold(&mut peers, &peer_id);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+
+    let peer = peers.get_peer(&peer_id).expect("peer is known");
+    let reputation_says_banned = peer.reputation().banned();
+    let status_says_banned = peer.connection_status().is_banned();
+
+    // the two stores are read by different call sites, so they must not disagree about one peer
+    assert_eq!(
+        reputation_says_banned, status_says_banned,
+        "reputation and connection status disagree about whether the peer is banned"
+    );
+}
+
+/// A score-driven ban must be releasable by the same mechanism that applied it: score decay. If the
+/// release path keys on a state the peer never occupied, the ban outlives the score that caused it.
+#[test]
+fn a_score_driven_ban_is_released_by_score_decay() {
+    // a short halflife so a single heartbeat decays the score above both thresholds
+    let config = PeerConfig {
+        score_config: ScoreConfig { score_halflife: 0.001, ..Default::default() },
+        ..Default::default()
+    };
+    let mut peers = all_peers_with(config);
+
+    let peer_id = connect_from(&mut peers, ip(4));
+    penalize_to_disconnect_threshold(&mut peers, &peer_id);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+
+    // decay the score back into the tolerable range
+    std::thread::sleep(Duration::from_millis(1100));
+    let actions = peers.heartbeat_maintenance();
+
+    assert!(
+        score_of(&peers, &peer_id) > config.min_score_for_disconnect,
+        "precondition: the score must have decayed above the disconnect threshold"
+    );
+
+    // the release path keys on `Reputation::Banned`, so a peer that only ever sat between the
+    // thresholds must never have been marked banned in the first place
+    let status = *peers.get_peer(&peer_id).expect("peer is known").connection_status();
+    assert!(
+        !status.is_banned(),
+        "score recovered to {} but the peer is still {status:?} (actions: {actions:?})",
+        score_of(&peers, &peer_id)
+    );
+    assert_eq!(peers.banned_peers.total(), 0, "IP charge outlived the score that caused it");
+}
+
+// Conservation: the ban accounting must match the set of banned peers
+
+/// `BannedPeers::total` is the input to `prune_banned_peers`. It must equal the number of peers
+/// actually held in `ConnectionStatus::Banned`, or pruning evicts the wrong number of peers.
+#[test]
+fn banned_total_equals_the_number_of_banned_peers() {
+    let mut peers = all_peers();
+
+    let banned = connect_from(&mut peers, ip(10));
+    peers.process_penalty(&banned, Penalty::Fatal);
+    peers.update_connection_status(&banned, NewConnectionStatus::Disconnected);
+
+    let healthy = connect_from(&mut peers, ip(11));
+    peers.update_connection_status(
+        &healthy,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
+    peers.update_connection_status(&healthy, NewConnectionStatus::Disconnected);
+
+    assert_eq!(
+        peers.banned_peers.total(),
+        peers_in_banned_status(&peers),
+        "banned total drifted from the set of peers in ConnectionStatus::Banned"
+    );
+}
+
+/// Every increment of the ban accounting has exactly one matching decrement. Unbanning a peer that
+/// was never banned must be a no-op, otherwise `total` underflows below the real count.
+#[test]
+fn unbanning_a_never_banned_peer_does_not_decrement_the_total() {
+    let mut peers = all_peers();
+
+    let banned = connect_from(&mut peers, ip(12));
+    peers.process_penalty(&banned, Penalty::Fatal);
+    peers.update_connection_status(&banned, NewConnectionStatus::Disconnected);
+    assert_eq!(peers.banned_peers.total(), 1, "precondition: one banned peer");
+
+    // a peer that was disconnected normally is asked to unban
+    let healthy = connect_from(&mut peers, ip(13));
+    peers.update_connection_status(
+        &healthy,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
+    peers.update_connection_status(&healthy, NewConnectionStatus::Disconnected);
+    peers.update_connection_status(&healthy, NewConnectionStatus::Unbanned);
+
+    // INVARIANT: only a banned peer's release may decrement the total.
+    // CURRENT: `BannedPeers::remove_banned_peer` decrements unconditionally.
+    assert_eq!(
+        peers.banned_peers.total(),
+        peers_in_banned_status(&peers),
+        "unbanning a never-banned peer corrupted the banned total"
+    );
+}
+
+/// Ban and unban must round-trip the per-IP counters, so an IP is not blocklisted by a charge that
+/// no longer corresponds to a banned peer.
+#[test]
+fn ban_then_unban_round_trips_the_per_ip_counters() {
+    let mut peers = all_peers();
+    let shared = ip(14);
+
+    let ids: Vec<_> = (0..2)
+        .map(|_| {
+            let peer_id = connect_from(&mut peers, shared);
+            peers.process_penalty(&peer_id, Penalty::Fatal);
+            peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+            peer_id
+        })
+        .collect();
+
+    assert!(peers.ip_banned(&shared), "precondition: two banned peers blocklist the shared IP");
+
+    for peer_id in &ids {
+        peers.update_connection_status(peer_id, NewConnectionStatus::Unbanned);
+    }
+
+    assert!(!peers.ip_banned(&shared), "IP stayed blocklisted after every ban was released");
+    assert_eq!(peers.banned_peers.total(), 0, "banned total did not return to zero");
+}
+
+// Score semantics
+
+/// `Penalty::Fatal` assigns the floor rather than subtracting, so applying it twice must leave the
+/// score where the first one put it.
+#[test]
+fn repeated_fatal_penalties_are_idempotent() {
+    let config = ScoreConfig::default();
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(20));
+
+    peers.process_penalty(&peer_id, Penalty::Fatal);
+    let after_first = score_of(&peers, &peer_id);
+    peers.process_penalty(&peer_id, Penalty::Fatal);
+
+    assert_eq!(after_first, config.min_score, "Fatal must assign the configured floor");
+    assert_eq!(score_of(&peers, &peer_id), after_first, "a second Fatal moved the score");
+}
+
+/// Penalties clamp at the configured floor rather than accumulating below it, so a peer cannot be
+/// driven arbitrarily negative and outlast the decay schedule.
+#[test]
+fn penalties_clamp_at_the_configured_floor() {
+    let config = ScoreConfig::default();
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(21));
+
+    for _ in 0..40 {
+        peers.process_penalty(&peer_id, Penalty::Severe);
+    }
+
+    assert_eq!(score_of(&peers, &peer_id), config.min_score, "score escaped the configured floor");
+}
+
+/// The reputation ladder is read at exactly two points. A peer sitting exactly on a threshold must
+/// land on the harsher side consistently, and one point above it must not.
+#[test]
+fn reputation_boundaries_are_inclusive_at_the_threshold() {
+    let config = PeerConfig::default();
+    let mut peers = all_peers();
+
+    // exactly on the disconnect threshold
+    let at_threshold = connect_from(&mut peers, ip(22));
+    while score_of(&peers, &at_threshold) > config.min_score_for_disconnect {
+        peers.process_penalty(&at_threshold, Penalty::Medium);
+    }
+    assert_eq!(score_of(&peers, &at_threshold), config.min_score_for_disconnect);
+    assert_eq!(
+        peers.get_peer(&at_threshold).expect("known").reputation(),
+        Reputation::Disconnected,
+        "a score exactly at the disconnect threshold must count as Disconnected"
+    );
+
+    // one Mild above it
+    let above = connect_from(&mut peers, ip(23));
+    while score_of(&peers, &above) > config.min_score_for_disconnect + 1.0 {
+        peers.process_penalty(&above, Penalty::Mild);
+    }
+    assert_eq!(
+        peers.get_peer(&above).expect("known").reputation(),
+        Reputation::Trusted,
+        "a score above the disconnect threshold must still count as Trusted"
+    );
+}
+
+// Absolution
+
+/// A current-committee member is immune to penalties, so its score must not move at all.
+#[test]
+fn committee_members_are_immune_to_penalties() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(30));
+    peers.current_committee.insert(peer_id);
+
+    let before = score_of(&peers, &peer_id);
+    let action = peers.process_penalty(&peer_id, Penalty::Fatal);
+
+    assert!(matches!(action, PeerAction::NoAction));
+    assert_eq!(score_of(&peers, &peer_id), before, "a committee member's score was penalized");
+}


### PR DESCRIPTION
## Summary

Align a peer's connection state with its reputation verdict on the admission and disconnect paths.

- disconnecting at the score threshold no longer bans the peer: a Disconnected verdict maps to DisconnectReason::Penalized, which neither sets ConnectionStatus::Banned nor charges the peer's ips into the ban table
- register_peer_connection gates on PeerManager::peer_banned, the same predicate the admission gates use, so a committee member admitted at the gate is not then refused at registration
- a connection register_peer_connection refuses is closed, so the swarm does not keep a connection the manager holds no state for

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No wire-format or message-shape change, so it stays rolling-upgrade safe.
