### PR TITLE
fix: conserve ban-table accounting on ban and release

### DIFF
--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -91,7 +91,7 @@ impl AllPeers {
     ) {
         let peer_id: PeerId = network_key.clone().into();
         let trusted_peer = Peer::new_trusted(bls_public_key, network_key, addr);
-        let _ = self.banned_peers.remove_banned_peer(trusted_peer.known_ip_addresses());
+        let _ = self.banned_peers.remove_banned_peer(&peer_id);
         self.peers.insert(peer_id, trusted_peer);
     }
 
@@ -386,7 +386,7 @@ impl AllPeers {
                 }
                 ConnectionStatus::Banned { .. } => {
                     error!(target: "peer-manager", ?peer_id, "accepted a connection from a banned peer");
-                    self.banned_peers.remove_banned_peer(peer.known_ip_addresses());
+                    self.banned_peers.remove_banned_peer(peer_id);
                 }
                 ConnectionStatus::Disconnecting { .. } => {
                     warn!(target: "peer-manager", ?peer_id, "connected to a disconnecting peer")
@@ -416,7 +416,7 @@ impl AllPeers {
             match current_status {
                 ConnectionStatus::Banned { .. } => {
                     warn!(target: "peer-manager", ?peer_id, "dialing a banned peer");
-                    self.banned_peers.remove_banned_peer(peer.known_ip_addresses());
+                    self.banned_peers.remove_banned_peer(peer_id);
                 }
                 ConnectionStatus::Disconnected { .. } => {
                     self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
@@ -487,7 +487,7 @@ impl AllPeers {
         // update peer's status
         if let Some(peer) = self.peers.get_mut(peer_id) {
             peer.set_connection_status(ConnectionStatus::Banned { instant: Instant::now() });
-            self.banned_peers.add_banned_peer(peer);
+            self.banned_peers.add_banned_peer(peer_id, peer);
             let banned_ips = peer
                 .known_ip_addresses()
                 .filter(|ip| !already_banned_ips.contains(ip))
@@ -531,6 +531,10 @@ impl AllPeers {
             ConnectionStatus::Banned { .. } => {
                 // banned peers should already be disconnected
                 error!(target: "peer-manager", ?peer_id, "disconnecting from a banned peer - banned peer should already be disconnected");
+
+                // the peer is leaving the banned state, so its charge must be released here or it
+                // outlives the ban and the next ban charges the same peer twice
+                self.banned_peers.remove_banned_peer(peer_id);
             }
             ConnectionStatus::Connected { .. } | ConnectionStatus::Dialing { .. } => {
                 // only a healthy peer evicted for connection limits is worth helping find
@@ -557,7 +561,7 @@ impl AllPeers {
         if let Some(peer) = self.peers.get_mut(peer_id) {
             match current_state {
                 ConnectionStatus::Disconnected { .. } => {
-                    self.banned_peers.add_banned_peer(peer);
+                    self.banned_peers.add_banned_peer(peer_id, peer);
                     self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
                     let already_banned_ips = self.banned_peers.banned_ips();
 
@@ -591,7 +595,7 @@ impl AllPeers {
                 }
                 ConnectionStatus::Unknown => {
                     warn!(target: "peer-manager", ?peer_id, "banning an unknown peer");
-                    self.banned_peers.add_banned_peer(peer);
+                    self.banned_peers.add_banned_peer(peer_id, peer);
                     peer.set_connection_status(ConnectionStatus::Banned {
                         instant: Instant::now(),
                     });
@@ -624,7 +628,7 @@ impl AllPeers {
                     peer.set_connection_status(ConnectionStatus::Disconnected { instant });
 
                     // update counters
-                    self.banned_peers.remove_banned_peer(peer.known_ip_addresses());
+                    self.banned_peers.remove_banned_peer(peer_id);
                     self.disconnected_peers = self.disconnected_peers.saturating_add(1);
 
                     return PeerAction::Unban(peer.known_ip_addresses().collect());
@@ -828,9 +832,9 @@ impl AllPeers {
                 }
             });
 
-            for (_, peer_id, ip_addrs) in excess_peers {
+            for (_, peer_id, _) in excess_peers {
                 self.peers.remove(&peer_id);
-                let ips = self.banned_peers.remove_banned_peer(ip_addrs.clone().into_iter());
+                let ips = self.banned_peers.remove_banned_peer(&peer_id);
                 unbanned.push((peer_id, ips));
             }
         }

--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -21,7 +21,6 @@ use libp2p::{Multiaddr, PeerId};
 use rand::seq::SliceRandom as _;
 use rayls_infrastructure_types::{BlsPublicKey, NetworkPublicKey};
 use std::{
-    cmp::Reverse,
     collections::{BinaryHeap, HashMap, HashSet},
     net::IpAddr,
     time::{Duration, Instant},
@@ -777,15 +776,18 @@ impl AllPeers {
         (action, pruned_peers)
     }
 
-    /// Filter peers based on connection status.
+    /// Select the `excess` oldest peers whose status `filter` accepts.
     ///
-    /// This creates a min-heap with the excess number of peers.
-    /// Used by Self::prune_banned_peers and Self::prune_disconnected_peers.
+    /// Used by [`Self::prune_banned_peers`] and [`Self::prune_disconnected_peers`] to age out the
+    /// longest-standing records when a capacity bound is exceeded.
+    ///
+    /// The heap is a max-heap on the instant, so `peek` is the newest selected peer; replacing it
+    /// whenever an older candidate arrives converges the heap on the `excess` oldest.
     fn collect_excess_peers<F>(
         &self,
         excess: usize,
         filter: F,
-    ) -> BinaryHeap<(Reverse<Instant>, PeerId, Vec<IpAddr>)>
+    ) -> BinaryHeap<(Instant, PeerId, Vec<IpAddr>)>
     where
         F: Fn(&ConnectionStatus) -> Option<Instant>,
     {
@@ -794,16 +796,13 @@ impl AllPeers {
 
         for (peer_id, peer) in &self.peers {
             if let Some(instant) = filter(peer.connection_status()) {
-                // min-heap sorted by instant (oldest first)
-                let entry =
-                    (Reverse(instant), *peer_id, peer.known_ip_addresses().collect::<Vec<_>>());
+                let entry = (instant, *peer_id, peer.known_ip_addresses().collect::<Vec<_>>());
 
                 if excess_peers.len() < excess {
                     // fill the heap until `excess` elements
                     excess_peers.push(entry);
-                } else if let Some(current_max) = excess_peers.peek() {
-                    // if peer's banned instant is older, replace it
-                    if entry.0 < current_max.0 {
+                } else if let Some(newest) = excess_peers.peek() {
+                    if entry.0 < newest.0 {
                         excess_peers.pop();
                         excess_peers.push(entry);
                     }

--- a/crates/consensus/network/src/peers/banned.rs
+++ b/crates/consensus/network/src/peers/banned.rs
@@ -2,6 +2,7 @@
 //!
 //! Peers that score poorly are eventually banned.
 use super::peer::Peer;
+use libp2p::PeerId;
 use std::{
     collections::{HashMap, HashSet},
     net::IpAddr,
@@ -15,30 +16,33 @@ mod banned_peers;
 /// Currently set to 1, so ips are banned if more than one peer is banned.
 const BANNED_PEERS_PER_IP_THRESHOLD: usize = 1;
 
-/// The total number of banned peers and a collection of the number of bad peers by IP address.
+/// The ip addresses charged for each banned peer, and the resulting per-ip counts.
 #[derive(Debug, Default)]
 pub(super) struct BannedPeers {
-    /// The total number of banned peers for this node.
-    total: usize,
+    /// The ip addresses charged when each peer was banned.
+    ///
+    /// A ban must be released against exactly the addresses it charged. A peer's address set
+    /// changes while it is banned, through record updates and address pruning, so re-reading it at
+    /// release time credits addresses the ban never debited and leaves others charged forever.
+    /// Keying on the peer also makes the total a derived value rather than a counter that can
+    /// drift from the map it is supposed to describe.
+    charged_ips: HashMap<PeerId, Vec<IpAddr>>,
     /// The number of banned peers by IP address.
     banned_peers_by_ip: HashMap<IpAddr, usize>,
 }
 
 impl BannedPeers {
-    /// Remove banned peers by IP address.
+    /// Release the ban charge for a peer, returning the ip addresses that are no longer banned.
     ///
-    /// This method always reduces the total number of banned peers by 1. The method also attempts
-    /// to reduce the number of banned peers by IP address. IP addresses that are no longer banned
-    /// are returned to the sender.
-    ///
-    /// NOTE: it's possible to have multiple peers from a single IP address
-    pub(super) fn remove_banned_peer(
-        &mut self,
-        ip_addresses: impl Iterator<Item = IpAddr>,
-    ) -> Vec<IpAddr> {
-        self.total = self.total.saturating_sub(1);
+    /// Releasing a peer that holds no charge is a no-op, so a caller that unbans indiscriminately
+    /// cannot drive the total below the number of banned peers.
+    pub(super) fn remove_banned_peer(&mut self, peer_id: &PeerId) -> Vec<IpAddr> {
+        let Some(ip_addresses) = self.charged_ips.remove(peer_id) else {
+            return Vec::new();
+        };
 
         ip_addresses
+            .into_iter()
             .filter(|ip| {
                 match self.banned_peers_by_ip.get_mut(ip) {
                     Some(count) => {
@@ -63,18 +67,26 @@ impl BannedPeers {
             .collect()
     }
 
-    /// Add IP addresse to the banned peers collection and update counts.
-    pub(super) fn add_banned_peer(&mut self, peer: &Peer) {
-        self.total = self.total.saturating_add(1);
-        for address in peer.known_ip_addresses() {
-            tracing::debug!(target: "peer-manager", ?address, "known ip address for banned peer");
-            *self.banned_peers_by_ip.entry(address.clone()).or_insert(0) += 1;
+    /// Charge a banned peer's ip addresses.
+    ///
+    /// Charging a peer that is already charged is a no-op, so a peer cannot hold two charges for
+    /// one ban.
+    pub(super) fn add_banned_peer(&mut self, peer_id: &PeerId, peer: &Peer) {
+        if self.charged_ips.contains_key(peer_id) {
+            return;
         }
+
+        let ip_addresses: Vec<_> = peer.known_ip_addresses().collect();
+        for address in &ip_addresses {
+            tracing::debug!(target: "peer-manager", ?address, "known ip address for banned peer");
+            *self.banned_peers_by_ip.entry(*address).or_insert(0) += 1;
+        }
+        self.charged_ips.insert(*peer_id, ip_addresses);
     }
 
     /// Return the number of banned peers.
     pub(super) fn total(&self) -> usize {
-        self.total
+        self.charged_ips.len()
     }
 
     /// Return a [HashSet] of banned IP addresses.

--- a/crates/consensus/network/src/tests/banned_peers.rs
+++ b/crates/consensus/network/src/tests/banned_peers.rs
@@ -2,11 +2,11 @@
 
 use super::*;
 use crate::common::{ensure_score_config, random_ip_addr};
-use libp2p::{multiaddr::Protocol, Multiaddr};
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use std::net::Ipv4Addr;
 
-/// Helper function to create a peer with specific IP addresses.
-fn create_peer_with_ips(ips: Vec<IpAddr>) -> Peer {
+/// Helper function to create a distinctly-identified peer with specific IP addresses.
+fn create_peer_with_ips(ips: Vec<IpAddr>) -> (PeerId, Peer) {
     ensure_score_config(None);
 
     let mut peer = Peer::default_for_test();
@@ -24,7 +24,7 @@ fn create_peer_with_ips(ips: Vec<IpAddr>) -> Peer {
         peer.register_outgoing(multiaddr);
     }
 
-    peer
+    (PeerId::random(), peer)
 }
 
 #[test]
@@ -40,12 +40,12 @@ fn test_remove_banned_peer() {
     let ip1 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let ip2 = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
 
-    let peer = create_peer_with_ips(vec![ip1, ip2]);
+    let (peer_id, peer) = create_peer_with_ips(vec![ip1, ip2]);
 
-    banned_peers.add_banned_peer(&peer);
+    banned_peers.add_banned_peer(&peer_id, &peer);
     assert_eq!(banned_peers.total(), 1);
 
-    let unbanned_ips = banned_peers.remove_banned_peer(vec![ip1, ip2].into_iter());
+    let unbanned_ips = banned_peers.remove_banned_peer(&peer_id);
 
     assert_eq!(banned_peers.total(), 0);
     assert_eq!(unbanned_ips.len(), 2);
@@ -63,8 +63,8 @@ fn test_add_multiple_peers_same_ip() {
 
     // add multiple peers with the same IP
     for i in 0..BANNED_PEERS_PER_IP_THRESHOLD {
-        let peer = create_peer_with_ips(vec![ip]);
-        banned_peers.add_banned_peer(&peer);
+        let (peer_id, peer) = create_peer_with_ips(vec![ip]);
+        banned_peers.add_banned_peer(&peer_id, &peer);
 
         // check the total is incrementing
         assert_eq!(banned_peers.total(), i + 1);
@@ -80,8 +80,8 @@ fn test_add_multiple_peers_same_ip() {
     }
 
     // add one more peer to exceed threshold
-    let peer = create_peer_with_ips(vec![ip]);
-    banned_peers.add_banned_peer(&peer);
+    let (peer_id, peer) = create_peer_with_ips(vec![ip]);
+    banned_peers.add_banned_peer(&peer_id, &peer);
 
     // assert IP is now banned
     assert!(banned_peers.ip_banned(&ip));
@@ -95,7 +95,7 @@ fn test_add_peer_no_ip() {
 
     // Create a peer with no IP addresses
     let peer = Peer::default_for_test();
-    banned_peers.add_banned_peer(&peer);
+    banned_peers.add_banned_peer(&PeerId::random(), &peer);
 
     // total should increment but no IPs should be banned
     assert_eq!(banned_peers.total(), 1);
@@ -103,20 +103,21 @@ fn test_add_peer_no_ip() {
 }
 
 #[test]
-fn test_remove_nonexistent_ip() {
+fn test_remove_peer_that_was_never_banned() {
     let mut banned_peers = BannedPeers::default();
     let ip1 = random_ip_addr();
     let ip2 = random_ip_addr();
 
     // Add a peer with ip1
-    let peer = create_peer_with_ips(vec![ip1]);
-    banned_peers.add_banned_peer(&peer);
+    let (peer_id, peer) = create_peer_with_ips(vec![ip1]);
+    banned_peers.add_banned_peer(&peer_id, &peer);
 
-    // Remove a peer with ip2, which doesn't exist in the collection
-    let unbanned_ips = banned_peers.remove_banned_peer(vec![ip2].into_iter());
+    // Release a different peer, which holds no charge
+    let (other_id, _) = create_peer_with_ips(vec![ip2]);
+    let unbanned_ips = banned_peers.remove_banned_peer(&other_id);
 
-    // Total should decrease but no IPs should be unbanned
-    assert_eq!(banned_peers.total(), 0);
+    // the charged peer is untouched, so the total cannot drift below the peers actually banned
+    assert_eq!(banned_peers.total(), 1);
     assert!(unbanned_ips.is_empty());
 }
 
@@ -131,21 +132,21 @@ fn test_remove_banned_peer_partial() {
 
     // add enough peers so ip is banned after removal
     for _ in 0..banned_peers_threshold {
-        let peer = create_peer_with_ips(vec![ip1]);
-        banned_peers.add_banned_peer(&peer);
+        let (peer_id, peer) = create_peer_with_ips(vec![ip1]);
+        banned_peers.add_banned_peer(&peer_id, &peer);
     }
 
     // add one peer with both ips
     // this puts ip1 at threshold + 1 so removing the peer won't unban the IP
     let peer3_ips = vec![ip1, ip2];
-    let peer3 = create_peer_with_ips(peer3_ips.clone());
-    banned_peers.add_banned_peer(&peer3);
+    let (peer3_id, peer3) = create_peer_with_ips(peer3_ips.clone());
+    banned_peers.add_banned_peer(&peer3_id, &peer3);
 
     // assert 1 extra peer past threshold
     assert_eq!(banned_peers.total(), banned_peers_threshold + 1);
 
     // remove one peer with both ip addresses
-    let unbanned_ips = banned_peers.remove_banned_peer(peer3_ips.into_iter());
+    let unbanned_ips = banned_peers.remove_banned_peer(&peer3_id);
 
     // assert total decreased by 1
     assert_eq!(banned_peers.total(), banned_peers_threshold);
@@ -171,19 +172,19 @@ fn test_multiple_ips_different_ban_status() {
 
     // Add BANNED_PEERS_PER_IP_THRESHOLD+1 peers with ip1 (will be banned)
     for _ in 0..banned_peers_threshold {
-        let peer = create_peer_with_ips(vec![ip1]);
-        banned_peers.add_banned_peer(&peer);
+        let (peer_id, peer) = create_peer_with_ips(vec![ip1]);
+        banned_peers.add_banned_peer(&peer_id, &peer);
     }
 
     // add just enough so at threshold, but not banned
     for _ in 0..banned_peers_threshold - 1 {
-        let peer = create_peer_with_ips(vec![ip2]);
-        banned_peers.add_banned_peer(&peer);
+        let (peer_id, peer) = create_peer_with_ips(vec![ip2]);
+        banned_peers.add_banned_peer(&peer_id, &peer);
     }
 
     // add 1 peer with ip3 (below threshold)
-    let peer = create_peer_with_ips(vec![ip3]);
-    banned_peers.add_banned_peer(&peer);
+    let (peer_id, peer) = create_peer_with_ips(vec![ip3]);
+    banned_peers.add_banned_peer(&peer_id, &peer);
 
     // assert banned ips
     assert!(banned_peers.ip_banned(&ip1));
@@ -204,13 +205,13 @@ fn test_remove_all_ips_for_peer() {
     let ips: Vec<IpAddr> = (0..10).map(|_| random_ip_addr()).collect();
 
     // add a peer with all IPs
-    let peer = create_peer_with_ips(ips.clone());
-    banned_peers.add_banned_peer(&peer);
+    let (peer_id, peer) = create_peer_with_ips(ips.clone());
+    banned_peers.add_banned_peer(&peer_id, &peer);
 
     assert_eq!(banned_peers.total(), 1);
 
     // remove the peer
-    let unbanned_ips = banned_peers.remove_banned_peer(ips.iter().cloned());
+    let unbanned_ips = banned_peers.remove_banned_peer(&peer_id);
 
     // check all IPs were unbanned
     assert_eq!(unbanned_ips.len(), ips.len());
@@ -224,7 +225,7 @@ fn test_saturating_operations() {
     let mut banned_peers = BannedPeers::default();
 
     // assert total doesn't underflow
-    let unbanned_ips = banned_peers.remove_banned_peer(vec![].into_iter());
+    let unbanned_ips = banned_peers.remove_banned_peer(&PeerId::random());
     assert_eq!(banned_peers.total(), 0);
     assert!(unbanned_ips.is_empty());
 
@@ -232,17 +233,19 @@ fn test_saturating_operations() {
 
     // add a large number of peers with the same IP
     let ip = random_ip_addr();
+    let mut ids = Vec::new();
     for _ in 0..(banned_peers_threshold * 2) {
-        let peer = create_peer_with_ips(vec![ip]);
-        banned_peers.add_banned_peer(&peer);
+        let (peer_id, peer) = create_peer_with_ips(vec![ip]);
+        banned_peers.add_banned_peer(&peer_id, &peer);
+        ids.push(peer_id);
     }
 
     // verify the IP is banned
     assert!(banned_peers.ip_banned(&ip));
 
-    // remove more peers than added
-    for _ in 0..(banned_peers_threshold * 3) {
-        banned_peers.remove_banned_peer(vec![ip].into_iter());
+    // release every charged peer, then release each one again
+    for peer_id in ids.iter().chain(ids.iter()) {
+        banned_peers.remove_banned_peer(peer_id);
     }
 
     // assert total does not underflow

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -371,3 +371,66 @@ fn committee_members_are_immune_to_penalties() {
     assert!(matches!(action, PeerAction::NoAction));
     assert_eq!(score_of(&peers, &peer_id), before, "a committee member's score was penalized");
 }
+
+// Ban-table capacity and trust promotion
+
+/// The ban table is bounded for memory, not for amnesty. Eviction ages out the oldest bans, so a
+/// flood of new identities cannot flush the bans this node most recently earned.
+///
+/// Three bans against a bound of one forces `excess == 2`. A selection that is correct only for a
+/// single eviction passes the one-peer case and still picks the wrong pair here.
+#[test]
+fn ban_table_overflow_retires_the_oldest_bans() {
+    let mut peers = all_peers_with(PeerConfig { max_banned_peers: 1, ..Default::default() });
+
+    // ban three peers without pruning in between, so the bound is exceeded by two at once
+    let banned: Vec<_> = (70..73u8)
+        .map(|octet| {
+            let peer_id = connect_from(&mut peers, ip(octet));
+            peers.process_penalty(&peer_id, Penalty::Fatal);
+            peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+            std::thread::sleep(Duration::from_millis(2));
+            peer_id
+        })
+        .collect();
+    assert_eq!(peers.banned_peers.total(), 3, "precondition: three bans, bound of one");
+
+    // any disconnect registration triggers the capacity sweep
+    let (_, pruned) = peers.register_disconnected(&banned[2]);
+    let retired: Vec<_> = pruned.iter().map(|(id, _)| *id).collect();
+
+    assert_eq!(retired.len(), 2, "a bound of one against three bans retires two");
+    assert!(retired.contains(&banned[0]), "the oldest ban survived eviction");
+    assert!(retired.contains(&banned[1]), "the second-oldest ban survived eviction");
+    assert!(!retired.contains(&banned[2]), "eviction retired the ban applied most recently");
+}
+
+/// Disconnected-peer eviction ages out the oldest records, like ban eviction. Both callers share
+/// `collect_excess_peers`, so both inherit whichever ordering it implements.
+#[test]
+fn disconnected_peer_eviction_retires_the_oldest_record() {
+    let mut peers = all_peers_with(PeerConfig { max_disconnected_peers: 1, ..Default::default() });
+
+    let first = connect_from(&mut peers, ip(95));
+    peers.update_connection_status(
+        &first,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
+    peers.register_disconnected(&first);
+
+    let second = connect_from(&mut peers, ip(96));
+    peers.update_connection_status(
+        &second,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
+    peers.register_disconnected(&second);
+
+    // INVARIANT: the older record is the one evicted.
+    // CURRENT: `collect_excess_peers` converges on the newest entries, so the record just created
+    // is dropped and the stale one is retained.
+    assert!(
+        peers.get_peer(&second).is_some(),
+        "eviction dropped the newest disconnected record instead of the oldest"
+    );
+    assert!(peers.get_peer(&first).is_none(), "the oldest disconnected record survived eviction");
+}

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -434,3 +434,152 @@ fn disconnected_peer_eviction_retires_the_oldest_record() {
     );
     assert!(peers.get_peer(&first).is_none(), "the oldest disconnected record survived eviction");
 }
+
+// Leaving the Banned state: every exit settles the accounting
+
+/// Promoting a peer to trusted is documented to unban its IPs. It must actually release every
+/// charge that peer holds, or the charge outlives the peer record entirely.
+#[test]
+fn promoting_a_banned_peer_to_trusted_releases_its_ip_charges() {
+    let mut peers = all_peers();
+    let shared = ip(72);
+
+    let mut identities = Vec::new();
+    for seed in 10..12u8 {
+        let (bls, network_key) = random_keys(seed);
+        let peer_id: PeerId = network_key.clone().into();
+        peers.update_connection_status(
+            &peer_id,
+            NewConnectionStatus::Connected {
+                multiaddr: create_multiaddr(Some(shared)),
+                direction: ConnectionDirection::Incoming,
+            },
+        );
+        peers.process_penalty(&peer_id, Penalty::Fatal);
+        peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+        identities.push((bls, network_key));
+    }
+    assert!(peers.ip_banned(&shared), "precondition: the shared IP is blocklisted");
+
+    for (bls, network_key) in identities {
+        peers.add_trusted_peer(bls, network_key, vec![create_multiaddr(Some(shared))]);
+    }
+
+    // INVARIANT: after both peers are trusted, nothing is still charged against their IP.
+    // CURRENT: `Peer::new_trusted` files the address under `listening_addrs`, so
+    // `known_ip_addresses()` on the fresh value is empty and `remove_banned_peer` cleans nothing.
+    assert!(!peers.ip_banned(&shared), "IP stayed blocklisted after every holder became trusted");
+}
+
+/// Disconnecting a peer that is already banned must not lose its ban accounting. If the counters
+/// stay charged while no peer is in `ConnectionStatus::Banned`, the next ban double-charges.
+#[test]
+fn disconnecting_an_already_banned_peer_settles_the_accounting() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(90));
+
+    peers.process_penalty(&peer_id, Penalty::Fatal);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    assert_ban_accounting_conserved(&peers, "after the ban");
+
+    // the manager disconnects a peer it already banned; `disconnect_peer` hardcodes `banned: false`
+    peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+
+    // INVARIANT: the peer is no longer banned, so nothing is still charged for it.
+    // CURRENT: `handle_disconnecting_transition` sets the new status before inspecting the old
+    // one, and its `Banned` arm only logs - `remove_banned_peer` is never called.
+    assert_ban_accounting_conserved(&peers, "after disconnecting an already-banned peer");
+}
+/// Re-banning a peer whose earlier ban was never settled must not charge it twice, or the ban
+/// table grows a permanent surplus for a single peer.
+#[test]
+fn re_banning_a_peer_does_not_double_charge_it() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(91));
+
+    peers.process_penalty(&peer_id, Penalty::Fatal);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Disconnecting { reason: DisconnectReason::ExcessPeers },
+    );
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+
+    // the same peer is banned again from the Disconnected state
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Banned);
+
+    // INVARIANT: one banned peer is worth exactly one charge.
+    // CURRENT: the first charge was never released, so `add_banned_peer` takes the total to 2.
+    assert_ban_accounting_conserved(&peers, "after re-banning the same peer");
+}
+/// A peer's ban must charge only its own IPs. If the charge is released against whatever addresses
+/// the peer holds at release time, one peer's unban can cancel another peer's ban.
+#[test]
+fn releasing_a_ban_cannot_cancel_another_peers_ban() {
+    let mut peers = all_peers();
+    let shared = ip(93);
+
+    // two peers banned from the shared address, enough to blocklist it
+    for seed in 30..32u8 {
+        let (bls, network_key) = random_keys(seed);
+        let peer_id: PeerId = network_key.clone().into();
+        peers.update_connection_status(
+            &peer_id,
+            NewConnectionStatus::Connected {
+                multiaddr: create_multiaddr(Some(shared)),
+                direction: ConnectionDirection::Incoming,
+            },
+        );
+        peers.upsert_peer(bls, network_key, vec![create_multiaddr(Some(shared))]);
+        peers.process_penalty(&peer_id, Penalty::Fatal);
+        peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    }
+    assert!(peers.ip_banned(&shared), "precondition: the shared address is blocklisted");
+
+    // an unrelated peer is banned from its own address, then learns the shared one from a record
+    let (bls, network_key) = random_keys(32);
+    let outsider: PeerId = network_key.clone().into();
+    peers.update_connection_status(
+        &outsider,
+        NewConnectionStatus::Connected {
+            multiaddr: create_multiaddr(Some(ip(94))),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    peers.process_penalty(&outsider, Penalty::Fatal);
+    peers.update_connection_status(&outsider, NewConnectionStatus::Disconnected);
+    peers.upsert_peer(bls, network_key, vec![create_multiaddr(Some(shared))]);
+
+    // releasing the outsider's own ban
+    peers.update_connection_status(&outsider, NewConnectionStatus::Unbanned);
+
+    // INVARIANT: two peers are still banned at the shared address, so it stays blocklisted.
+    // CURRENT: `remove_banned_peer` decrements every IP the peer holds *at release time*, which
+    // now includes an address it never charged.
+    assert!(
+        peers.ip_banned(&shared),
+        "one peer's unban cancelled a charge belonging to two other banned peers"
+    );
+}
+/// Promoting an unrelated peer to trusted must not touch the ban accounting at all.
+#[test]
+fn promoting_an_unrelated_peer_to_trusted_leaves_the_ban_total_alone() {
+    let mut peers = all_peers();
+
+    let banned = connect_from(&mut peers, ip(97));
+    peers.process_penalty(&banned, Penalty::Fatal);
+    peers.update_connection_status(&banned, NewConnectionStatus::Disconnected);
+    assert_eq!(peers.banned_peers.total(), 1, "precondition: exactly one banned peer");
+
+    let (bls, network_key) = random_keys(40);
+    peers.add_trusted_peer(bls, network_key, vec![create_multiaddr(Some(ip(98)))]);
+
+    // INVARIANT: adding a trusted peer that was never banned changes nothing.
+    // CURRENT: `add_trusted_peer` calls `remove_banned_peer`, whose unconditional
+    // `total.saturating_sub(1)` runs even though the IP iterator it is handed is always empty.
+    assert_ban_accounting_conserved(&peers, "after promoting an unrelated peer to trusted");
+}


### PR DESCRIPTION
## Summary

Make the ban-table accounting a conserved quantity that cannot drift from the set of banned peers.

- capacity eviction retires the oldest bans instead of the newest, so a flood of new identities cannot flush the bans just earned
- a ban is released against exactly the ip addresses it charged, keyed by peer id; the total is derived from that map rather than a hand-maintained counter, so it cannot drift

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No wire-format or message-shape change, so it stays rolling-upgrade safe.
