### PR TITLE
ci: scope release builds to the binary package, drop auto release PR

### DIFF
--- a/.github/workflows/feature-build-matrix.yml
+++ b/.github/workflows/feature-build-matrix.yml
@@ -81,7 +81,11 @@ jobs:
       - name: Build rayls-network (production, default features)
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
-        run: cargo build --bin rayls-network --release --locked
+        # `-p` is load-bearing: a bare `--bin rayls-network` selects every default
+        # workspace member for feature resolution, so features enabled by the testing
+        # crates (e2e-tests / chaos-framework pull in `rayls-infrastructure-config/test-utils`,
+        # which drops PBKDF2 to 1 round) unify into the shipping binary.
+        run: cargo build -p rayls-network --bin rayls-network --release --locked
 
       - name: sccache stats
         if: always()
@@ -139,7 +143,9 @@ jobs:
           VERGEN_GIT_SHA: ${{ github.sha }}
         # matrix.cargo_flags is a static, workflow-authored value (not user
         # input), so expanding it into the run line is safe.
-        run: cargo build --bin rayls-network --release --locked ${{ matrix.cargo_flags }}
+        # `-p` scopes feature resolution to the binary's own package — see the
+        # production job above.
+        run: cargo build -p rayls-network --bin rayls-network --release --locked ${{ matrix.cargo_flags }}
 
       - name: sccache stats
         if: always()

--- a/.github/workflows/feature-build-matrix.yml
+++ b/.github/workflows/feature-build-matrix.yml
@@ -81,10 +81,6 @@ jobs:
       - name: Build rayls-network (production, default features)
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
-        # `-p` is load-bearing: a bare `--bin rayls-network` selects every default
-        # workspace member for feature resolution, so features enabled by the testing
-        # crates (e2e-tests / chaos-framework pull in `rayls-infrastructure-config/test-utils`,
-        # which drops PBKDF2 to 1 round) unify into the shipping binary.
         run: cargo build -p rayls-network --bin rayls-network --release --locked
 
       - name: sccache stats
@@ -141,10 +137,6 @@ jobs:
       - name: Build rayls-network (${{ matrix.name }})
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}
-        # matrix.cargo_flags is a static, workflow-authored value (not user
-        # input), so expanding it into the run line is safe.
-        # `-p` scopes feature resolution to the binary's own package — see the
-        # production job above.
         run: cargo build -p rayls-network --bin rayls-network --release --locked ${{ matrix.cargo_flags }}
 
       - name: sccache stats

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release — bump version
 
 # Manually start a release. Bumps the shared workspace version
-# ([workspace.package].version, inherited by all crates) and opens a PR.
-# Merging that PR triggers tag-on-release.yml, which tags v<version> and builds
-# the devnet image — so this workflow's only job is the version bump + PR.
+# ([workspace.package].version, inherited by all crates), commits it to a
+# release/v<version> branch and pushes that branch.
+#
+# Opening the PR is deliberately left to a human: this org does not grant
+# Actions permission to create pull requests. Open release/v<version> -> main
+# yourself (the run summary links straight to the compare page); merging it
+# triggers tag-on-release.yml, which tags v<version> and builds the devnet image.
 #
 # ACCESS: workflow_dispatch already requires write access to the repo, so only
 # collaborators / org members granted write can start a release. The job also
@@ -26,11 +30,10 @@ on:
 
 permissions:
   contents: write        # push the release/* branch
-  pull-requests: write   # open the release PR
 
 jobs:
   bump:
-    name: Bump ${{ inputs.bump }} and open PR
+    name: Bump ${{ inputs.bump }} and push release branch
     runs-on: ubuntu-latest
     # Fork guard: only run on the canonical org repo. Who may trigger is already
     # bounded by workflow_dispatch's write-access requirement (i.e. org members
@@ -86,13 +89,9 @@ jobs:
           echo "old=$OLD" >> "$GITHUB_OUTPUT"
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
 
-      - name: Create branch, commit, open PR
+      - name: Create branch, commit and push
         env:
-          GH_TOKEN: ${{ github.token }}
           NEW: ${{ steps.bump.outputs.new }}
-          OLD: ${{ steps.bump.outputs.old }}
-          BUMP: ${{ inputs.bump }}
-          ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
           BRANCH="release/v$NEW"
