### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chaos-framework"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "clap",
  "const-hex",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "consensus-metrics"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "axum 0.8.8",
  "futures",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "clap",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-batch-builder"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_matches",
  "futures-util",
@@ -7744,7 +7744,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-batch-validator"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7761,7 +7761,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-network"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7788,7 +7788,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-primary"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7819,7 +7819,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-primary-metrics"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "consensus-metrics",
  "prometheus",
@@ -7828,7 +7828,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-state-sync"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "consensus-metrics",
  "eyre",
@@ -7845,7 +7845,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-consensus-worker"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -7873,7 +7873,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-evm"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -7944,7 +7944,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-faucet"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -7978,7 +7978,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-metrics"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "eyre",
  "rayls-infrastructure-types",
@@ -7993,7 +7993,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-execution-rpc"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -8006,7 +8006,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-config"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "aes-gcm-siv",
  "backoff",
@@ -8030,7 +8030,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-network-types"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "eyre",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-storage"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "criterion",
  "eyre",
@@ -8066,7 +8066,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-types"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8104,7 +8104,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-utils"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "futures",
  "parking_lot",
@@ -8113,7 +8113,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-bridge"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "consensus-metrics",
  "eyre",
@@ -8134,7 +8134,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-orchestrator"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "consensus-metrics",
@@ -8176,7 +8176,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-processor"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "assert_matches",
  "eyre",
@@ -8202,7 +8202,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-middleware-rewards"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "eyre",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-network"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "clap",
  "rayls-execution-faucet",
@@ -8231,7 +8231,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-network-cli"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "bs58",
@@ -8258,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-replay"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8279,7 +8279,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-testing-test-utils"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "clap",
  "eyre",
@@ -8296,7 +8296,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-testing-test-utils-committee"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "rand 0.9.3",
  "rayls-execution-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ exclude = ["crates/testing/fuzz-targets"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 # Remember to update:
 # - .clippy.toml


### PR DESCRIPTION
## Release v1.3.0

Version bumped \`v1.2.3\` → \`1.3.0\` (level: \`minor\`) and pushed to \`version/v1.3.0\`

