### PR TITLE
fix(network): thread peer score config instead of a process-wide global

### DIFF
--- a/crates/consensus/network/src/peers/all_peers.rs
+++ b/crates/consensus/network/src/peers/all_peers.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use libp2p::{Multiaddr, PeerId};
 use rand::seq::SliceRandom as _;
+use rayls_infrastructure_config::ScoreConfig;
 use rayls_infrastructure_types::{BlsPublicKey, NetworkPublicKey};
 use std::{
     collections::{BinaryHeap, HashMap, HashSet},
@@ -67,6 +68,9 @@ pub(super) struct AllPeers {
     max_banned_peers: usize,
     /// The maximum number of disconnected peers to maintain before pruning.
     max_disconnected_peers: usize,
+    /// Peer scoring configuration, threaded into every [`Peer`]/`Score` this store creates so the
+    /// whole node shares one configuration without a process-global.
+    score_config: ScoreConfig,
 }
 
 impl AllPeers {
@@ -75,6 +79,7 @@ impl AllPeers {
         dial_timeout: Duration,
         max_banned_peers: usize,
         max_disconnected_peers: usize,
+        score_config: ScoreConfig,
     ) -> Self {
         Self {
             peers: Default::default(),
@@ -87,6 +92,7 @@ impl AllPeers {
             dial_timeout,
             max_banned_peers,
             max_disconnected_peers,
+            score_config,
         }
     }
 
@@ -100,7 +106,7 @@ impl AllPeers {
         addr: Vec<Multiaddr>,
     ) {
         let peer_id: PeerId = network_key.clone().into();
-        let trusted_peer = Peer::new_trusted(bls_public_key, network_key, addr);
+        let trusted_peer = Peer::new_trusted(bls_public_key, network_key, addr, self.score_config);
         let _ = self.banned_peers.remove_banned_peer(&peer_id);
         self.peers.insert(peer_id, trusted_peer);
     }
@@ -133,10 +139,14 @@ impl AllPeers {
             }
         } else if is_committee_member {
             debug!(target: "peer-manager", ?peer_id, "committee member peer does not exist, creating trusted");
-            self.peers.insert(peer_id, Peer::new_trusted(bls_public_key, network_key, addrs));
+            self.peers.insert(
+                peer_id,
+                Peer::new_trusted(bls_public_key, network_key, addrs, self.score_config),
+            );
         } else {
             debug!(target: "peer-manager", ?peer_id, "peer does not exist, creating new peer");
-            self.peers.insert(peer_id, Peer::new(bls_public_key, network_key, addrs));
+            self.peers
+                .insert(peer_id, Peer::new(bls_public_key, network_key, addrs, self.score_config));
         }
     }
 
@@ -201,7 +211,7 @@ impl AllPeers {
             }
 
             // add default peer
-            let mut peer = Peer::default();
+            let mut peer = Peer::empty(self.score_config);
             if self.is_peer_validator(peer_id) {
                 peer.make_trusted();
             }

--- a/crates/consensus/network/src/peers/manager.rs
+++ b/crates/consensus/network/src/peers/manager.rs
@@ -3,7 +3,6 @@
 use super::{
     all_peers::AllPeers,
     cache::BannedPeerCache,
-    score::init_peer_score_config,
     status::{DisconnectReason, NewConnectionStatus},
     types::{ConnectionDirection, ConnectionType, DialRequest, PeerAction},
     PeerEvent, PeerExchangeMap, Penalty,
@@ -98,11 +97,9 @@ impl PeerManager {
             config.dial_timeout,
             config.max_banned_peers,
             config.max_disconnected_peers,
+            config.score_config,
         );
         let temporarily_banned = BannedPeerCache::new(config.excess_peers_reconnection_timeout);
-
-        // initialize global score config
-        init_peer_score_config(config.score_config);
 
         Self {
             config: *config,

--- a/crates/consensus/network/src/peers/mod.rs
+++ b/crates/consensus/network/src/peers/mod.rs
@@ -12,7 +12,3 @@ mod types;
 pub(crate) use manager::PeerManager;
 pub(crate) use types::PeerEvent;
 pub use types::{PeerExchangeMap, Penalty};
-
-// visibility for tests
-#[cfg(test)]
-pub(crate) use score::GLOBAL_SCORE_CONFIG;

--- a/crates/consensus/network/src/peers/peer.rs
+++ b/crates/consensus/network/src/peers/peer.rs
@@ -1,12 +1,13 @@
 //! Information shared between peers.
 
 use super::{
-    score::{global_score_config, Reputation, ReputationUpdate, Score},
+    score::{Reputation, ReputationUpdate, Score},
     status::ConnectionStatus,
     types::ConnectionDirection,
     Penalty,
 };
 use libp2p::{core::multiaddr::Multiaddr, PeerId};
+use rayls_infrastructure_config::ScoreConfig;
 use rayls_infrastructure_types::{BlsPublicKey, NetworkPublicKey, Protocol};
 use std::{collections::HashSet, net::IpAddr, time::Instant};
 use tracing::error;
@@ -19,7 +20,7 @@ const MAX_MULTIADDRS_PER_PEER: usize = 20;
 /// It is possible we need to track a peer before we have network settings.
 /// These are only used for peer exchange and if not set then this peer will not
 /// be exchaged (which is fine since we don't have this info yet).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(super) struct Peer {
     /// The peers Bls public key.
     bls_public_key: Option<BlsPublicKey>,
@@ -27,6 +28,9 @@ pub(super) struct Peer {
     network_key: Option<NetworkPublicKey>,
     /// The peer's score - used to derive [Reputation].
     score: Score,
+    /// Peer scoring configuration, threaded from the `PeerManager` so a score rebuilt on a trust
+    /// change reuses the node's configuration.
+    config: ScoreConfig,
     /// The multiaddrs this node has witnessed the peer using.
     ///
     /// These are used to manage the banning process and are exchanged with peers.
@@ -55,12 +59,14 @@ impl Peer {
         bls_public_key: BlsPublicKey,
         network_key: NetworkPublicKey,
         listening_addrs: Vec<Multiaddr>,
+        config: ScoreConfig,
     ) -> Peer {
         Self {
             bls_public_key: Some(bls_public_key),
             network_key: Some(network_key),
             listening_addrs,
-            score: Score::new_max(),
+            score: Score::new_max(config),
+            config,
             is_trusted: true,
             multiaddrs: Default::default(),
             connection_status: Default::default(),
@@ -74,12 +80,32 @@ impl Peer {
         bls_public_key: BlsPublicKey,
         network_key: NetworkPublicKey,
         listening_addrs: Vec<Multiaddr>,
+        config: ScoreConfig,
     ) -> Peer {
         Self {
             bls_public_key: Some(bls_public_key),
             network_key: Some(network_key),
             listening_addrs,
-            score: Score::default(),
+            score: Score::new(config),
+            config,
+            is_trusted: false,
+            multiaddrs: Default::default(),
+            connection_status: Default::default(),
+            connection_direction: Default::default(),
+            routable: false,
+        }
+    }
+
+    /// Create an empty peer record (no keys yet) with the node's score configuration.
+    ///
+    /// Used when a connection status update arrives for a peer we have not yet recorded.
+    pub(super) fn empty(config: ScoreConfig) -> Peer {
+        Self {
+            bls_public_key: None,
+            network_key: None,
+            listening_addrs: Vec::new(),
+            score: Score::new(config),
+            config,
             is_trusted: false,
             multiaddrs: Default::default(),
             connection_status: Default::default(),
@@ -96,11 +122,13 @@ impl Peer {
         let bls_public_key = *BlsKeypair::generate(&mut rng).public();
         let network_key: NetworkPublicKey = NetworkKeypair::generate_ed25519().public().into();
         let listening_addrs = vec![Multiaddr::empty()];
+        let config = ScoreConfig::default();
         Self {
             bls_public_key: Some(bls_public_key),
             network_key: Some(network_key),
             listening_addrs,
-            score: Score::new_max(),
+            score: Score::new_max(config),
+            config,
             is_trusted: false,
             multiaddrs: Default::default(),
             connection_status: Default::default(),
@@ -143,16 +171,12 @@ impl Peer {
 
     /// Return a peer's reputation based on the aggregate score.
     ///
-    /// The thresholds come from the score config, the same source [`Score::is_banned`] reads to arm
-    /// the decay freeze. A second pair of thresholds would have to agree with these for the freeze
-    /// and the verdict to describe the same peers, and nothing could enforce that.
+    /// Delegates to [`Score::reputation`], which reads the same thresholds [`Score::is_banned`]
+    /// uses to arm the decay freeze — so the verdict and the freeze describe the same peers from a
+    /// single configuration source, rather than a second pair of thresholds nothing could keep in
+    /// agreement.
     pub(super) fn reputation(&self) -> Reputation {
-        let config = global_score_config();
-        match self.score.aggregate_score() {
-            score if score <= config.min_score_before_ban => Reputation::Banned,
-            score if score <= config.min_score_before_disconnect => Reputation::Disconnected,
-            _ => Reputation::Trusted,
-        }
+        self.score.reputation()
     }
 
     /// Return an iterator of known ip addresses for a peer.
@@ -332,7 +356,7 @@ impl Peer {
     pub(super) fn make_trusted(&mut self) {
         if !self.is_trusted {
             self.is_trusted = true;
-            self.score = Score::new_max();
+            self.score = Score::new_max(self.config);
         }
     }
 
@@ -340,7 +364,7 @@ impl Peer {
     pub(super) fn make_untrusted(&mut self) {
         if self.is_trusted {
             self.is_trusted = false;
-            self.score = Score::default();
+            self.score = Score::new(self.config);
         }
     }
 

--- a/crates/consensus/network/src/peers/score.rs
+++ b/crates/consensus/network/src/peers/score.rs
@@ -8,44 +8,13 @@
 use super::types::Penalty;
 use rayls_infrastructure_config::ScoreConfig;
 use serde::Serialize;
-use std::{
-    fmt::Display,
-    sync::{Arc, RwLock},
-    time::Instant,
-};
-
-/// Global peer score configuration.
-///
-/// A node runs with one configuration for its whole life, so production installs it once through
-/// `init_peer_score_config`. The lock, rather than a `OnceLock`, lets the test harness install a
-/// fresh configuration per case: `cargo test` runs the whole suite in one process, so a write-once
-/// cell would leak the first case's configuration into every later one.
-pub(crate) static GLOBAL_SCORE_CONFIG: RwLock<Option<Arc<ScoreConfig>>> = RwLock::new(None);
-
-/// Install the global peer score configuration.
-///
-/// Sets the configuration only once: a node installs it at startup, and a later caller (a second
-/// `PeerManager`, or a test's node harness) must not overwrite a configuration already in force.
-pub(super) fn init_peer_score_config(config: ScoreConfig) {
-    let mut guard = GLOBAL_SCORE_CONFIG.write().expect("score config lock poisoned");
-    if guard.is_none() {
-        *guard = Some(Arc::new(config));
-    }
-}
-
-/// Get a clone of the global peer score configuration.
-///
-/// Panics if the configuration has not been installed.
-pub(super) fn global_score_config() -> Arc<ScoreConfig> {
-    let config = GLOBAL_SCORE_CONFIG.read().expect("score config lock poisoned").clone();
-    config.expect("Peer score configuration not initialized")
-}
+use std::{fmt::Display, time::Instant};
 
 /// A peer's score (perceived potential usefulness).
 ///
 /// This simplistic version consists of a global score per peer which decays to 0 over time. The
 /// decay rate applies equally to positive and negative scores.
-#[derive(PartialEq, Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(super) struct Score {
     /// The global score used to accumulate penalties.
     ///
@@ -58,29 +27,42 @@ pub(super) struct Score {
     /// The time the score was last updated to perform time-based adjustments such as score-decay.
     #[serde(skip)]
     last_updated: Instant,
+    /// Peer scoring configuration (score bounds, halflife, ban thresholds).
+    ///
+    /// Node-scoped: owned by the `PeerManager` and threaded down through `AllPeers`/`Peer`, so
+    /// every score shares one configuration without a process-global. `ScoreConfig` is `Copy`.
+    #[serde(skip)]
+    config: ScoreConfig,
 }
 
-impl Default for Score {
-    fn default() -> Self {
-        let config = global_score_config();
-
-        Score {
-            rayls_score: config.default_score,
-            aggregate_score: config.default_score,
-            last_updated: Instant::now(),
-        }
+impl PartialEq for Score {
+    // The configuration is identical for every score in a node, so equality is defined by the
+    // mutable scoring state alone (matching the pre-config derived behaviour).
+    fn eq(&self, other: &Self) -> bool {
+        self.rayls_score == other.rayls_score
+            && self.aggregate_score == other.aggregate_score
+            && self.last_updated == other.last_updated
     }
 }
 
 impl Score {
-    /// Create `Self` with max values.
-    pub(super) fn new_max() -> Self {
-        let config = global_score_config();
+    /// Create a score initialized to the configured default (new-peer) score.
+    pub(super) fn new(config: ScoreConfig) -> Self {
+        Self {
+            rayls_score: config.default_score,
+            aggregate_score: config.default_score,
+            last_updated: Instant::now(),
+            config,
+        }
+    }
 
+    /// Create `Self` with max values.
+    pub(super) fn new_max(config: ScoreConfig) -> Self {
         Self {
             rayls_score: config.max_score,
             aggregate_score: config.max_score,
             last_updated: Instant::now(),
+            config,
         }
     }
 
@@ -91,7 +73,7 @@ impl Score {
 
     /// Modifies the score based on the penalty type and returns the new score.
     pub(super) fn apply_penalty(&mut self, penalty: Penalty) {
-        let config = global_score_config();
+        let config = self.config;
 
         // NOTE: these use `Self::add`
         // which cannot overflow using default config min and max scores
@@ -110,7 +92,7 @@ impl Score {
 
     /// Add an f64 to the currrent application score within the min/max limits.
     fn add(&mut self, score: f64) -> f64 {
-        let config = global_score_config();
+        let config = self.config;
         (self.rayls_score + score).clamp(config.min_score, config.max_score)
     }
 
@@ -133,7 +115,7 @@ impl Score {
         if let Some(prev_update) =
             now.checked_duration_since(self.last_updated).map(|d| d.as_secs_f64())
         {
-            let config = global_score_config();
+            let config = self.config;
 
             // e^(-ln(2)/HL*t)
             //
@@ -160,7 +142,7 @@ impl Score {
 
         // ban the peer if threshold reached
         if !already_banned && self.is_banned() {
-            let config = global_score_config();
+            let config = self.config;
 
             // ban the peer for at least BANNED_BEFORE_DECAY seconds
             self.last_updated += config.banned_before_decay();
@@ -169,8 +151,19 @@ impl Score {
 
     /// Helper method if a peer has reached the threshold for being banned.
     pub(super) fn is_banned(&self) -> bool {
-        let config = global_score_config();
-        self.aggregate_score <= config.min_score_before_ban
+        self.aggregate_score <= self.config.min_score_before_ban
+    }
+
+    /// The peer's reputation implied by its aggregate score.
+    ///
+    /// Reads the same thresholds [`Score::is_banned`] uses, so the verdict and the ban decay freeze
+    /// always describe the same peers from a single configuration source.
+    pub(super) fn reputation(&self) -> Reputation {
+        match self.aggregate_score {
+            score if score <= self.config.min_score_before_ban => Reputation::Banned,
+            score if score <= self.config.min_score_before_disconnect => Reputation::Disconnected,
+            _ => Reputation::Trusted,
+        }
     }
 }
 

--- a/crates/consensus/network/src/tests/banned_peers.rs
+++ b/crates/consensus/network/src/tests/banned_peers.rs
@@ -1,14 +1,12 @@
 //! Unit tests for banned peers
 
 use super::*;
-use crate::common::{ensure_score_config, random_ip_addr};
+use crate::common::random_ip_addr;
 use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
 use std::net::Ipv4Addr;
 
 /// Helper function to create a distinctly-identified peer with specific IP addresses.
 fn create_peer_with_ips(ips: Vec<IpAddr>) -> (PeerId, Peer) {
-    ensure_score_config(None);
-
     let mut peer = Peer::default_for_test();
 
     // add multiaddrs with the specified IPs
@@ -90,7 +88,6 @@ fn test_add_multiple_peers_same_ip() {
 
 #[test]
 fn test_add_peer_no_ip() {
-    ensure_score_config(None);
     let mut banned_peers = BannedPeers::default();
 
     // Create a peer with no IP addresses

--- a/crates/consensus/network/src/tests/common.rs
+++ b/crates/consensus/network/src/tests/common.rs
@@ -1,31 +1,17 @@
 //! Fixtures used in multiple tests.
 
-use crate::{peers::GLOBAL_SCORE_CONFIG, PeerExchangeMap, RLMessage};
+use crate::{PeerExchangeMap, RLMessage};
 use libp2p::Multiaddr;
 use rand::prelude::*;
-use rayls_infrastructure_config::ScoreConfig;
 use rayls_infrastructure_types::{
     BlockHash, Certificate, CertificateDigest, Header, SealedBatch, Vote,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::Arc,
-};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 /// Default heartbeat for tests.
 #[allow(dead_code)] // used in network_tests.rs
 pub(crate) const TEST_HEARTBEAT_INTERVAL: u64 = 1;
-
-/// Install a score configuration for the current test.
-///
-/// Overwrites any prior value: `cargo test --test-threads 1` shares one process, so each test
-/// installs the configuration it needs at setup rather than inheriting the first test's.
-#[allow(dead_code)] // used in `all_peers` and `banned_peers`
-pub(crate) fn ensure_score_config(config: Option<ScoreConfig>) {
-    *GLOBAL_SCORE_CONFIG.write().expect("score config lock poisoned") =
-        Some(Arc::new(config.unwrap_or_default()));
-}
 
 // impl RLMessage trait for types
 impl RLMessage for TestWorkerRequest {

--- a/crates/consensus/network/src/tests/peers.rs
+++ b/crates/consensus/network/src/tests/peers.rs
@@ -1,7 +1,7 @@
 //! Unit tests for `AllPeers`
 
 use super::*;
-use crate::common::{create_multiaddr, ensure_score_config, random_ip_addr};
+use crate::common::{create_multiaddr, random_ip_addr};
 use libp2p::PeerId;
 use rand::{rngs::StdRng, SeedableRng as _};
 use rayls_infrastructure_config::{PeerConfig, ScoreConfig};
@@ -14,9 +14,13 @@ use std::{
 /// Helper function to create a test AllPeers instance
 fn create_all_peers(peer_config: Option<PeerConfig>) -> AllPeers {
     let config = peer_config.unwrap_or_default();
-    ensure_score_config(Some(config.score_config));
     let dial_timeout = Duration::from_secs(5);
-    AllPeers::new(dial_timeout, config.max_banned_peers, config.max_disconnected_peers)
+    AllPeers::new(
+        dial_timeout,
+        config.max_banned_peers,
+        config.max_disconnected_peers,
+        config.score_config,
+    )
 }
 
 #[test]
@@ -338,9 +342,8 @@ fn test_pruning_logic() {
 
 #[test]
 fn test_is_validator() {
-    ensure_score_config(None);
     let validator_id = PeerId::random();
-    let mut all_peers = AllPeers::new(Duration::from_secs(5), 10, 10);
+    let mut all_peers = AllPeers::new(Duration::from_secs(5), 10, 10, ScoreConfig::default());
     all_peers.current_committee.insert(validator_id);
     assert!(all_peers.is_peer_validator(&validator_id));
     assert!(!all_peers.is_peer_validator(&PeerId::random()));

--- a/crates/consensus/network/src/tests/reputation_invariants.rs
+++ b/crates/consensus/network/src/tests/reputation_invariants.rs
@@ -9,20 +9,24 @@
 //! line naming the violation; the fixes have landed, so they now pass as regression guards.
 
 use super::*;
-use crate::common::{create_multiaddr, ensure_score_config};
+use crate::common::create_multiaddr;
 use libp2p::PeerId;
 use rand::{rngs::StdRng, SeedableRng as _};
 use rayls_infrastructure_config::{PeerConfig, ScoreConfig};
 use rayls_infrastructure_types::{now, BlsKeypair, NetworkKeypair};
 use std::net::{IpAddr, Ipv4Addr};
 
-/// Build an `AllPeers` from an operator config, installing its `ScoreConfig` for this test.
+/// Build an `AllPeers` from an operator config.
 ///
-/// The configuration is process-global but overwritten per test, so under `cargo test
-/// --test-threads 1` each case runs against the config it installs here.
+/// The `ScoreConfig` is owned by the store (threaded to every peer's `Score`), so each test is
+/// isolated and safe under parallel `cargo test` — no process-global to clobber.
 fn all_peers_with(config: PeerConfig) -> AllPeers {
-    ensure_score_config(Some(config.score_config));
-    AllPeers::new(Duration::from_secs(5), config.max_banned_peers, config.max_disconnected_peers)
+    AllPeers::new(
+        Duration::from_secs(5),
+        config.max_banned_peers,
+        config.max_disconnected_peers,
+        config.score_config,
+    )
 }
 
 /// Build an `AllPeers` with the default operator config.


### PR DESCRIPTION
**The problem**

Peer scoring read its configuration from a process-wide mutable global (`GLOBAL_SCORE_CONFIG`). Production sets it once, but the test harness overwrote it per case — and since `cargo test` runs the whole suite in one process with parallel threads, a config-dependent test could have its config clobbered mid-run by another test. Concretely, `decay_depends_on_elapsed_time_not_on_heartbeat_frequency` sets a 1s halflife and sleeps one second; a parallel test would reinstall the default (large) halflife during that window, so the score barely decayed and the assertion failed. It passed in isolation and failed in the full suite — order/timing-dependent flakiness.

**What's changed**

`ScoreConfig` (which is `Copy`) is now owned by the `PeerManager` and threaded down `AllPeers → Peer → Score`; each `Score` carries its own config and all decay/ban logic reads `self.config`. Removed `GLOBAL_SCORE_CONFIG`, `init_peer_score_config`, `global_score_config`, and the test-only `ensure_score_config` shim. Threshold logic is centralized in `Score::reputation()` (with `Peer::reputation` delegating). Production behavior is unchanged — a node still runs one config for its whole life; it's just no longer shared mutable state.

**Tests**

Full `rayls-consensus-network` lib suite green across repeated runs and `--test-threads 16`; the previously-flaky decay test now passes in-suite and is order-independent.
