### PR TITLE
fix: release resolved-member bans and correct kad and reqres attribution

### DIFF
--- a/crates/consensus/network/src/consensus/kad.rs
+++ b/crates/consensus/network/src/consensus/kad.rs
@@ -281,8 +281,9 @@ where
 
         // Fresh record: store it first. add_known_peer only on success so a full
         // store cannot be used as a side-channel to populate known_peers (PR #280).
+        let publisher = record.publisher;
         if let Err(err) = self.swarm.behaviour_mut().kademlia.store_mut().put(record) {
-            self.handle_kad_store_error(&source, err);
+            self.handle_kad_store_error(&source, publisher, err);
             return;
         }
 
@@ -333,21 +334,30 @@ where
             .map_err(RecordInvalidReason::InvalidPeerRecord)
     }
 
-    /// Handle a store error from `put()`.
+    /// Handle a store error from `put()`, charging the peer at fault, if any.
     ///
-    /// A full store or oversize value is this node's local condition, not the deliverer's fault;
-    /// the penalty here is provisional, pending a separate local-vs-remote cause split.
-    fn handle_kad_store_error(&mut self, peer_id: &PeerId, err: Error) {
-        let (reason, penalty) = match err {
-            Error::MaxRecords => (RecordInvalidReason::MaxRecordSizeExceeded, Penalty::Mild),
-            Error::MaxProvidedKeys => (RecordInvalidReason::MaxProvidedKeysExceeded, Penalty::Mild),
-            Error::ValueTooLarge => (
-                RecordInvalidReason::InvalidPeerRecord("value too large".to_string()),
-                Penalty::Fatal,
-            ),
+    /// Runs after `verify_kad_put_authenticity`, so `publisher` is authenticated: an oversize
+    /// value charges only its author, never an honest relayer, matching
+    /// [`kad_record_fault_penalty`]. A full store is a local capacity condition, so the deliverer
+    /// is charged only `Penalty::Mild`.
+    fn handle_kad_store_error(
+        &mut self,
+        deliverer: &PeerId,
+        publisher: Option<PeerId>,
+        err: Error,
+    ) {
+        let penalty = match err {
+            Error::MaxRecords => Some(Penalty::Mild),
+            Error::ValueTooLarge => (publisher == Some(*deliverer)).then_some(Penalty::Fatal),
+            // `process_add_provider_request` drops provider records, so `add_provider` never runs.
+            Error::MaxProvidedKeys => {
+                unreachable!("provider records are dropped, so the store holds no provider keys")
+            }
         };
-        warn!(target: "network-kad", ?peer_id, ?reason, "kad store rejected record");
-        self.swarm.behaviour_mut().peer_manager.process_penalty(*peer_id, penalty);
+        if let Some(penalty) = penalty {
+            warn!(target: "network-kad", ?deliverer, ?err, ?penalty, "kad store rejected record");
+            self.swarm.behaviour_mut().peer_manager.process_penalty(*deliverer, penalty);
+        }
     }
 
     /// Apply the penalty owed for an invalid KAD record delivered by `deliverer`.
@@ -599,10 +609,6 @@ fn kad_record_fault_penalty(
         }
         // The source itself is banned - the deliverer is the offender, independent of authorship.
         RecordInvalidReason::SourceBanned => Some(Penalty::Fatal),
-        // Local store capacity, not the peer's fault. Kept for exhaustiveness; the store path
-        // penalizes directly (Class B) and does not reach here.
-        RecordInvalidReason::MaxRecordSizeExceeded
-        | RecordInvalidReason::MaxProvidedKeysExceeded => Some(Penalty::Mild),
     }
 }
 

