### PR TITLE
fix: correct committee handover, ban logging, and kad penalty

### DIFF
--- a/crates/consensus/network/src/consensus/gossip.rs
+++ b/crates/consensus/network/src/consensus/gossip.rs
@@ -73,8 +73,10 @@ where
                         author = ?gossip_source,
                         ?topic,
                         ?propagation_source,
-                        "applying fatal penalty to message author (or propagation source as fallback)"
+                        "applying fatal penalty to message author"
                     );
+                    // Penalize the message author only, never the forwarding propagation source; a
+                    // relayer must not be banned for an invalid message it merely gossiped on.
                     if let Some(peer_id) = gossip_source {
                         self.swarm
                             .behaviour_mut()

--- a/crates/consensus/network/src/consensus/kad.rs
+++ b/crates/consensus/network/src/consensus/kad.rs
@@ -115,12 +115,16 @@ where
                         } else {
                             trace!(target: "network-kad", "Received invalid peer record!");
 
-                            // assess penalty for invalid peer record
+                            // assess penalty against the record's author, not the responder that
+                            // relayed it (see `kad_record_fault_penalty`)
                             if let Some(peer_id) = peer {
-                                self.swarm
-                                    .behaviour_mut()
-                                    .peer_manager
-                                    .process_penalty(peer_id, Penalty::Fatal);
+                                self.apply_invalid_kad_request_penalty(
+                                    &peer_id,
+                                    record.publisher,
+                                    &RecordInvalidReason::InvalidPeerRecord(
+                                        "get record failed validation".to_string(),
+                                    ),
+                                );
                             }
 
                             // ensure query cleaned up
@@ -233,6 +237,7 @@ where
             error!(target: "network-kad", ?source, "failed to decode record value - rejecting put request");
             self.apply_invalid_kad_request_penalty(
                 &source,
+                record.publisher,
                 &RecordInvalidReason::InvalidPeerRecord("decoding failed".to_string()),
             );
             return;
@@ -240,7 +245,11 @@ where
 
         let Ok(key) = BlsPublicKey::from_literal_bytes(record.key.as_ref()) else {
             error!(target: "network-kad", ?source, "invalid record key format - rejecting put request");
-            self.apply_invalid_kad_request_penalty(&source, &RecordInvalidReason::InvalidKeyFormat);
+            self.apply_invalid_kad_request_penalty(
+                &source,
+                record.publisher,
+                &RecordInvalidReason::InvalidKeyFormat,
+            );
             return;
         };
 
@@ -257,7 +266,7 @@ where
                 // handle race condition with PM
                 self.swarm.behaviour_mut().kademlia.remove_record(&record.key);
             }
-            self.apply_invalid_kad_request_penalty(&source, &reason);
+            self.apply_invalid_kad_request_penalty(&source, record.publisher, &reason);
             error!(target: "network-kad", ?source, ?reason, "failed to process kad put request");
             return;
         }
@@ -282,22 +291,19 @@ where
     }
 
     /// Process on inbound add provider request.
+    ///
+    /// Discovery here runs on `get_record` against the BLS key; `get_providers` is never called, so
+    /// a stored provider record is never read. Persisting one only grows a never-queried table that
+    /// takes unsigned writes from any non-banned peer, so foreign provider records are dropped.
+    /// Sending an ADD_PROVIDER is ordinary libp2p traffic, not misbehavior, so the sender is not
+    /// penalized.
     fn process_add_provider_request(&mut self, record: Option<ProviderRecord>) {
         if let Some(record) = record {
-            let peer_id = record.provider;
-
-            if self.swarm.behaviour().peer_manager.peer_banned(&peer_id) {
-                warn!(target: "network-kad", ?peer_id, "rejecting add provider from banned peer");
-                self.apply_invalid_kad_request_penalty(
-                    &peer_id,
-                    &RecordInvalidReason::SourceBanned,
-                );
-                return;
-            }
-
-            if let Err(err) = self.swarm.behaviour_mut().kademlia.store_mut().add_provider(record) {
-                self.handle_kad_store_error(&peer_id, err);
-            }
+            trace!(
+                target: "network-kad",
+                provider = ?record.provider,
+                "dropping unused inbound provider record"
+            );
         }
     }
 
