### PR TITLE
fix: charge ip bans from observed state and unify thresholds

### DIFF
--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -390,6 +390,11 @@ impl AllPeers {
         multiaddr: Multiaddr,
         direction: ConnectionDirection,
     ) -> PeerAction {
+        // a ban cleared here has to be announced: the gossipsub blacklist and the kad routing
+        // entry are repaired only by `PeerAction::Unban`, so releasing the counters silently
+        // leaves the peer blocked in stores this method does not own
+        let mut unbanned_ips = None;
+
         if let Some(peer) = self.peers.get_mut(peer_id) {
             // update counters based on previous state
             match current_status {
@@ -398,7 +403,7 @@ impl AllPeers {
                 }
                 ConnectionStatus::Banned { .. } => {
                     error!(target: "peer-manager", ?peer_id, "accepted a connection from a banned peer");
-                    self.banned_peers.remove_banned_peer(peer_id);
+                    unbanned_ips = Some(self.banned_peers.remove_banned_peer(peer_id));
                 }
                 ConnectionStatus::Disconnecting { .. } => {
                     warn!(target: "peer-manager", ?peer_id, "connected to a disconnecting peer")
@@ -415,7 +420,10 @@ impl AllPeers {
             }
         }
 
-        PeerAction::NoAction
+        match unbanned_ips {
+            Some(ip_addrs) => PeerAction::Unban(ip_addrs),
+            None => PeerAction::NoAction,
+        }
     }
 
     /// Handle transition to Dialing state
@@ -424,11 +432,15 @@ impl AllPeers {
         peer_id: &PeerId,
         current_status: ConnectionStatus,
     ) -> PeerAction {
+        // see `handle_connected_transition`: clearing a ban without announcing it strands the
+        // gossipsub blacklist and the kad routing entry the ban removed
+        let mut unbanned_ips = None;
+
         if let Some(peer) = self.peers.get_mut(peer_id) {
             match current_status {
                 ConnectionStatus::Banned { .. } => {
                     warn!(target: "peer-manager", ?peer_id, "dialing a banned peer");
-                    self.banned_peers.remove_banned_peer(peer_id);
+                    unbanned_ips = Some(self.banned_peers.remove_banned_peer(peer_id));
                 }
                 ConnectionStatus::Disconnected { .. } => {
                     self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
@@ -450,7 +462,10 @@ impl AllPeers {
             }
         }
 
-        PeerAction::NoAction
+        match unbanned_ips {
+            Some(ip_addrs) => PeerAction::Unban(ip_addrs),
+            None => PeerAction::NoAction,
+        }
     }
 
     /// Handle transition to Disconnected state

--- a/crates/consensus/network/src/peers/peer.rs
+++ b/crates/consensus/network/src/peers/peer.rs
@@ -116,6 +116,10 @@ impl Peer {
     }
 
     /// Update keys and network address.
+    ///
+    /// The addresses come from the peer's own record, so they are recorded as advertised rather
+    /// than witnessed. `multiaddrs` drives ban accounting and peer exchange, and a peer must be
+    /// able to neither charge nor advertise an address this node has not seen it connect from.
     pub(super) fn update_net(
         &mut self,
         bls_public_key: BlsPublicKey,
@@ -124,8 +128,7 @@ impl Peer {
     ) {
         self.bls_public_key = Some(bls_public_key);
         self.network_key = Some(network_key);
-        self.multiaddrs.extend(multiaddrs);
-        self.prune_multiaddrs();
+        self.update_listening_addrs(multiaddrs);
     }
 
     /// Rayls: Remove excess multiaddrs when exceeding limit.
@@ -348,6 +351,10 @@ impl Peer {
     pub(super) fn update_listening_addrs(&mut self, multiaddrs: Vec<Multiaddr>) -> bool {
         let mut res = false;
         for multiaddr in multiaddrs {
+            // these are peer-supplied, so the set needs the same bound `multiaddrs` carries
+            if self.listening_addrs.len() >= MAX_MULTIADDRS_PER_PEER {
+                break;
+            }
             if !self.listening_addrs.contains(&multiaddr) {
                 self.listening_addrs.push(multiaddr);
                 res = true;

--- a/crates/consensus/network/src/peers/peer.rs
+++ b/crates/consensus/network/src/peers/peer.rs
@@ -1,13 +1,12 @@
 //! Information shared between peers.
 
 use super::{
-    score::{Reputation, ReputationUpdate, Score},
+    score::{global_score_config, Reputation, ReputationUpdate, Score},
     status::ConnectionStatus,
     types::ConnectionDirection,
     Penalty,
 };
 use libp2p::{core::multiaddr::Multiaddr, PeerId};
-use rayls_infrastructure_config::PeerConfig;
 use rayls_infrastructure_types::{BlsPublicKey, NetworkPublicKey, Protocol};
 use std::{collections::HashSet, net::IpAddr, time::Instant};
 use tracing::error;
@@ -26,8 +25,6 @@ pub(super) struct Peer {
     bls_public_key: Option<BlsPublicKey>,
     /// The peers network public key (libp2p public key).
     network_key: Option<NetworkPublicKey>,
-    /// The config
-    config: PeerConfig,
     /// The peer's score - used to derive [Reputation].
     score: Score,
     /// The multiaddrs this node has witnessed the peer using.
@@ -65,7 +62,6 @@ impl Peer {
             listening_addrs,
             score: Score::new_max(),
             is_trusted: true,
-            config: Default::default(),
             multiaddrs: Default::default(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
@@ -85,7 +81,6 @@ impl Peer {
             listening_addrs,
             score: Score::default(),
             is_trusted: false,
-            config: Default::default(),
             multiaddrs: Default::default(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
@@ -107,7 +102,6 @@ impl Peer {
             listening_addrs,
             score: Score::new_max(),
             is_trusted: false,
-            config: Default::default(),
             multiaddrs: Default::default(),
             connection_status: Default::default(),
             connection_direction: Default::default(),
@@ -148,10 +142,15 @@ impl Peer {
     }
 
     /// Return a peer's reputation based on the aggregate score.
+    ///
+    /// The thresholds come from the score config, the same source [`Score::is_banned`] reads to arm
+    /// the decay freeze. A second pair of thresholds would have to agree with these for the freeze
+    /// and the verdict to describe the same peers, and nothing could enforce that.
     pub(super) fn reputation(&self) -> Reputation {
+        let config = global_score_config();
         match self.score.aggregate_score() {
-            score if score <= self.config.min_score_for_ban => Reputation::Banned,
-            score if score <= self.config.min_score_for_disconnect => Reputation::Disconnected,
+            score if score <= config.min_score_before_ban => Reputation::Banned,
+            score if score <= config.min_score_before_disconnect => Reputation::Disconnected,
             _ => Reputation::Trusted,
         }
     }

--- a/crates/consensus/network/src/peers/score.rs
+++ b/crates/consensus/network/src/peers/score.rs
@@ -36,7 +36,7 @@ pub(super) fn init_peer_score_config(config: ScoreConfig) {
 /// Get a clone of the global peer score configuration.
 ///
 /// Panics if the configuration has not been installed.
-fn global_score_config() -> Arc<ScoreConfig> {
+pub(super) fn global_score_config() -> Arc<ScoreConfig> {
     let config = GLOBAL_SCORE_CONFIG.read().expect("score config lock poisoned").clone();
     config.expect("Peer score configuration not initialized")
 }

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -691,3 +691,51 @@ fn only_observed_addresses_charge_the_ip_ban_table() {
         "two peers blocklisted an address neither of them ever connected from"
     );
 }
+
+/// Clearing a peer's ban is a decision other stores must hear about - the gossipsub blacklist and
+/// the kad routing table are repaired only by `PeerAction::Unban`.
+#[test]
+fn clearing_a_ban_on_dial_emits_an_unban_action() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(92));
+
+    peers.process_penalty(&peer_id, Penalty::Fatal);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    assert_eq!(peers.banned_peers.total(), 1, "precondition: the peer is banned and charged");
+
+    let action = peers.update_connection_status(&peer_id, NewConnectionStatus::Dialing);
+
+    // INVARIANT: a transition that clears the ban stores announces it.
+    // CURRENT: `handle_dialing_transition`'s `Banned` arm calls `remove_banned_peer` and then
+    // returns `NoAction`, so the peer is silently un-charged while the gossipsub blacklist and the
+    // kad routing entry stay as the ban left them.
+    assert!(
+        matches!(action, PeerAction::Unban(_)),
+        "ban cleared on dial without an Unban action: {action:?}"
+    );
+}
+
+/// The same law on the connect path. Accepting a connection from a banned peer releases the ban,
+/// so it carries the same obligation to announce it.
+#[test]
+fn clearing_a_ban_on_connect_emits_an_unban_action() {
+    let mut peers = all_peers();
+    let peer_id = connect_from(&mut peers, ip(99));
+
+    peers.process_penalty(&peer_id, Penalty::Fatal);
+    peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    assert_eq!(peers.banned_peers.total(), 1, "precondition: the peer is banned and charged");
+
+    let action = peers.update_connection_status(
+        &peer_id,
+        NewConnectionStatus::Connected {
+            multiaddr: create_multiaddr(Some(ip(99))),
+            direction: ConnectionDirection::Incoming,
+        },
+    );
+
+    assert!(
+        matches!(action, PeerAction::Unban(_)),
+        "ban cleared on connect without an Unban action: {action:?}"
+    );
+}

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -64,13 +64,13 @@ fn score_of(all_peers: &AllPeers, peer_id: &PeerId) -> f64 {
 /// Apply `Medium` penalties until the peer's score reaches the disconnect threshold, returning the
 /// last action. Deliberately stops short of the ban threshold.
 fn penalize_to_disconnect_threshold(all_peers: &mut AllPeers, peer_id: &PeerId) -> PeerAction {
-    let config = PeerConfig::default();
+    let config = ScoreConfig::default();
     let mut action = PeerAction::NoAction;
-    while score_of(all_peers, peer_id) > config.min_score_for_disconnect {
+    while score_of(all_peers, peer_id) > config.min_score_before_disconnect {
         action = all_peers.process_penalty(peer_id, Penalty::Medium);
     }
     assert!(
-        score_of(all_peers, peer_id) > config.min_score_for_ban,
+        score_of(all_peers, peer_id) > config.min_score_before_ban,
         "helper must stop between the disconnect and ban thresholds"
     );
     action
@@ -196,7 +196,7 @@ fn a_score_driven_ban_is_released_by_score_decay() {
     let actions = peers.heartbeat_maintenance();
 
     assert!(
-        score_of(&peers, &peer_id) > config.min_score_for_disconnect,
+        score_of(&peers, &peer_id) > config.score_config.min_score_before_disconnect,
         "precondition: the score must have decayed above the disconnect threshold"
     );
 
@@ -329,15 +329,15 @@ fn penalties_clamp_at_the_configured_floor() {
 /// land on the harsher side consistently, and one point above it must not.
 #[test]
 fn reputation_boundaries_are_inclusive_at_the_threshold() {
-    let config = PeerConfig::default();
+    let config = ScoreConfig::default();
     let mut peers = all_peers();
 
     // exactly on the disconnect threshold
     let at_threshold = connect_from(&mut peers, ip(22));
-    while score_of(&peers, &at_threshold) > config.min_score_for_disconnect {
+    while score_of(&peers, &at_threshold) > config.min_score_before_disconnect {
         peers.process_penalty(&at_threshold, Penalty::Medium);
     }
-    assert_eq!(score_of(&peers, &at_threshold), config.min_score_for_disconnect);
+    assert_eq!(score_of(&peers, &at_threshold), config.min_score_before_disconnect);
     assert_eq!(
         peers.get_peer(&at_threshold).expect("known").reputation(),
         Reputation::Disconnected,
@@ -346,7 +346,7 @@ fn reputation_boundaries_are_inclusive_at_the_threshold() {
 
     // one Mild above it
     let above = connect_from(&mut peers, ip(23));
-    while score_of(&peers, &above) > config.min_score_for_disconnect + 1.0 {
+    while score_of(&peers, &above) > config.min_score_before_disconnect + 1.0 {
         peers.process_penalty(&above, Penalty::Mild);
     }
     assert_eq!(
@@ -737,5 +737,65 @@ fn clearing_a_ban_on_connect_emits_an_unban_action() {
     assert!(
         matches!(action, PeerAction::Unban(_)),
         "ban cleared on connect without an Unban action: {action:?}"
+    );
+}
+
+// Configured thresholds
+
+/// The decay freeze and the ban verdict must agree about which peers are banned. A peer the freeze
+/// holds but the verdict calls merely disconnected has a score nothing can move and a state
+/// nothing can release, because every release path keys on the verdict.
+#[test]
+fn the_decay_freeze_agrees_with_the_ban_verdict() {
+    // an operator hardens the ban threshold
+    let config = PeerConfig {
+        score_config: ScoreConfig { min_score_before_ban: -15.0, ..Default::default() },
+        ..Default::default()
+    };
+    let mut peers = all_peers_with(config);
+
+    // one peer either side of the configured threshold
+    for (octet, penalties) in [(41u8, 2usize), (43, 4)] {
+        let peer_id = connect_from(&mut peers, ip(octet));
+        for _ in 0..penalties {
+            peers.process_penalty(&peer_id, Penalty::Medium);
+        }
+
+        let peer = peers.get_peer(&peer_id).expect("known");
+        assert_eq!(
+            peer.score().is_banned(),
+            peer.reputation().banned(),
+            "the freeze and the verdict disagree at score {}",
+            peer.score().aggregate_score()
+        );
+    }
+}
+
+/// The operator's configured thresholds are the ones enforced. A security control that reads as
+/// configured but is not is worse than no knob at all, because it converts an available mitigation
+/// into a false belief that the mitigation is applied.
+#[test]
+fn operator_configured_thresholds_are_enforced() {
+    // an operator relaxes the thresholds to stop false positives
+    let config = PeerConfig {
+        score_config: ScoreConfig {
+            min_score_before_disconnect: -60.0,
+            min_score_before_ban: -80.0,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut peers = all_peers_with(config);
+
+    let peer_id = connect_from(&mut peers, ip(42));
+    for _ in 0..4 {
+        peers.process_penalty(&peer_id, Penalty::Medium);
+    }
+    assert_eq!(score_of(&peers, &peer_id), -20.0, "precondition: the peer sits at -20");
+
+    assert_eq!(
+        peers.get_peer(&peer_id).expect("known").reputation(),
+        Reputation::Trusted,
+        "the disconnect threshold was configured to -60 but a peer at -20 was disconnected"
     );
 }

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -654,3 +654,40 @@ fn the_heartbeat_acts_on_a_disconnect_verdict() {
         "heartbeat reached a disconnect verdict but returned no action: {actions:?}"
     );
 }
+
+// Provenance: what an IP charge is allowed to be derived from
+
+/// The IP ban table is a Sybil defense keyed on where a peer actually connected from. Charging it
+/// with addresses a peer merely claims lets that peer blocklist an address it does not control.
+#[test]
+fn only_observed_addresses_charge_the_ip_ban_table() {
+    let mut peers = all_peers();
+    let victim = ip(50);
+
+    // two throwaway identities, each connecting from its own address and then advertising the
+    // victim's address as one of its own in a peer record
+    for seed in 0..2u8 {
+        let (bls, network_key) = random_keys(seed);
+        let peer_id: PeerId = network_key.clone().into();
+        peers.update_connection_status(
+            &peer_id,
+            NewConnectionStatus::Connected {
+                multiaddr: create_multiaddr(Some(ip(51 + seed))),
+                direction: ConnectionDirection::Incoming,
+            },
+        );
+        peers.upsert_peer(bls, network_key, vec![create_multiaddr(Some(victim))]);
+
+        // each identity earns its own ban
+        peers.process_penalty(&peer_id, Penalty::Fatal);
+        peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
+    }
+
+    // INVARIANT: only the address this node observed the connection on is charged.
+    // CURRENT: `Peer::known_ip_addresses` reads `multiaddrs`, which `update_net` extends from the
+    // peer's own record, so two peers can blocklist any address they name.
+    assert!(
+        !peers.ip_banned(&victim),
+        "two peers blocklisted an address neither of them ever connected from"
+    );
+}

--- a/crates/infrastructure/config/src/network.rs
+++ b/crates/infrastructure/config/src/network.rs
@@ -299,10 +299,6 @@ pub struct PeerConfig {
     pub target_num_peers: usize,
     /// The timeout for dialing a peer.
     pub dial_timeout: Duration,
-    /// The threshold before a peer is disconnected
-    pub min_score_for_disconnect: f64,
-    /// The threshold before a peer is banned.
-    pub min_score_for_ban: f64,
     /// A fraction of `Self::target_num_peers` that is allowed to connect to this node in excess of
     /// `PeerManager::target_num_peers`.
     ///
@@ -346,8 +342,6 @@ impl Default for PeerConfig {
             heartbeat_interval: 30,
             target_num_peers,
             dial_timeout: Duration::from_secs(15),
-            min_score_for_disconnect: -20.0,
-            min_score_for_ban: -50.0,
             peer_excess_factor: 0.3,
             priority_peer_excess: 0.2,
             target_outbound_only_factor: 0.3,


### PR DESCRIPTION
## Summary

Ground ban-ip charges and thresholds in observed state, and propagate a cleared ban to the stores that hold it.

- the ip ban table is charged only from addresses this node observed the peer connect from, not from addresses the peer advertised in its own record
- a ban cleared by a reconnect or a dial returns PeerAction::Unban, so the gossipsub blacklist and kad routing entry the ban removed are repaired
- reputation reads one configured pair of thresholds, so the decay freeze and the ban verdict describe the same peers

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No wire-format or message-shape change, so it stays rolling-upgrade safe.
