### PR TITLE
fix: apply hardfork migrations on non-first batches

### DIFF
--- a/crates/execution/evm/src/evm/block.rs
+++ b/crates/execution/evm/src/evm/block.rs
@@ -817,33 +817,17 @@ where
             self.spec.is_spurious_dragon_active_at_block(self.evm.block().number().saturating_to());
         self.evm.db_mut().set_state_clear_flag(state_clear_flag);
 
-        // log newly activated hardforks on the first batch of an output
-        if self.ctx.first_batch() {
-            let block_number = self.evm.block().number().saturating_to::<u64>();
-            let parent_number = block_number.saturating_sub(1);
-            for fork in self.spec.newly_activated_forks(parent_number, block_number) {
-                info!(
-                    target: "engine",
-                    ?fork,
-                    block_number,
-                    "Rayls hardfork activated"
-                );
-            }
-        }
-
         // apply any one-shot hardfork state migrations newly activated at this block
-        if self.ctx.first_batch() {
-            let block_number = self.evm.block().number().saturating_to::<u64>();
-            let parent_number = block_number.saturating_sub(1);
-            hardforks::apply_activated_migrations(
-                &self.spec,
-                &mut *self.evm.db_mut(),
-                &mut self.state_hook,
-                self.receipts.len(),
-                parent_number,
-                block_number,
-            )?;
-        }
+        let block_number = self.evm.block().number().saturating_to::<u64>();
+        let parent_number = block_number.saturating_sub(1);
+        hardforks::apply_activated_migrations(
+            &self.spec,
+            &mut *self.evm.db_mut(),
+            &mut self.state_hook,
+            self.receipts.len(),
+            parent_number,
+            block_number,
+        )?;
 
         // apply system calls and cleanup state
         if self.ctx.first_batch() {
@@ -1077,5 +1061,39 @@ where
             header,
             body: BlockBody { transactions, ommers: Default::default(), withdrawals },
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        chainspec::RaylsChainSpec, native_erc20::ERC20_PRECOMPILE_ADDRESS,
+        test_utils::pre_execution::run_pre_execution,
+    };
+    use rayls_infrastructure_types::test_chain_spec_arc;
+
+    // A skipped activation leaves later system calls and execution running against un-migrated
+    // state, so the node diverges.
+    #[test]
+    fn migration_applies_when_activation_block_is_not_first_batch() {
+        const ACTIVATION_BLOCK: u64 = 2;
+        let spec = RaylsChainSpec::builder(test_chain_spec_arc())
+            .erc20_precompile_bytecode(ACTIVATION_BLOCK)
+            .build();
+
+        let state = run_pre_execution(spec, ACTIVATION_BLOCK, 1);
+
+        let account = state
+            .cache
+            .accounts
+            .get(&ERC20_PRECOMPILE_ADDRESS)
+            .expect("migration must create the precompile account even on a non-first batch")
+            .account
+            .as_ref()
+            .expect("account info present");
+        assert!(
+            account.info.code.is_some(),
+            "the Erc20PrecompileBytecode migration must install STOP bytecode on a non-first batch",
+        );
     }
 }