--- a/crates/consensus/network/src/consensus/reqres.rs
+++ b/crates/consensus/network/src/consensus/reqres.rs
@@ -126,29 +126,9 @@ where
             }
             ReqResEvent::InboundFailure { peer, request_id, error, connection_id: _ } => {
                 debug!(target: "network", ?peer, ?error, pending=?self.inbound_requests, "Inbound failure for req/res");
-                debug!(target: "network", my_id=?self.swarm.local_peer_id(), "this node");
-                match error {
-                    ReqResInboundFailure::Io(e) => {
-                        // penalize peer since this is an attack surface
-                        warn!(target: "network", ?e, ?peer, ?request_id, "inbound IO failure");
-                        self.swarm
-                            .behaviour_mut()
-                            .peer_manager
-                            .process_penalty(peer, Penalty::Medium);
-                    }
-                    ReqResInboundFailure::UnsupportedProtocols => {
-                        warn!(target: "network", ?peer, ?request_id, ?error, "inbound failure: unsupported protocol");
-
-                        // the local peer supports none of the protocols requested by the remote
-                        self.swarm
-                            .behaviour_mut()
-                            .peer_manager
-                            .process_penalty(peer, Penalty::Fatal);
-                    }
-                    ReqResInboundFailure::Timeout | ReqResInboundFailure::ConnectionClosed => {
-                        // no penalty for connection-level failures
-                    }
-                    ReqResInboundFailure::ResponseOmission => { /* ignore local error */ }
+                if let Some(penalty) = inbound_failure_penalty(&error) {
+                    warn!(target: "network", ?peer, ?request_id, ?error, ?penalty, "penalizing inbound failure");
+                    self.swarm.behaviour_mut().peer_manager.process_penalty(peer, penalty);
                 }
 
                 // forward cancelation to handler and ignore errors
@@ -186,10 +166,49 @@ fn outbound_failure_penalty(error: &OutboundFailure) -> Option<Penalty> {
     }
 }
 
+/// Classifies an inbound request-response failure into the penalty owed the requesting peer.
+///
+/// Returns `None` for failures not the requester's fault. libp2p reports an unreadable request
+/// and a failed response write as the same `Io` variant, so charging it would ban an innocent
+/// requester for this node's own write failure.
+fn inbound_failure_penalty(error: &ReqResInboundFailure) -> Option<Penalty> {
+    match error {
+        // The requester spoke a protocol set this node does not accept.
+        ReqResInboundFailure::UnsupportedProtocols => Some(Penalty::Fatal),
+        ReqResInboundFailure::Io(_)
+        | ReqResInboundFailure::Timeout
+        | ReqResInboundFailure::ConnectionClosed
+        | ReqResInboundFailure::ResponseOmission => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io;
+
+    /// An inbound `Io` failure is ambiguous between an unreadable request and this node's own
+    /// failure to write the response, so it must never charge the requester.
+    #[test]
+    fn inbound_io_failure_is_not_penalized() {
+        let error = ReqResInboundFailure::Io(io::Error::other("failed to write response"));
+        assert!(
+            inbound_failure_penalty(&error).is_none(),
+            "an inbound Io failure may be our own write failure and must not ban the requester"
+        );
+    }
+
+    /// Connection-level and local inbound failures earn nothing; only a protocol mismatch does.
+    #[test]
+    fn inbound_failure_penalties_match_fault() {
+        assert!(inbound_failure_penalty(&ReqResInboundFailure::Timeout).is_none());
+        assert!(inbound_failure_penalty(&ReqResInboundFailure::ConnectionClosed).is_none());
+        assert!(inbound_failure_penalty(&ReqResInboundFailure::ResponseOmission).is_none());
+        assert!(matches!(
+            inbound_failure_penalty(&ReqResInboundFailure::UnsupportedProtocols),
+            Some(Penalty::Fatal)
+        ));
+    }
 
     /// A local outbound substream exhaustion must not penalize the (innocent) target peer.
     #[test]

--- a/crates/consensus/network/src/consensus/types.rs
+++ b/crates/consensus/network/src/consensus/types.rs
@@ -36,10 +36,6 @@ pub(super) enum RecordInvalidReason {
     InvalidKeyFormat,
     #[error("Record failed application-level validation: {0}")]
     InvalidPeerRecord(String),
-    #[error("Max record size exceeded")]
-    MaxRecordSizeExceeded,
-    #[error("Max provided keys exceeded")]
-    MaxProvidedKeysExceeded,
 }
 
 /// Enum if the received gossip is initially accepted for further processing.

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -704,6 +704,18 @@ impl PeerManager {
             "add_known_peer",
         );
         self.peers.upsert_peer(bls_key, info.pubkey.clone(), info.multiaddrs.clone());
+
+        // A member banned before discovery resolved it still carries its ban after `upsert_peer`
+        // trusts it; release it so the unban action repairs the gossipsub blacklist and kad routing
+        // entry. Not in `upsert_peer`: `new_epoch` also calls it and does its own boundary unban.
+        if self.peers.is_peer_validator(&peer_id)
+            && self.peers.get_peer(&peer_id).is_some_and(|p| p.connection_status().is_banned())
+        {
+            let action =
+                self.peers.update_connection_status(&peer_id, NewConnectionStatus::Unbanned);
+            self.apply_peer_action(peer_id, action);
+        }
+
         self.known_peers.insert(bls_key, info.clone());
         self.known_peers_time_added.insert(bls_key, now());
         self.known_peerids.insert(peer_id, bls_key);

--- a/crates/consensus/network/src/peers/peer.rs
+++ b/crates/consensus/network/src/peers/peer.rs
@@ -112,8 +112,8 @@ impl Peer {
     /// Update keys and network address.
     ///
     /// The addresses come from the peer's own record, so they are recorded as advertised rather
-    /// than witnessed. `multiaddrs` drives ban accounting and peer exchange, and a peer must be
-    /// able to neither charge nor advertise an address this node has not seen it connect from.
+    /// than witnessed. `multiaddrs` drives ban accounting and peer exchange, so a peer must not be
+    /// able to charge or advertise an address this node has not observed it connecting from.
     pub(super) fn update_net(
         &mut self,
         bls_public_key: BlsPublicKey,

--- a/crates/consensus/network/src/tests/peer_manager.rs
+++ b/crates/consensus/network/src/tests/peer_manager.rs
@@ -614,7 +614,7 @@ async fn test_committee_member_resolved_mid_epoch_is_absolved_immediately() {
     );
 
     // INVARIANT: resolution grants the exemption, so penalties from this point are absolved.
-    // CURRENT: `new_epoch` rebuilds `current_committee_keys` only from members it could already
+    // PRE-FIX: `new_epoch` rebuilds `current_committee_keys` only from members it could already
     // resolve, so `upsert_peer` sees an unknown key and leaves the peer untrusted for the epoch.
     assert!(
         peer_manager.is_peer_validator(&unresolved),
@@ -737,7 +737,7 @@ async fn test_admitted_connection_is_registered_under_the_same_ban_predicate() {
     );
 
     // INVARIANT: a connection the admission checks accepted is registered.
-    // CURRENT: `register_peer_connection` gates on `AllPeers::peer_banned`, which has no committee
+    // PRE-FIX: `register_peer_connection` gates on `AllPeers::peer_banned`, which has no committee
     // exemption, so it refuses and logs `error "connected with banned peer"` - while
     // `on_connection_established` discards the `false` and still emits `PeerEvent::PeerConnected`.
     assert!(

--- a/crates/consensus/network/src/tests/peer_manager.rs
+++ b/crates/consensus/network/src/tests/peer_manager.rs
@@ -624,6 +624,63 @@ async fn test_committee_member_resolved_mid_epoch_is_absolved_immediately() {
     assert!(!peer_manager.peer_banned(&unresolved), "a committee member was banned by a penalty");
 }
 
+/// A ban charged against a committee member before its record resolved is released when discovery
+/// trusts it. A lingering charge can evict an innocent peer under the cap or push a shared IP over
+/// the block threshold.
+#[tokio::test]
+async fn resolving_a_banned_committee_member_releases_its_ban() {
+    let all_nodes = CommitteeFixture::builder(MemDatabase::default).build();
+    let mut authorities = all_nodes.authorities();
+    let authority_1 = authorities.next().expect("first authority");
+    let authority_2 = authorities.next().expect("second authority");
+    let config = authority_1.consensus_config();
+    let mut peer_manager = PeerManager::new(config.network_config().peer_config());
+
+    // this node resolves itself, then installs a committee whose second member it cannot yet
+    // resolve
+    peer_manager.add_known_peer(
+        *authority_1.authority().protocol_key(),
+        NetworkInfo {
+            pubkey: config.key_config().primary_network_public_key(),
+            multiaddrs: vec![config.primary_address()],
+            timestamp: now(),
+        },
+    );
+    peer_manager.new_epoch(config.committee_pub_keys());
+
+    // authority_2 connects and is banned while still an ordinary, unresolved peer
+    let config_2 = authority_2.consensus_config();
+    let unresolved: PeerId = config_2.key_config().primary_network_public_key().into();
+    assert!(peer_manager.register_peer_connection(
+        &unresolved,
+        ConnectionType::IncomingConnection { multiaddr: create_multiaddr(None) }
+    ));
+    peer_manager.process_penalty(unresolved, Penalty::Fatal);
+    peer_manager.register_disconnected(&unresolved);
+    assert!(peer_manager.peer_banned(&unresolved), "precondition: banned before resolution");
+    let _ = collect_all_events(&mut peer_manager);
+
+    // discovery resolves the record mid-epoch and trusts the member
+    peer_manager.add_known_peer(
+        *authority_2.authority().protocol_key(),
+        NetworkInfo {
+            pubkey: config_2.key_config().primary_network_public_key(),
+            multiaddrs: vec![config_2.primary_address()],
+            timestamp: now(),
+        },
+    );
+
+    // INVARIANT: resolution releases the ban, surfacing an unban that repairs the gossipsub
+    // blacklist and the kad routing entry.
+    // PRE-FIX: `upsert_peer` only trusts the resolved member; the `Banned` status and IP charge
+    // survive discovery.
+    let events = collect_all_events(&mut peer_manager);
+    assert!(
+        events.iter().any(|e| matches!(e, PeerEvent::Unbanned(p) if *p == unresolved)),
+        "resolving a banned committee member must release its ban"
+    );
+}
+
 /// The admission check and the registration check must use the same ban predicate. If the swarm
 /// admits a connection that `register_peer_connection` then refuses, the node holds an open
 /// connection it does not track.

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -5,8 +5,8 @@
 //! `update_connection_status` and `heartbeat_maintenance` - never against a hand-set internal
 //! state, so that a refactor of the transition table cannot make them vacuous.
 //!
-//! Where a test currently fails, the invariant it states is the intended behavior and the failure
-//! is the bug. Such tests carry an `INVARIANT`/`CURRENT` comment pair naming both.
+//! Tests that pinned a live bug carry an `INVARIANT` line stating the property and a `PRE-FIX`
+//! line naming the violation; the fixes have landed, so they now pass as regression guards.
 
 use super::*;
 use crate::common::{create_multiaddr, ensure_score_config};
@@ -258,7 +258,7 @@ fn unbanning_a_never_banned_peer_does_not_decrement_the_total() {
     peers.update_connection_status(&healthy, NewConnectionStatus::Unbanned);
 
     // INVARIANT: only a banned peer's release may decrement the total.
-    // CURRENT: `BannedPeers::remove_banned_peer` decrements unconditionally.
+    // PRE-FIX: `BannedPeers::remove_banned_peer` decrements unconditionally.
     assert_eq!(
         peers.banned_peers.total(),
         peers_in_banned_status(&peers),
@@ -426,7 +426,7 @@ fn disconnected_peer_eviction_retires_the_oldest_record() {
     peers.register_disconnected(&second);
 
     // INVARIANT: the older record is the one evicted.
-    // CURRENT: `collect_excess_peers` converges on the newest entries, so the record just created
+    // PRE-FIX: `collect_excess_peers` converges on the newest entries, so the record just created
     // is dropped and the stale one is retained.
     assert!(
         peers.get_peer(&second).is_some(),
@@ -466,7 +466,7 @@ fn promoting_a_banned_peer_to_trusted_releases_its_ip_charges() {
     }
 
     // INVARIANT: after both peers are trusted, nothing is still charged against their IP.
-    // CURRENT: `Peer::new_trusted` files the address under `listening_addrs`, so
+    // PRE-FIX: `Peer::new_trusted` files the address under `listening_addrs`, so
     // `known_ip_addresses()` on the fresh value is empty and `remove_banned_peer` cleans nothing.
     assert!(!peers.ip_banned(&shared), "IP stayed blocklisted after every holder became trusted");
 }
@@ -490,7 +490,7 @@ fn disconnecting_an_already_banned_peer_settles_the_accounting() {
     peers.update_connection_status(&peer_id, NewConnectionStatus::Disconnected);
 
     // INVARIANT: the peer is no longer banned, so nothing is still charged for it.
-    // CURRENT: `handle_disconnecting_transition` sets the new status before inspecting the old
+    // PRE-FIX: `handle_disconnecting_transition` sets the new status before inspecting the old
     // one, and its `Banned` arm only logs - `remove_banned_peer` is never called.
     assert_ban_accounting_conserved(&peers, "after disconnecting an already-banned peer");
 }
@@ -513,7 +513,7 @@ fn re_banning_a_peer_does_not_double_charge_it() {
     peers.update_connection_status(&peer_id, NewConnectionStatus::Banned);
 
     // INVARIANT: one banned peer is worth exactly one charge.
-    // CURRENT: the first charge was never released, so `add_banned_peer` takes the total to 2.
+    // PRE-FIX: the first charge was never released, so `add_banned_peer` takes the total to 2.
     assert_ban_accounting_conserved(&peers, "after re-banning the same peer");
 }
 /// A peer's ban must charge only its own IPs. If the charge is released against whatever addresses
@@ -558,7 +558,7 @@ fn releasing_a_ban_cannot_cancel_another_peers_ban() {
     peers.update_connection_status(&outsider, NewConnectionStatus::Unbanned);
 
     // INVARIANT: two peers are still banned at the shared address, so it stays blocklisted.
-    // CURRENT: `remove_banned_peer` decrements every IP the peer holds *at release time*, which
+    // PRE-FIX: `remove_banned_peer` decrements every IP the peer holds *at release time*, which
     // now includes an address it never charged.
     assert!(
         peers.ip_banned(&shared),
@@ -579,7 +579,7 @@ fn promoting_an_unrelated_peer_to_trusted_leaves_the_ban_total_alone() {
     peers.add_trusted_peer(bls, network_key, vec![create_multiaddr(Some(ip(98)))]);
 
     // INVARIANT: adding a trusted peer that was never banned changes nothing.
-    // CURRENT: `add_trusted_peer` calls `remove_banned_peer`, whose unconditional
+    // PRE-FIX: `add_trusted_peer` calls `remove_banned_peer`, whose unconditional
     // `total.saturating_sub(1)` runs even though the IP iterator it is handed is always empty.
     assert_ban_accounting_conserved(&peers, "after promoting an unrelated peer to trusted");
 }
@@ -607,7 +607,7 @@ fn decay_depends_on_elapsed_time_not_on_heartbeat_frequency() {
     }
 
     // INVARIANT: after one halflife the score has moved roughly halfway back to zero.
-    // CURRENT: `Score::update_at` truncates elapsed to whole seconds but advances `last_updated`
+    // PRE-FIX: `Score::update_at` truncates elapsed to whole seconds but advances `last_updated`
     // unconditionally, so a sub-second sampling cadence discards every remainder.
     assert!(
         score_of(&peers, &peer_id) > after_penalty / 2.0,
@@ -684,7 +684,7 @@ fn only_observed_addresses_charge_the_ip_ban_table() {
     }
 
     // INVARIANT: only the address this node observed the connection on is charged.
-    // CURRENT: `Peer::known_ip_addresses` reads `multiaddrs`, which `update_net` extends from the
+    // PRE-FIX: `Peer::known_ip_addresses` reads `multiaddrs`, which `update_net` extends from the
     // peer's own record, so two peers can blocklist any address they name.
     assert!(
         !peers.ip_banned(&victim),
@@ -706,7 +706,7 @@ fn clearing_a_ban_on_dial_emits_an_unban_action() {
     let action = peers.update_connection_status(&peer_id, NewConnectionStatus::Dialing);
 
     // INVARIANT: a transition that clears the ban stores announces it.
-    // CURRENT: `handle_dialing_transition`'s `Banned` arm calls `remove_banned_peer` and then
+    // PRE-FIX: `handle_dialing_transition`'s `Banned` arm calls `remove_banned_peer` and then
     // returns `NoAction`, so the peer is silently un-charged while the gossipsub blacklist and the
     // kad routing entry stay as the ban left them.
     assert!(


### PR DESCRIPTION
## Summary
Follow-ups to the review round on #92-#96: the two confirmed code findings, a reqres attribution fix, and the doc cleanups.
- a committee member banned before discovery resolved its record has that ban released the moment discovery trusts it, so the stale charge cannot evict an innocent peer under the cap or hold a shared IP blocklisted
- an oversize kad record charges only its authenticated author, never an honest relayer, matching the deliverer-vs-author invariant; the dead store-error reasons and the unreachable provider-key arm are removed
- an inbound request-response Io failure earns no penalty: libp2p reports an unreadable request and this node's own failed response write as the same variant, so charging it would ban an innocent requester
- the invariant-suite INVARIANT/CURRENT pins are reframed as PRE-FIX regression guards now that the pinned bugs are fixed, and a double-negation doc on update_net is reworded
## Surface areas touched
- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only
## Breaking / compatibility
None. No wire-format or message-shape change, so it stays rolling-upgrade safe.