@@ -327,56 +333,43 @@ where
             .map_err(RecordInvalidReason::InvalidPeerRecord)
     }
 
-    /// Handle a store error from `add_provider()` or `put()`.
+    /// Handle a store error from `put()`.
     ///
-    /// Map the store error to a penalty reason and penalize the source peer.
+    /// A full store or oversize value is this node's local condition, not the deliverer's fault;
+    /// the penalty here is provisional, pending a separate local-vs-remote cause split.
     fn handle_kad_store_error(&mut self, peer_id: &PeerId, err: Error) {
-        let reason = match err {
-            Error::MaxRecords => {
-                warn!(target: "network-kad", ?peer_id, "kad store at record capacity");
-                RecordInvalidReason::MaxRecordSizeExceeded
-            }
-            Error::MaxProvidedKeys => {
-                warn!(target: "network-kad", ?peer_id, "kad store at provider key capacity");
-                RecordInvalidReason::MaxProvidedKeysExceeded
-            }
-            Error::ValueTooLarge => {
-                warn!(target: "network-kad", ?peer_id, "kad record value too large");
-                RecordInvalidReason::InvalidPeerRecord("value too large".to_string())
-            }
+        let (reason, penalty) = match err {
+            Error::MaxRecords => (RecordInvalidReason::MaxRecordSizeExceeded, Penalty::Mild),
+            Error::MaxProvidedKeys => (RecordInvalidReason::MaxProvidedKeysExceeded, Penalty::Mild),
+            Error::ValueTooLarge => (
+                RecordInvalidReason::InvalidPeerRecord("value too large".to_string()),
+                Penalty::Fatal,
+            ),
         };
-        self.apply_invalid_kad_request_penalty(peer_id, &reason);
+        warn!(target: "network-kad", ?peer_id, ?reason, "kad store rejected record");
+        self.swarm.behaviour_mut().peer_manager.process_penalty(*peer_id, penalty);
     }
 
+    /// Apply the penalty owed for an invalid KAD record delivered by `deliverer`.
+    ///
+    /// The record's fault may belong to its `publisher` rather than the deliverer; the decision is
+    /// made by [`kad_record_fault_penalty`], and no penalty is applied when the deliverer is only
+    /// an honest relayer of someone else's bad record.
     fn apply_invalid_kad_request_penalty(
         &mut self,
-        peer_id: &PeerId,
+        deliverer: &PeerId,
+        publisher: Option<PeerId>,
         reason: &RecordInvalidReason,
     ) {
-        match reason {
-            RecordInvalidReason::MissingPublisher
-            | RecordInvalidReason::PublisherBanned
-            | RecordInvalidReason::SourceBanned
-            | RecordInvalidReason::InvalidKeyFormat
-            | RecordInvalidReason::InvalidPeerRecord(_) => {
-                self.process_fatal_penalty(peer_id, reason);
+        match kad_record_fault_penalty(deliverer, publisher, reason) {
+            Some(penalty) => {
+                trace!(target: "network-kad", ?deliverer, ?reason, ?penalty, "penalizing invalid kad record");
+                self.swarm.behaviour_mut().peer_manager.process_penalty(*deliverer, penalty);
             }
-            RecordInvalidReason::TimestampTooFarInFuture
-            | RecordInvalidReason::MaxRecordSizeExceeded
-            | RecordInvalidReason::MaxProvidedKeysExceeded => {
-                self.process_mild_penalty(peer_id, reason);
+            None => {
+                trace!(target: "network-kad", ?deliverer, ?publisher, ?reason, "no penalty: kad record fault belongs to its author, not the deliverer");
             }
         }
-    }
-
-    fn process_mild_penalty(&mut self, peer_id: &PeerId, reason: &RecordInvalidReason) {
-        trace!(target: "network-kad", ?peer_id, "processing mild penalty for {:?}", reason);
-        self.swarm.behaviour_mut().peer_manager.process_penalty(*peer_id, Penalty::Mild);
-    }
-
-    fn process_fatal_penalty(&mut self, peer_id: &PeerId, reason: &RecordInvalidReason) {
-        trace!(target: "network-kad", ?peer_id, "processing fatal penalty for {:?}", reason);
-        self.swarm.behaviour_mut().peer_manager.process_penalty(*peer_id, Penalty::Fatal);
     }
 
     /// Check the local kad store to compare record timestamps.
@@ -443,9 +436,15 @@ where
             // record signature invalid
             warn!(target: "network-kad", "Received invalid peer record!");
 
-            // assess penalty for invalid peer record
+            // assess penalty against the record's author, not the responder that relayed it
             if let Some(peer_id) = peer {
-                self.swarm.behaviour_mut().peer_manager.process_penalty(peer_id, Penalty::Fatal);
+                self.apply_invalid_kad_request_penalty(
+                    &peer_id,
+                    record.publisher,
+                    &RecordInvalidReason::InvalidPeerRecord(
+                        "query record failed validation".to_string(),
+                    ),
+                );
             }
         }
 
@@ -567,5 +566,130 @@ where
         if let Err(err) = self.swarm.behaviour_mut().kademlia.put_record(record, kad::Quorum::One) {
             error!(target: "network-kad", "Failed to publish record: {err}");
         }
+    }
+}
+
+/// Classifies a KAD record fault into the penalty owed the delivering peer.
+///
+/// A record travels the DHT by replication, so its deliverer is not necessarily its author. A
+/// content-integrity fault (undecodable value, malformed key, absent publisher) could never pass
+/// an honest peer's validation, so no honest peer relays it: the deliverer is the origin and its
+/// `publisher` is unauthenticated (bound only once the signature verifies), so it cannot excuse
+/// the deliverer, which always pays. An author-attributed fault on a well-formed record (banned
+/// publisher, future timestamp) can be carried by an honest relayer, so charge only the named
+/// author, else one banned author becomes a ban cascade. `SourceBanned` names the deliverer
+/// itself; store-capacity faults go through `handle_kad_store_error` and never reach here.
+fn kad_record_fault_penalty(
+    deliverer: &PeerId,
+    publisher: Option<PeerId>,
+    reason: &RecordInvalidReason,
+) -> Option<Penalty> {
+    let authored_by_deliverer = publisher == Some(*deliverer);
+    match reason {
+        // Content-integrity fault: never legitimately relayed, and `publisher` is unauthenticated,
+        // so the deliverer is the origin and always pays regardless of the publisher field.
+        RecordInvalidReason::InvalidPeerRecord(_)
+        | RecordInvalidReason::InvalidKeyFormat
+        | RecordInvalidReason::MissingPublisher => Some(Penalty::Fatal),
+        // Author-attributed fault on a well-formed record: an honest relayer forwarding someone
+        // else's record earns nothing; only the named author pays.
+        RecordInvalidReason::PublisherBanned => authored_by_deliverer.then_some(Penalty::Fatal),
+        RecordInvalidReason::TimestampTooFarInFuture => {
+            authored_by_deliverer.then_some(Penalty::Mild)
+        }
+        // The source itself is banned - the deliverer is the offender, independent of authorship.
+        RecordInvalidReason::SourceBanned => Some(Penalty::Fatal),
+        // Local store capacity, not the peer's fault. Kept for exhaustiveness; the store path
+        // penalizes directly (Class B) and does not reach here.
+        RecordInvalidReason::MaxRecordSizeExceeded
+        | RecordInvalidReason::MaxProvidedKeysExceeded => Some(Penalty::Mild),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // INVARIANT: penalty attribution splits by fault class. A content-integrity fault (undecodable
+    // value, malformed key, absent publisher) is never legitimately relayed and carries an
+    // unauthenticated publisher, so the deliverer always pays. An author-attributed fault on a
+    // well-formed record (banned publisher, future timestamp) can be honestly relayed, so only the
+    // named author pays.
+
+    /// A content-integrity fault always charges the deliverer, no matter what the (unauthenticated)
+    /// publisher field says. Guards the regression where an attacker escaped by setting
+    /// `publisher = None` or a stranger's id on a record that no honest peer would ever relay.
+    #[test]
+    fn content_integrity_fault_always_penalizes_deliverer() {
+        let deliverer = PeerId::random();
+        let stranger = PeerId::random();
+        for reason in [
+            RecordInvalidReason::InvalidPeerRecord("decoding failed".to_string()),
+            RecordInvalidReason::InvalidPeerRecord("bad signature".to_string()),
+            RecordInvalidReason::InvalidKeyFormat,
+            RecordInvalidReason::MissingPublisher,
+        ] {
+            for publisher in [None, Some(stranger), Some(deliverer)] {
+                assert!(
+                    matches!(
+                        kad_record_fault_penalty(&deliverer, publisher, &reason),
+                        Some(Penalty::Fatal)
+                    ),
+                    "content-integrity fault must charge the deliverer Fatal for \
+                     publisher={publisher:?}, reason={reason:?}"
+                );
+            }
+        }
+    }
+
+    /// An honest relayer forwarding another author's banned or future-dated record must not move
+    /// toward a ban: the author is named and authenticated, and the deliverer is a relayer.
+    #[test]
+    fn honest_relayer_of_author_faulted_record_is_not_penalized() {
+        let deliverer = PeerId::random();
+        let author = PeerId::random();
+        for reason in
+            [RecordInvalidReason::PublisherBanned, RecordInvalidReason::TimestampTooFarInFuture]
+        {
+            assert!(
+                kad_record_fault_penalty(&deliverer, Some(author), &reason).is_none(),
+                "relayer must not be penalized for author fault: {reason:?}"
+            );
+        }
+    }
+
+    /// The named author of a banned-publisher or future-timestamp record still pays, at the
+    /// severity the fault carried before the authorship split.
+    #[test]
+    fn author_pays_for_its_own_attributed_fault() {
+        let author = PeerId::random();
+        assert!(matches!(
+            kad_record_fault_penalty(&author, Some(author), &RecordInvalidReason::PublisherBanned),
+            Some(Penalty::Fatal)
+        ));
+        assert!(matches!(
+            kad_record_fault_penalty(
+                &author,
+                Some(author),
+                &RecordInvalidReason::TimestampTooFarInFuture
+            ),
+            Some(Penalty::Mild)
+        ));
+    }
+
+    /// `SourceBanned` names the deliverer itself as the offender, so it applies regardless of who
+    /// authored the record (or whether a publisher is set at all).
+    #[test]
+    fn source_banned_always_penalizes_the_deliverer() {
+        let source = PeerId::random();
+        let publisher = PeerId::random();
+        assert!(matches!(
+            kad_record_fault_penalty(&source, Some(publisher), &RecordInvalidReason::SourceBanned),
+            Some(Penalty::Fatal)
+        ));
+        assert!(matches!(
+            kad_record_fault_penalty(&source, None, &RecordInvalidReason::SourceBanned),
+            Some(Penalty::Fatal)
+        ));
     }
 }

--- a/crates/consensus/network/src/consensus/reqres.rs
+++ b/crates/consensus/network/src/consensus/reqres.rs
@@ -106,6 +106,10 @@ where
                 // this node disconnects after a px timeout
                 if self.pending_px_disconnects.remove(&request_id).is_some() {
                     debug!(target: "network", "outbound failure expected because of px disconnect");
+                    // a px request is tracked in outbound_requests too; the common cleanup below is
+                    // skipped by this early return, so drop the ack here. Dropping the sender also
+                    // resolves the px task's wait immediately instead of holding it to the timeout.
+                    self.outbound_requests.remove(&(peer, request_id));
                     return Ok(());
                 }
 

--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -43,6 +43,15 @@ pub(super) struct AllPeers {
     peers: HashMap<PeerId, Peer>,
     /// The collection of staked current_committee at the beginning of each epoch.
     current_committee: HashSet<PeerId>,
+    /// Committee members seated in the previous epoch that are not seated in this one.
+    ///
+    /// A validator applies an epoch boundary on its own schedule, so a departing member is still
+    /// publishing as a member while this node has already stopped treating it as one. It stays
+    /// important for one epoch so that its in-flight gossip keeps passing the authorization
+    /// fallback, whose rejection is fatal. It is deliberately not counted as a validator: the
+    /// penalty absolution and the ban exemption both end at the boundary, so a member rotated out
+    /// for misbehaving gains no extra immunity.
+    departing_committee: HashSet<PeerId>,
     /// The collection of staked current_committee pub key to peerid at the beginning of each
     /// epoch.
     current_committee_keys: HashMap<BlsPublicKey, Option<PeerId>>,
@@ -70,6 +79,7 @@ impl AllPeers {
         Self {
             peers: Default::default(),
             current_committee: Default::default(),
+            departing_committee: Default::default(),
             current_committee_keys: Default::default(),
             banned_peers: Default::default(),
             disconnected_peers: 0,
@@ -701,6 +711,14 @@ impl AllPeers {
         self.current_committee.contains(peer_id)
     }
 
+    /// Boolean indicating this peer is seated now or was seated in the previous epoch.
+    ///
+    /// Used for gossip authorization and connection priority during a committee handover. This is
+    /// not the penalty exemption: see [`Self::is_peer_validator`].
+    pub(super) fn is_peer_recently_validator(&self, peer_id: &PeerId) -> bool {
+        self.is_peer_validator(peer_id) || self.departing_committee.contains(peer_id)
+    }
+
     /// Boolean indicating if the address is associated with a banned peer.
     pub(super) fn ip_banned(&self, ip: &IpAddr) -> bool {
         self.banned_peers.ip_banned(ip)
@@ -958,12 +976,14 @@ impl AllPeers {
             }
         }
 
-        // make peers not in old committeee that are not in the new committee untrusted
-        committee_delta.into_iter().for_each(|peer_id| {
-            if let Some(peer) = self.peers.get_mut(&peer_id) {
+        // drop trust for members that left at this boundary: their penalty absolution and ban
+        // exemption end with the seat. Only importance carries over (see `departing_committee`).
+        for peer_id in &committee_delta {
+            if let Some(peer) = self.peers.get_mut(peer_id) {
                 peer.make_untrusted();
             }
-        });
+        }
+        self.departing_committee = committee_delta;
 
         // return any unban actions for committee peers
         actions

--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -889,6 +889,22 @@ impl AllPeers {
 
     /// Prune excess number of disconnected peers to prevent exhausting memory.
     fn prune_disconnected_peers(&mut self) {
+        // `disconnected_peers` is hand-maintained across every status transition, unlike
+        // `banned_peers.total()` which derives from a length. Reconcile it against the real
+        // Disconnected count here (the one hot path this cap gates on) so a future transition arm
+        // that forgets to adjust it fails a test instead of silently defeating the cap in prod.
+        debug_assert_eq!(
+            self.disconnected_peers,
+            self.peers
+                .values()
+                .filter(|peer| matches!(
+                    peer.connection_status(),
+                    ConnectionStatus::Disconnected { .. }
+                ))
+                .count(),
+            "disconnected_peers counter drifted from actual Disconnected-status count"
+        );
+
         let excess = self.disconnected_peers.saturating_sub(self.max_disconnected_peers);
 
         if excess > 0 {

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -294,13 +294,16 @@ impl PeerManager {
     ///
     /// Actions on peers happen when their reputation or connection status changes.
     fn apply_peer_action(&mut self, peer_id: PeerId, action: PeerAction) {
+        // this is the single point every reputation-driven action passes through, and each arm
+        // fires only on an actual change, so the ban lifecycle is legible at warn/info without the
+        // per-penalty decay noise that sits at debug
         match action {
             PeerAction::Ban(ip_addrs) => {
-                debug!(target: "peer-manager", ?peer_id, ?ip_addrs, "reputation update results in ban");
+                warn!(target: "peer-manager", ?peer_id, score = ?self.peer_score(&peer_id), ?ip_addrs, "peer banned");
                 self.process_ban(&peer_id);
             }
             PeerAction::Disconnect => {
-                debug!(target: "peer-manager", ?peer_id, "reputation update results in disconnect");
+                info!(target: "peer-manager", ?peer_id, score = ?self.peer_score(&peer_id), "peer disconnected for reputation");
                 self.temporarily_banned.insert(peer_id);
                 self.push_event(PeerEvent::DisconnectPeer(peer_id));
             }
@@ -312,7 +315,7 @@ impl PeerManager {
                 self.events.push_back(PeerEvent::DisconnectPeerX(peer_id, exchange));
             }
             PeerAction::Unban(ip_addrs) => {
-                debug!(target: "peer-manager", ?peer_id, ?ip_addrs, "reputation update results in unban");
+                info!(target: "peer-manager", ?peer_id, ?ip_addrs, "peer unbanned");
                 self.push_event(PeerEvent::Unbanned(peer_id));
             }
 

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -644,7 +644,7 @@ impl PeerManager {
 
     /// Bool indicating if the peer is trusted or a validator.
     pub(crate) fn peer_is_important(&self, peer_id: &PeerId) -> bool {
-        self.is_peer_validator(peer_id)
+        self.peers.is_peer_recently_validator(peer_id)
             || self.peers.get_peer(peer_id).map(|p| p.is_trusted()).unwrap_or_default()
     }
 

--- a/crates/consensus/network/src/tests/network_tests.rs
+++ b/crates/consensus/network/src/tests/network_tests.rs
@@ -1758,6 +1758,90 @@ async fn test_kad_provider_store_exhaustion_does_not_propagate_error() -> eyre::
     Ok(())
 }
 
+/// A foreign inbound AddProvider record must not be stored.
+///
+/// Rayls discovers peers with `get_record` on the BLS key and never calls `get_providers`, so a
+/// stored provider record is never read - it only grows an unbounded, never-queried table that
+/// takes unsigned writes from any non-banned peer. The handler drops foreign provider records
+/// rather than persist them.
+#[tokio::test]
+async fn test_kad_foreign_provider_record_is_not_stored() -> eyre::Result<()> {
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+
+    let key = RecordKey::new(b"foreign-provided-key");
+    let record = ProviderRecord {
+        key: key.clone(),
+        provider: PeerId::random(),
+        expires: None,
+        addresses: vec![],
+    };
+
+    let event = kad::Event::InboundRequest {
+        request: kad::InboundRequest::AddProvider { record: Some(record) },
+    };
+
+    let result = network.process_kad_event(event);
+    assert!(result.is_ok(), "processing an inbound provider record must not error");
+
+    let providers = network.swarm.behaviour_mut().kademlia.store_mut().providers(&key);
+    assert!(providers.is_empty(), "foreign provider record must not be stored");
+
+    Ok(())
+}
+
+/// A peer-exchange disconnect whose request fails must not orphan its tracked ack.
+///
+/// A PX disconnect is recorded in both `pending_px_disconnects` and `outbound_requests`. The
+/// expected outcome is an `OutboundFailure` (the node is dropping the peer), and that arm must
+/// clear the entry from BOTH maps - otherwise the `outbound_requests` ack lingers until the
+/// periodic sweep, one leaked entry per PX-disconnect.
+#[tokio::test]
+async fn test_px_disconnect_failure_clears_outbound_request() -> eyre::Result<()> {
+    use crate::peers::{PeerEvent, PeerExchangeMap};
+    use libp2p::{
+        request_response::{Event as ReqResEvent, OutboundFailure},
+        swarm::ConnectionId,
+    };
+
+    let TestTypes { peer1, .. } = create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+
+    let peer_id = PeerId::random();
+
+    // drive a PX disconnect: inserts into pending_px_disconnects AND outbound_requests
+    network.process_peer_manager_event(PeerEvent::DisconnectPeerX(
+        peer_id,
+        PeerExchangeMap(std::collections::HashMap::new()),
+    ))?;
+
+    let request_id = *network
+        .pending_px_disconnects
+        .keys()
+        .next()
+        .expect("px disconnect registered a pending request");
+    assert!(
+        network.outbound_requests.contains_key(&(peer_id, request_id)),
+        "precondition: px request is tracked in outbound_requests"
+    );
+
+    // the px request fails - the expected path, since the node is dropping the peer
+    let event = ReqResEvent::OutboundFailure {
+        peer: peer_id,
+        request_id,
+        error: OutboundFailure::ConnectionClosed,
+        connection_id: ConnectionId::new_unchecked(0),
+    };
+    network.process_reqres_event(event)?;
+
+    assert!(
+        !network.outbound_requests.contains_key(&(peer_id, request_id)),
+        "px outbound failure must clear the tracked ack, not orphan it"
+    );
+
+    Ok(())
+}
+
 /// FIND-025 Path B: PutRecord store exhaustion must not propagate a fatal error.
 ///
 /// Pre-fill the record store to capacity, then submit a valid BLS-signed PutRecord.

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -13,7 +13,7 @@ use crate::common::{create_multiaddr, ensure_score_config};
 use libp2p::PeerId;
 use rand::{rngs::StdRng, SeedableRng as _};
 use rayls_infrastructure_config::{PeerConfig, ScoreConfig};
-use rayls_infrastructure_types::{BlsKeypair, NetworkKeypair};
+use rayls_infrastructure_types::{now, BlsKeypair, NetworkKeypair};
 use std::net::{IpAddr, Ipv4Addr};
 
 /// Build an `AllPeers` from an operator config, installing its `ScoreConfig` for this test.
@@ -797,5 +797,54 @@ fn operator_configured_thresholds_are_enforced() {
         peers.get_peer(&peer_id).expect("known").reputation(),
         Reputation::Trusted,
         "the disconnect threshold was configured to -60 but a peer at -20 was disconnected"
+    );
+}
+
+// Committee handover
+
+/// A validator applies an epoch boundary on its own schedule, so between this node installing the
+/// new committee and that peer installing it, the peer is still publishing as a member. Its gossip
+/// must keep passing the authorization fallback for that window, because the rejection is Fatal.
+///
+/// The grace covers importance only. A departing member stays penalizable, so a validator rotated
+/// out for misbehaving is not handed an extra epoch of immunity.
+#[test]
+fn a_departing_committee_member_stays_important_for_one_epoch() {
+    let mut peers = all_peers();
+    let (bls_stays, net_stays) = random_keys(50);
+    let (bls_leaves, net_leaves) = random_keys(51);
+    let leaving: PeerId = net_leaves.clone().into();
+
+    let seated = |bls, net: &NetworkPublicKey| {
+        (bls, Some(NetworkInfo { pubkey: net.clone(), multiaddrs: Vec::new(), timestamp: now() }))
+    };
+
+    // epoch N seats both
+    peers.new_epoch(vec![seated(bls_stays, &net_stays), seated(bls_leaves, &net_leaves)]);
+    assert!(peers.is_peer_validator(&leaving), "precondition: seated in epoch N");
+
+    // epoch N+1 drops one of them
+    peers.new_epoch(vec![seated(bls_stays, &net_stays)]);
+    assert!(
+        !peers.is_peer_validator(&leaving),
+        "a departing member is not a validator, so penalties still apply to it"
+    );
+    assert!(
+        peers.is_peer_recently_validator(&leaving),
+        "a departing member lost gossip authorization in the epoch it is still publishing into"
+    );
+
+    // the seat is gone, so the handover grace must not carry penalty immunity with it
+    let action = peers.process_penalty(&leaving, Penalty::Fatal);
+    assert!(
+        !matches!(action, PeerAction::NoAction),
+        "a departing member kept the penalty immunity that belongs to a seat"
+    );
+
+    // epoch N+2: the handover window has passed
+    peers.new_epoch(vec![seated(bls_stays, &net_stays)]);
+    assert!(
+        !peers.is_peer_recently_validator(&leaving),
+        "the grace outlived the handover it exists for"
     );
 }


### PR DESCRIPTION
## Summary

Correct committee handover, surface the ban lifecycle, and attribute kad record faults to their author.

- a committee member departing at an epoch boundary keeps gossip-authorization importance for one epoch, but loses its penalty absolution and ban exemption at the boundary
- the ban lifecycle is logged at warn and info from the single point every reputation action converges, so an operator sees the ban and the score that caused it
- a kad record fault is charged to the record's author: a content-integrity fault always charges the deliverer, an author-attributed fault charges only the named author, so an honest relayer earns no penalty

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No wire-format or message-shape change, so it stays rolling-upgrade safe.