--- a/crates/execution/evm/src/evm/hardforks/mod.rs
+++ b/crates/execution/evm/src/evm/hardforks/mod.rs
@@ -59,9 +59,16 @@ pub(crate) fn apply_activated_migrations<DB: alloy_evm::Database>(
 where
     DB::Error: core::fmt::Display,
 {
-    let newly = spec.newly_activated_forks(parent_number, block_number);
+    let newly_activated_forks = spec.newly_activated_forks(parent_number, block_number);
 
-    for fork in newly {
+    for fork in newly_activated_forks {
+        info!(
+            target: "engine",
+            ?fork,
+            block_number,
+            "Rayls hardfork activated"
+        );
+
         let mut state = match fork {
             RaylsHardFork::AdminTransfer => {
                 info!(

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -690,3 +690,63 @@ pub async fn create_committee_from_state(epoch_state: EpochState) -> eyre::Resul
     committee.load();
     Ok(committee)
 }
+
+/// Shared drivers for the crate's own executor unit tests.
+#[cfg(test)]
+pub(crate) mod pre_execution {
+    use crate::{
+        chainspec::RaylsChainSpec,
+        evm::{RaylsBlockExecutionCtx, RaylsBlockExecutor, RaylsEvmFactory},
+    };
+    use rayls_infrastructure_types::{B256, EMPTY_OMMER_ROOT_HASH, U256};
+    use rayls_middleware_rewards::RewardsCounter;
+    use reth_evm::{block::BlockExecutor as _, EvmEnv, EvmFactory as _};
+    use reth_evm_ethereum::RethReceiptBuilder;
+    use reth_revm::{
+        context::{BlockEnv, CfgEnv},
+        db::EmptyDBTyped,
+        primitives::hardfork::SpecId,
+        State,
+    };
+
+    /// Run the pre-execution phase for `spec` at `block_number` with the given intra-output
+    /// `batch_index`, against a fresh empty [`State`], and return the post-state for assertions.
+    ///
+    /// Boots no node. `batch_index > 0` makes `first_batch()` false, the case a one-shot hardfork
+    /// migration must still apply on.
+    pub(crate) fn run_pre_execution(
+        spec: RaylsChainSpec,
+        block_number: u64,
+        batch_index: usize,
+    ) -> State<EmptyDBTyped<core::convert::Infallible>> {
+        let mut state = State::builder()
+            .with_database(EmptyDBTyped::<core::convert::Infallible>::new())
+            .with_bundle_update()
+            .build();
+
+        let block_env = BlockEnv { number: U256::from(block_number), ..Default::default() };
+        // A pre-Osaka spec keeps the incidental EIP-2935 blockhashes system call from tripping the
+        // Osaka per-transaction gas cap; that call is orthogonal to the pre-execution phase.
+        let cfg = CfgEnv::new().with_spec_and_mainnet_gas_params(SpecId::CANCUN);
+        let evm = RaylsEvmFactory.create_evm(&mut state, EvmEnv::new(cfg, block_env));
+
+        let ctx = RaylsBlockExecutionCtx {
+            parent_hash: B256::ZERO,
+            parent_beacon_block_root: None,
+            nonce: 0,
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            requests_hash: None,
+            close_epoch: None,
+            // difficulty packs `batch_index << 16 | worker_id`, as block construction does; only
+            // the batch index matters here (worker id 0).
+            difficulty: U256::from(batch_index << 16),
+            rewards_counter: RewardsCounter::default(),
+            close_epoch_tally: None,
+        };
+
+        let mut executor = RaylsBlockExecutor::new(evm, ctx, spec, RethReceiptBuilder::default());
+        executor.apply_pre_execution_changes().expect("pre-execution changes succeed");
+        drop(executor);
+        state
+    }
+}


### PR DESCRIPTION
## Summary

- One-shot hardfork migrations were applied only when `first_batch()` was true, so an activation block produced from a batch with index > 0 (an epoch-close boundary block rides the last batch, a drained parked batch lands out of order) silently skipped its migration and later ran against un-migrated state.
- Apply the migrations on every batch; the activation is a parent-to-block transition, so it still fires exactly once, on the block whose number crosses the activation threshold.
- Fold the "hardfork activated" log into the migration loop so it reports wherever the migration runs.

Closes #702

## Surface areas touched

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

Execution-behavior change at hardfork activation blocks. All nodes must run this version before any activation block that can land on a non-first batch: a mixed-version network computing such a block diverges, because upgraded nodes apply the migration and un-upgraded nodes skip it. Not a wire-format change and no restart/contract migration required beyond the coordinated rollout.

## Test plan

- [x] Added `migration_applies_when_activation_block_is_not_first_batch`: fails with the old `first_batch()` guard, passes with the fix (verified by restoring the guard and re-running).
- [x] `cargo test -p rayls-execution-evm --all-features` green (87 + 1); `cargo check --workspace --all-features --all-targets` clean.
