### PR TITLE
fix: decay on wall time and act on the heartbeat verdict

### DIFF
--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -103,21 +103,30 @@ impl AllPeers {
         addrs: Vec<Multiaddr>,
     ) {
         let peer_id: PeerId = network_key.clone().into();
+
+        // Check if this peer is a committee member - only committee members get trusted status
+        let is_committee_member = self.current_committee_keys.contains_key(&bls_public_key);
+        if is_committee_member {
+            // this call is the only place the key-to-peer mapping becomes known for a member the
+            // epoch boundary could not resolve, so record it here or the exemption waits an epoch
+            self.current_committee_keys.insert(bls_public_key, Some(peer_id));
+            self.current_committee.insert(peer_id);
+        }
+
         if let Some(peer) = self.peers.get_mut(&peer_id) {
             debug!(target: "peer-manager", peer=?peer, "peer already exists, overwriting");
             peer.update_net(bls_public_key, network_key, addrs);
-        } else {
-            // Check if this peer is a committee member - only committee members get trusted status
-            let is_committee_member = self.current_committee_keys.contains_key(&bls_public_key);
-            let peer;
+
+            // a committee member that connected before its record arrived was created untrusted
             if is_committee_member {
-                debug!(target: "peer-manager", ?peer_id, "committee member peer does not exist, creating trusted");
-                peer = Peer::new_trusted(bls_public_key, network_key, addrs);
-            } else {
-                debug!(target: "peer-manager", ?peer_id, "peer does not exist, creating new peer");
-                peer = Peer::new(bls_public_key, network_key, addrs);
+                peer.make_trusted();
             }
-            self.peers.insert(peer_id, peer);
+        } else if is_committee_member {
+            debug!(target: "peer-manager", ?peer_id, "committee member peer does not exist, creating trusted");
+            self.peers.insert(peer_id, Peer::new_trusted(bls_public_key, network_key, addrs));
+        } else {
+            debug!(target: "peer-manager", ?peer_id, "peer does not exist, creating new peer");
+            self.peers.insert(peer_id, Peer::new(bls_public_key, network_key, addrs));
         }
     }
 