@@ -102,9 +101,25 @@ jobs:
           git add Cargo.toml Cargo.lock
           git commit -m "chore(release): v$NEW"
           git push --set-upstream origin "$BRANCH"
-          gh pr create --base main --head "$BRANCH" \
-            --title "chore(release): v$NEW" \
-            --assignee "$ACTOR" \
-            --body "Automated version bump \`$OLD\` → \`$NEW\` (level: \`$BUMP\`), triggered by @$ACTOR.
 
-          Merging this PR creates tag \`v$NEW\` and builds the \`devnet-v$NEW\` image (via \`tag-on-release.yml\`)."
+      # The PR is opened by hand, so leave the operator everything needed to do it.
+      - name: Summary
+        env:
+          NEW: ${{ steps.bump.outputs.new }}
+          OLD: ${{ steps.bump.outputs.old }}
+          BUMP: ${{ inputs.bump }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BRANCH="release/v$NEW"
+          {
+            echo "## Release v$NEW"
+            echo
+            echo "Version bumped \`$OLD\` → \`$NEW\` (level: \`$BUMP\`) and pushed to \`$BRANCH\`."
+            echo
+            echo "**Next step — open the PR manually:**"
+            echo
+            echo "[Open \`$BRANCH\` → \`main\`]($REPO_URL/compare/main...$BRANCH?expand=1&title=chore%28release%29%3A+v$NEW)"
+            echo
+            echo "Merging it creates tag \`v$NEW\` and builds the \`devnet-v$NEW\` image (via \`tag-on-release.yml\`)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tag-on-release.yml
+++ b/.github/workflows/tag-on-release.yml
@@ -1,8 +1,8 @@
 name: Tag & build release
 
-# When the shared workspace version changes on main (via the release PR from
-# release.yml, or any manual edit to [workspace.package].version), create tag
-# v<version> and build the devnet image.
+# When the shared workspace version changes on main (via the manually opened PR
+# for the release/* branch that release.yml pushes, or any manual edit to
+# [workspace.package].version), create tag v<version> and build the devnet image.
 #
 # We invoke build-docker.yml directly (workflow_call) rather than relying on the
 # tag push to trigger it: a tag created with the default GITHUB_TOKEN does NOT

--- a/etc/chaos-network/Dockerfile
+++ b/etc/chaos-network/Dockerfile
@@ -24,8 +24,6 @@ COPY rayls-contracts/ ./rayls-contracts/
 ARG VERGEN_GIT_SHA
 ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 
-# build the binary. `-p` scopes feature resolution to the binary's own package so chaos
-# exercises the same build the release image ships -- see etc/docker-network/Dockerfile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=./target \

--- a/etc/chaos-network/Dockerfile
+++ b/etc/chaos-network/Dockerfile
@@ -24,11 +24,12 @@ COPY rayls-contracts/ ./rayls-contracts/
 ARG VERGEN_GIT_SHA
 ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 
-# build the binary
+# build the binary. `-p` scopes feature resolution to the binary's own package so chaos
+# exercises the same build the release image ships -- see etc/docker-network/Dockerfile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=./target \
-    cargo build --bin rayls-network --release \
+    cargo build -p rayls-network --bin rayls-network --release \
     && mv ./target/release/rayls-network /tmp/
 
 # production image with network tools for chaos testing

--- a/etc/docker-network/Dockerfile
+++ b/etc/docker-network/Dockerfile
@@ -20,11 +20,6 @@ COPY crates/ ./crates/
 COPY chain-configs/ ./chain-configs/
 COPY rayls-contracts/ ./rayls-contracts/
 
-# The builder image has no `git` and no `.git` directory, so vergen cannot derive
-# the commit itself and reads this variable instead. Never let it expand to the
-# empty string: reth's own build script reads the same variable and slices the
-# first 7 bytes off it, panicking on "". Fall back to an all-zero sha so a build
-# without --build-arg still works (with an obviously-unstamped version).
 ARG VERGEN_GIT_SHA
 ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 
@@ -32,12 +27,6 @@ ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 # `node --dev` chains. Empty (default) -> a production build with no extra features.
 ARG BUILD_FEATURES=""
 
-# `cargo build -p rayls-network` is package-scoped deliberately. A bare `--bin rayls-network`
-# selects every default workspace member for feature resolution, so features enabled by the
-# testing crates unify into this binary -- e2e-tests and chaos-framework depend on
-# `rayls-infrastructure-config` with `features = ["test-utils"]`, which drops the BLS keystore
-# from 1_000_000 PBKDF2 rounds to 1. `-p` restricts resolution to the binary's own package.
-#
 # move binary out of cache for subsequent build steps
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \

--- a/etc/docker-network/Dockerfile
+++ b/etc/docker-network/Dockerfile
@@ -32,11 +32,17 @@ ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 # `node --dev` chains. Empty (default) -> a production build with no extra features.
 ARG BUILD_FEATURES=""
 
+# `cargo build -p rayls-network` is package-scoped deliberately. A bare `--bin rayls-network`
+# selects every default workspace member for feature resolution, so features enabled by the
+# testing crates unify into this binary -- e2e-tests and chaos-framework depend on
+# `rayls-infrastructure-config` with `features = ["test-utils"]`, which drops the BLS keystore
+# from 1_000_000 PBKDF2 rounds to 1. `-p` restricts resolution to the binary's own package.
+#
 # move binary out of cache for subsequent build steps
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=./target \
-    cargo build --bin rayls-network --release ${BUILD_FEATURES:+--features ${BUILD_FEATURES}} \
+    cargo build -p rayls-network --bin rayls-network --release ${BUILD_FEATURES:+--features ${BUILD_FEATURES}} \
     && mv ./target/release/rayls-network /tmp/
 
 # production image

--- a/etc/docker-replay/Dockerfile
+++ b/etc/docker-replay/Dockerfile
@@ -43,9 +43,6 @@ COPY rayls-contracts/ ./rayls-contracts/
 ARG VERGEN_GIT_SHA
 ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 
-# build the replay binary; the archive-replay feature is selected by
-# bin/rayls-replay/Cargo.toml, so no extra --features flag is required.
-# `-p` scopes feature resolution to this package -- see etc/docker-network/Dockerfile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=./target \
@@ -75,11 +72,5 @@ USER $USER_NAME
 # copy binary
 COPY --from=builder /tmp/rayls-replay /usr/local/bin/rayls-replay
 
-# rayls-replay installs its own SIGTERM/SIGINT handler, so `docker stop` is caught
-# directly (it finishes the current output group, flushes, and exits resumable) —
-# no init wrapper needed even though the binary runs as PID 1.
-# parameters are appended as CLI flags, e.g.
-#   docker run <image> --snapshot-datadir /snapshot --archive-out /archive --chain mainnet
-# a bare `docker run <image>` prints usage via the default CMD.
 ENTRYPOINT ["rayls-replay"]
 CMD ["--help"]

--- a/etc/docker-replay/Dockerfile
+++ b/etc/docker-replay/Dockerfile
@@ -44,11 +44,12 @@ ARG VERGEN_GIT_SHA
 ENV VERGEN_GIT_SHA=${VERGEN_GIT_SHA:-0000000000000000000000000000000000000000}
 
 # build the replay binary; the archive-replay feature is selected by
-# bin/rayls-replay/Cargo.toml, so no extra --features flag is required
+# bin/rayls-replay/Cargo.toml, so no extra --features flag is required.
+# `-p` scopes feature resolution to this package -- see etc/docker-network/Dockerfile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=./target \
-    cargo build --bin rayls-replay --release \
+    cargo build -p rayls-replay --bin rayls-replay --release \
     && mv ./target/release/rayls-replay /tmp/
 
 # production image


### PR DESCRIPTION
Two unrelated CI fixes.

## 1. Scope the release build to the binary's package

`cargo build --bin rayls-network` without `-p` selects **every default workspace member** for feature resolution. `e2e-tests` and `chaos-framework` both declare:

Applied in all five places the binaries get built: the two `feature-build-matrix.yml` legs and the docker-network / chaos-network / docker-replay Dockerfiles.

## 2. Stop opening the release PR automatically

Actions isn't granted permission to create pull requests in this org, so `release.yml` now bumps the version, commits and pushes `release/vX`, then stops. Dropped the `pull-requests: write` permission and the `GH_TOKEN`/`ACTOR` env that only fed the PR body.

Added a job summary linking to a prefilled compare page so opening it by hand is one click. `tag-on-release.yml` is unaffected — it fires on the version change landing on `main` regardless of how the PR was opened; only its stale comment changed.