@@ -870,9 +879,11 @@ impl AllPeers {
     /// associated with the committee node are reset. The advertised
     /// listening addresses are updated and the peer is marked `trusted`
     /// so it won't incur any additional penalties.
+    /// Members whose [`NetworkInfo`] is not yet resolved are passed as `None`. Their keys are still
+    /// recorded, so [`Self::upsert_peer`] recognizes them as soon as discovery resolves the record.
     pub(super) fn new_epoch(
         &mut self,
-        committee: Vec<(BlsPublicKey, NetworkInfo)>,
+        committee: Vec<(BlsPublicKey, Option<NetworkInfo>)>,
     ) -> Vec<(PeerId, PeerAction)> {
         // clear self.current_committee and store the peers as old committee to then produce delta
         // from
@@ -881,7 +892,13 @@ impl AllPeers {
         self.current_committee_keys.clear();
 
         let mut actions = Vec::with_capacity(committee.len());
-        for (bls_key, NetworkInfo { pubkey, multiaddrs: addr, .. }) in committee {
+        for (bls_key, network_info) in committee {
+            let Some(NetworkInfo { pubkey, multiaddrs: addr, .. }) = network_info else {
+                // record the key so a later resolution is recognized within this epoch
+                self.current_committee_keys.insert(bls_key, None);
+                continue;
+            };
+
             let peer_id: PeerId = pubkey.clone().into();
             self.current_committee.insert(peer_id);
             self.current_committee_keys.insert(bls_key, Some(peer_id));

--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -255,25 +255,28 @@ impl AllPeers {
     /// Update scores for heartbeat interval.
     ///
     /// Returns any subsequent actions the peer manager should take after the peer's score is
-    /// updated. Peers are possibly unbanned, but penalties are not applied with this method.
-    /// It's impossible for a peer to become banned during heartbeat maintenance.
+    /// updated. Penalties are not applied here: decay moves a score toward zero, so the heartbeat
+    /// can lift a peer out of a ban but never push one into it.
     ///
-    /// See [Self::apply_penalty] for ban logic.
+    /// See [Self::process_penalty] for ban logic.
     fn update_peer_scores(&mut self) -> Vec<(PeerId, PeerAction)> {
-        // filter peers that are eligible to become unbanned
-        let unbanned_peers = self.peers.iter_mut().filter_map(|(id, peer)| {
+        let transitions = self.peers.iter_mut().filter_map(|(id, peer)| {
             let update = peer.heartbeat();
             match update {
-                ReputationUpdate::Unbanned => {
-                    Some(*id)
-                },
-                // filter other results and log error
-                ReputationUpdate::Banned | ReputationUpdate::Disconnect => {
+                ReputationUpdate::Unbanned => Some((*id, NewConnectionStatus::Unbanned)),
+                // a connected peer below the disconnect threshold. Decay alone will not lift it
+                // before the next beat, so shed the connection rather than restating the verdict
+                // every heartbeat for as long as the score stays down.
+                ReputationUpdate::Disconnect => Some((
+                    *id,
+                    NewConnectionStatus::Disconnecting { reason: DisconnectReason::Penalized },
+                )),
+                ReputationUpdate::Banned => {
                     error!(
                         target: "peer-manager",
                         ?update,
                         ?id,
-                        "peer reputation penalized during heartbeat - penalties only expected to decay"
+                        "peer reached the ban threshold during heartbeat - decay cannot lower a score"
                     );
                     None
                 },
@@ -282,11 +285,11 @@ impl AllPeers {
         }).collect::<Vec<_>>();
 
         // update peer connection status and return actions for manager
-        unbanned_peers
-            .iter()
-            .map(|id| {
-                let action = self.update_connection_status(id, NewConnectionStatus::Unbanned);
-                (*id, action)
+        transitions
+            .into_iter()
+            .map(|(id, status)| {
+                let action = self.update_connection_status(&id, status);
+                (id, action)
             })
             .collect()
     }

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -651,27 +651,33 @@ impl PeerManager {
     /// Update the committee for the new epoch.
     pub(crate) fn new_epoch(&mut self, committee: HashSet<BlsPublicKey>) {
         // remove from temporary banned and warn if validator was banned
-        let mut exp_committee = Vec::default();
+        //
+        // every committee key is forwarded, resolved or not: membership is decided by stake, so a
+        // member this node has not discovered yet must still be recognized the moment its record
+        // arrives rather than at the next boundary
+        let mut exp_committee = Vec::with_capacity(committee.len());
         for bls_key in &committee {
-            if let Some(NetworkInfo { pubkey, multiaddrs: multiaddr, timestamp }) =
+            let Some(NetworkInfo { pubkey, multiaddrs: multiaddr, timestamp }) =
                 self.known_peers.get(bls_key)
-            {
-                let peer_id: PeerId = pubkey.clone().into();
-                info!(target: "peer-manager", "adding committee member {bls_key}/{peer_id}");
-                if self.temporarily_banned.remove(&peer_id) {
-                    warn!(target: "peer-manager", ?peer_id, "removed committee member from temporarily banned list");
-                }
-                exp_committee.push((
-                    *bls_key,
-                    NetworkInfo {
-                        pubkey: pubkey.clone(),
-                        multiaddrs: multiaddr.clone(),
-                        timestamp: *timestamp,
-                    },
-                ));
-            } else {
+            else {
                 warn!(target: "peer-manager", "unknown committee member with key {bls_key}");
+                exp_committee.push((*bls_key, None));
+                continue;
+            };
+
+            let peer_id: PeerId = pubkey.clone().into();
+            info!(target: "peer-manager", "adding committee member {bls_key}/{peer_id}");
+            if self.temporarily_banned.remove(&peer_id) {
+                warn!(target: "peer-manager", ?peer_id, "removed committee member from temporarily banned list");
             }
+            exp_committee.push((
+                *bls_key,
+                Some(NetworkInfo {
+                    pubkey: pubkey.clone(),
+                    multiaddrs: multiaddr.clone(),
+                    timestamp: *timestamp,
+                }),
+            ));
         }
 
         // add trusted peer record

--- a/crates/consensus/network/src/peers/score.rs
+++ b/crates/consensus/network/src/peers/score.rs
@@ -10,26 +10,35 @@ use rayls_infrastructure_config::ScoreConfig;
 use serde::Serialize;
 use std::{
     fmt::Display,
-    sync::{Arc, OnceLock},
+    sync::{Arc, RwLock},
     time::Instant,
 };
 
-/// Global static configuration that is initialized only once for all peers.
-pub(crate) static GLOBAL_SCORE_CONFIG: OnceLock<Arc<ScoreConfig>> = OnceLock::new();
+/// Global peer score configuration.
+///
+/// A node runs with one configuration for its whole life, so production installs it once through
+/// `init_peer_score_config`. The lock, rather than a `OnceLock`, lets the test harness install a
+/// fresh configuration per case: `cargo test` runs the whole suite in one process, so a write-once
+/// cell would leak the first case's configuration into every later one.
+pub(crate) static GLOBAL_SCORE_CONFIG: RwLock<Option<Arc<ScoreConfig>>> = RwLock::new(None);
 
-/// Initialize the global peer score configuration.
+/// Install the global peer score configuration.
+///
+/// Sets the configuration only once: a node installs it at startup, and a later caller (a second
+/// `PeerManager`, or a test's node harness) must not overwrite a configuration already in force.
 pub(super) fn init_peer_score_config(config: ScoreConfig) {
-    let config = Arc::new(config);
-
-    // allow multiple calls to this fn
-    let _ = GLOBAL_SCORE_CONFIG.set(config);
+    let mut guard = GLOBAL_SCORE_CONFIG.write().expect("score config lock poisoned");
+    if guard.is_none() {
+        *guard = Some(Arc::new(config));
+    }
 }
 
-/// Get a reference to the global peer score configuration
+/// Get a clone of the global peer score configuration.
 ///
-/// Panics if score config isn't set.
+/// Panics if the configuration has not been installed.
 fn global_score_config() -> Arc<ScoreConfig> {
-    GLOBAL_SCORE_CONFIG.get().expect("Peer score configuration not initialized").clone()
+    let config = GLOBAL_SCORE_CONFIG.read().expect("score config lock poisoned").clone();
+    config.expect("Peer score configuration not initialized")
 }
 
 /// A peer's score (perceived potential usefulness).
@@ -122,13 +131,17 @@ impl Score {
     /// NOTE: this is a separate method for testing purposes.
     fn update_at(&mut self, now: Instant) {
         if let Some(prev_update) =
-            now.checked_duration_since(self.last_updated).map(|d| d.as_secs())
+            now.checked_duration_since(self.last_updated).map(|d| d.as_secs_f64())
         {
             let config = global_score_config();
 
             // e^(-ln(2)/HL*t)
+            //
+            // the elapsed time is not truncated to whole seconds: `last_updated` advances
+            // unconditionally below, so a discarded remainder is never decayed later, and a
+            // caller running more often than once a second would stop decay entirely
             let halflife_decay = config.halflife_decay();
-            let decay_factor = (halflife_decay * prev_update as f64).exp();
+            let decay_factor = (halflife_decay * prev_update).exp();
             self.rayls_score *= decay_factor;
             self.last_updated = now;
             self.update_score();

--- a/crates/consensus/network/src/tests/common.rs
+++ b/crates/consensus/network/src/tests/common.rs
@@ -10,25 +10,21 @@ use rayls_infrastructure_types::{
 use serde::{Deserialize, Serialize};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::{Arc, Once},
+    sync::Arc,
 };
 
 /// Default heartbeat for tests.
 #[allow(dead_code)] // used in network_tests.rs
 pub(crate) const TEST_HEARTBEAT_INTERVAL: u64 = 1;
 
-// ensure `init_peer_score_config` is only set once
-static INIT: Once = Once::new();
-
-// allow dead code due to compile warning that this fn is never used
-// but it is used in `all_peers` and `banned_peers`
-/// Initialize without error for unit tests.
-#[allow(dead_code)]
+/// Install a score configuration for the current test.
+///
+/// Overwrites any prior value: `cargo test --test-threads 1` shares one process, so each test
+/// installs the configuration it needs at setup rather than inheriting the first test's.
+#[allow(dead_code)] // used in `all_peers` and `banned_peers`
 pub(crate) fn ensure_score_config(config: Option<ScoreConfig>) {
-    INIT.call_once(|| {
-        // ignore result
-        let _ = GLOBAL_SCORE_CONFIG.set(Arc::new(config.unwrap_or_default()));
-    });
+    *GLOBAL_SCORE_CONFIG.write().expect("score config lock poisoned") =
+        Some(Arc::new(config.unwrap_or_default()));
 }
 
 // impl RLMessage trait for types

--- a/crates/consensus/network/src/tests/peer_manager.rs
+++ b/crates/consensus/network/src/tests/peer_manager.rs
@@ -561,6 +561,67 @@ async fn test_is_validator() {
 
     // Verify random peer is not a validator
     assert!(!peer_manager.is_peer_validator(&random_peer_id));
+
+    // Verify the committee member this node had already resolved IS a validator. Without this the
+    // test passes even if `new_epoch` recognizes nobody at all.
+    let resolved: PeerId = config.key_config().primary_network_public_key().into();
+    assert!(peer_manager.is_peer_validator(&resolved));
+}
+
+/// A committee member this node resolves after the epoch boundary must be absolved from that
+/// moment, not from the next boundary. Committee membership is decided by stake; whether local
+/// discovery has caught up is this node's problem, not the validator's.
+///
+/// The node genuinely cannot exempt a peer before it resolves the key-to-peer mapping, so the
+/// invariant starts at resolution.
+#[tokio::test]
+async fn test_committee_member_resolved_mid_epoch_is_absolved_immediately() {
+    let all_nodes = CommitteeFixture::builder(MemDatabase::default).build();
+    let mut authorities = all_nodes.authorities();
+    let authority_1 = authorities.next().expect("first authority");
+    let authority_2 = authorities.next().expect("second authority");
+    let config = authority_1.consensus_config();
+    let mut peer_manager = PeerManager::new(config.network_config().peer_config());
+
+    // this node resolved itself but not authority_2, the ordinary state on a fresh start or a
+    // restart before discovery has caught up
+    peer_manager.add_known_peer(
+        *authority_1.authority().protocol_key(),
+        NetworkInfo {
+            pubkey: config.key_config().primary_network_public_key(),
+            multiaddrs: vec![config.primary_address()],
+            timestamp: now(),
+        },
+    );
+    peer_manager.new_epoch(config.committee_pub_keys());
+
+    // authority_2 connects before its record arrives, so it is tracked as an ordinary peer
+    let config_2 = authority_2.consensus_config();
+    let unresolved: PeerId = config_2.key_config().primary_network_public_key().into();
+    assert!(peer_manager.register_peer_connection(
+        &unresolved,
+        ConnectionType::IncomingConnection { multiaddr: create_multiaddr(None) }
+    ));
+
+    // discovery completes and the record resolves mid-epoch
+    peer_manager.add_known_peer(
+        *authority_2.authority().protocol_key(),
+        NetworkInfo {
+            pubkey: config_2.key_config().primary_network_public_key(),
+            multiaddrs: vec![config_2.primary_address()],
+            timestamp: now(),
+        },
+    );
+
+    // INVARIANT: resolution grants the exemption, so penalties from this point are absolved.
+    // CURRENT: `new_epoch` rebuilds `current_committee_keys` only from members it could already
+    // resolve, so `upsert_peer` sees an unknown key and leaves the peer untrusted for the epoch.
+    assert!(
+        peer_manager.is_peer_validator(&unresolved),
+        "a committee member resolved mid-epoch was not recognized as a validator"
+    );
+    peer_manager.process_penalty(unresolved, Penalty::Fatal);
+    assert!(!peer_manager.peer_banned(&unresolved), "a committee member was banned by a penalty");
 }
 
 /// The admission check and the registration check must use the same ban predicate. If the swarm

--- a/crates/consensus/network/src/tests/peers.rs
+++ b/crates/consensus/network/src/tests/peers.rs
@@ -66,13 +66,16 @@ fn test_poc_stale_trust_persists_for_rotated_out_committee_member() {
     all_peers.new_epoch(vec![
         (
             bls_c,
-            NetworkInfo {
+            Some(NetworkInfo {
                 pubkey: net_c.clone(),
                 multiaddrs: vec![addr_c.clone()],
                 timestamp: now(),
-            },
+            }),
         ),
-        (bls_b, NetworkInfo { pubkey: net_b, multiaddrs: vec![addr_b.clone()], timestamp: now() }),
+        (
+            bls_b,
+            Some(NetworkInfo { pubkey: net_b, multiaddrs: vec![addr_b.clone()], timestamp: now() }),
+        ),
     ]);
 
     assert!(all_peers.is_peer_validator(&peer_id_b), "B must be a validator");
@@ -80,7 +83,7 @@ fn test_poc_stale_trust_persists_for_rotated_out_committee_member() {
     // Rotate to epoch N+1 committee (excluding B).
     all_peers.new_epoch(vec![(
         bls_c,
-        NetworkInfo { pubkey: net_c, multiaddrs: vec![addr_c], timestamp: now() },
+        Some(NetworkInfo { pubkey: net_c, multiaddrs: vec![addr_c], timestamp: now() }),
     )]);
 
     assert!(!all_peers.is_peer_validator(&peer_id_b), "B must not be a validator after rotation");

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -13,13 +13,13 @@ use crate::common::{create_multiaddr, ensure_score_config};
 use libp2p::PeerId;
 use rand::{rngs::StdRng, SeedableRng as _};
 use rayls_infrastructure_config::{PeerConfig, ScoreConfig};
-use rayls_infrastructure_types::{now, BlsKeypair, NetworkKeypair};
+use rayls_infrastructure_types::{BlsKeypair, NetworkKeypair};
 use std::net::{IpAddr, Ipv4Addr};
 
-/// Build an `AllPeers` from an operator config, installing its `ScoreConfig` globally.
+/// Build an `AllPeers` from an operator config, installing its `ScoreConfig` for this test.
 ///
-/// `ScoreConfig` lands in a process-wide `OnceLock`; nextest runs one process per test, so each
-/// test gets its own. Under `cargo test` this would be order-dependent.
+/// The configuration is process-global but overwritten per test, so under `cargo test
+/// --test-threads 1` each case runs against the config it installs here.
 fn all_peers_with(config: PeerConfig) -> AllPeers {
     ensure_score_config(Some(config.score_config));
     AllPeers::new(Duration::from_secs(5), config.max_banned_peers, config.max_disconnected_peers)
@@ -582,4 +582,36 @@ fn promoting_an_unrelated_peer_to_trusted_leaves_the_ban_total_alone() {
     // CURRENT: `add_trusted_peer` calls `remove_banned_peer`, whose unconditional
     // `total.saturating_sub(1)` runs even though the IP iterator it is handed is always empty.
     assert_ban_accounting_conserved(&peers, "after promoting an unrelated peer to trusted");
+}
+
+// Absolution
+
+/// Decay is a function of elapsed wall time. Running the heartbeat more often must not slow it
+/// down, or a node with a fast heartbeat never forgives anything.
+#[test]
+fn decay_depends_on_elapsed_time_not_on_heartbeat_frequency() {
+    let config = PeerConfig {
+        score_config: ScoreConfig { score_halflife: 1.0, ..Default::default() },
+        ..Default::default()
+    };
+    let mut peers = all_peers_with(config);
+
+    let peer_id = connect_from(&mut peers, ip(40));
+    peers.process_penalty(&peer_id, Penalty::Medium);
+    let after_penalty = score_of(&peers, &peer_id);
+
+    // one halflife of wall time, sampled every 100ms
+    for _ in 0..10 {
+        std::thread::sleep(Duration::from_millis(100));
+        peers.heartbeat_maintenance();
+    }
+
+    // INVARIANT: after one halflife the score has moved roughly halfway back to zero.
+    // CURRENT: `Score::update_at` truncates elapsed to whole seconds but advances `last_updated`
+    // unconditionally, so a sub-second sampling cadence discards every remainder.
+    assert!(
+        score_of(&peers, &peer_id) > after_penalty / 2.0,
+        "score did not decay across one halflife sampled at 100ms: {} vs {after_penalty}",
+        score_of(&peers, &peer_id)
+    );
 }

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -615,3 +615,42 @@ fn decay_depends_on_elapsed_time_not_on_heartbeat_frequency() {
         score_of(&peers, &peer_id)
     );
 }
+
+// Heartbeat verdicts
+
+/// Every verdict the heartbeat reaches must be acted on. A verdict that is computed and then
+/// dropped is a control that reads as present and is not.
+#[test]
+fn the_heartbeat_acts_on_a_disconnect_verdict() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(60));
+
+    // drive the peer clearly below the disconnect threshold, then let it reconnect with its score
+    // intact. One more penalty past the threshold keeps the verdict stable across the sub-second
+    // decay the heartbeat applies before reading the reputation back.
+    penalize_to_disconnect_threshold(&mut peers, &peer_id);
+    peers.process_penalty(&peer_id, Penalty::Medium);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Connected {
+            multiaddr: create_multiaddr(Some(ip(60))),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+    assert_eq!(
+        peers.get_peer(&peer_id).expect("known").reputation(),
+        Reputation::Disconnected,
+        "precondition: a connected peer sitting below the disconnect threshold"
+    );
+
+    let actions = peers.heartbeat_maintenance();
+
+    // a verdict the heartbeat computes and drops is a control that reads as present and is not,
+    // and it restates itself at error level on every beat for as long as the score stays down
+    assert!(
+        actions.iter().any(|(id, action)| *id == peer_id
+            && matches!(action, PeerAction::Disconnect | PeerAction::DisconnectWithPX)),
+        "heartbeat reached a disconnect verdict but returned no action: {actions:?}"
+    );
+}

--- a/crates/infrastructure/config/src/network.rs
+++ b/crates/infrastructure/config/src/network.rs
@@ -4,7 +4,7 @@ use crate::{ConfigFmt, ConfigTrait, RaylsDirs};
 use libp2p::{kad::K_VALUE, request_response::ProtocolSupport, StreamProtocol};
 use rayls_infrastructure_types::Round;
 use serde::{Deserialize, Serialize};
-use std::{num::NonZeroUsize, sync::OnceLock, time::Duration};
+use std::{num::NonZeroUsize, time::Duration};
 
 /// topic to be sent with the transactions batch gossip
 pub const GOSSIP_TOPIC_TXN: &str = "rayls-batch";
@@ -443,14 +443,12 @@ impl ScoreConfig {
         Duration::from_secs(self.banned_before_decay_secs)
     }
 
-    /// Calculate the halflife decay constant =
-    /// -(2.0f64.ln()) / self.score_halflife
+    /// Calculate the halflife decay constant, `-ln(2) / score_halflife`.
+    ///
+    /// Computed from `self` on every call: a process-wide cache would freeze the constant at the
+    /// first configuration it ever saw and ignore every later one.
     pub fn halflife_decay(&self) -> f64 {
-        // static cache that persists
-        static CACHE: OnceLock<f64> = OnceLock::new();
-
-        // return the cached value if it exists
-        *CACHE.get_or_init(|| -(2.0f64.ln()) / self.score_halflife)
+        -(2.0f64.ln()) / self.score_halflife
     }
 }
 


### PR DESCRIPTION
## Summary

Correct reputation decay and ensure every heartbeat verdict is acted on.

- decay accounts the fractional part of the elapsed interval, so a caller running more than once a second no longer stops decay entirely and strands a ban forever
- a committee member whose record resolves after the epoch boundary is recognized immediately, restoring its penalty absolution and ban exemption instead of waiting a whole epoch
- the heartbeat acts on the disconnect verdict it reaches instead of dropping it and restating it as an error every beat

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No wire-format or message-shape change, so it stays rolling-upgrade safe.
