### PR TITLE
fix(evm): raise fd limit when building temp RethEnvs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7882,6 +7882,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs-next",
  "eyre",
+ "fdlimit",
  "futures",
  "jsonrpsee",
  "parking_lot",

--- a/crates/execution/evm/Cargo.toml
+++ b/crates/execution/evm/Cargo.toml
@@ -15,6 +15,7 @@ rayls-infrastructure-types = { workspace = true }
 rayls-middleware-rewards = { workspace = true }
 rayls-consensus-worker = { workspace = true }
 dirs-next = "2.0.0"
+fdlimit = { workspace = true }
 parking_lot = { workspace = true }
 rayls-execution-metrics = { workspace = true }
 

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -189,12 +189,21 @@ impl RethEnv {
     }
 
     /// Create a new temp RethEnv using a specified chain spec.
+    ///
+    /// Raises the process descriptor limit first. Each env pins roughly forty descriptors: reth's
+    /// [`StaticFileProvider`] keeps a data and an offsets handle open per segment jar and never
+    /// evicts them, on top of MDBX and RocksDB. The node binary raises the limit before launching,
+    /// but temp envs skip that path, so a test run inherits the OS default (256 on macOS) and
+    /// spends it once a handful run concurrently -- surfacing as `Too many open files` in whichever
+    /// test next opens a jar, rather than in the one that exhausted the descriptors.
     pub async fn new_for_temp_chain<P: AsRef<Path>>(
         chain: Arc<RethChainSpec>,
         db_path: P,
         task_manager: &TaskManager,
         rewards: Option<RewardsCounter>,
     ) -> eyre::Result<Self> {
+        fdlimit::raise_fd_limit()?;
+
         let node_config = NodeConfig {
             datadir: DatadirArgs {
                 datadir: MaybePlatformPath::from(db_path.as_ref().to_path_buf()),

--- a/crates/execution/evm/src/reth_env/init.rs
+++ b/crates/execution/evm/src/reth_env/init.rs
@@ -243,6 +243,12 @@ impl RethEnv {
     ///
     /// `rayls_datadir` is the rayls root, holding `db/` + `static_files/` +
     /// `rocksdb/` as siblings (matching the standard node's layout).
+    ///
+    /// Raises the descriptor limit like [`Self::new_for_temp_chain`], for a different reason:
+    /// `rayls-replay` is its own binary, so it never reaches the node's startup call, and it opens
+    /// two envs (archive and snapshot) that walk the whole chain. Jars are never evicted once
+    /// loaded, so descriptors accumulate with the number of block ranges replayed rather than with
+    /// concurrency -- a long rebuild would otherwise run out partway through.
     #[cfg(feature = "archive-replay")]
     pub async fn new_for_archive_replay<P: AsRef<Path>>(
         chain: Arc<RethChainSpec>,
@@ -255,6 +261,8 @@ impl RethEnv {
         persistence_threshold: Option<u64>,
         rewards_counter: RewardsCounter,
     ) -> eyre::Result<Self> {
+        fdlimit::raise_fd_limit()?;
+
         let rayls_datadir = rayls_datadir.as_ref();
         let db_path = rayls_datadir.join("db");
         let node_config = NodeConfig {

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -61,6 +61,8 @@ impl RethEnv {
     }
 
     /// Create a new RethEnv with a custom RaylsChainSpec for testing hardfork behavior.
+    ///
+    /// Raises the descriptor limit for the same reason [`RethEnv::new_for_temp_chain`] does.
     pub async fn new_for_temp_chain_with_rayls_spec<P: AsRef<Path>>(
         chain: Arc<RethChainSpec>,
         rayls_chain_spec: Arc<crate::RaylsChainSpec>,
@@ -80,6 +82,8 @@ impl RethEnv {
         };
         use reth_provider::providers::BlockchainProvider;
         use reth_storage_api::{BlockNumReader, DatabaseProviderFactory};
+
+        fdlimit::raise_fd_limit()?;
 
         let node_config = NodeConfig {
             datadir: DatadirArgs {


### PR DESCRIPTION
Tests that build a temp RethEnv could fail with `Too many open files` depending on how many ran concurrently. Each env pins ~40 descriptors: reth's StaticFileProvider keeps a data and an offsets handle open per segment jar and never evicts them, on top of MDBX and RocksDB. The node binary calls raise_fd_limit() before launching, but temp envs skip that path and inherit the OS default of 256 on macOS, which a dozen test threads exhaust. The failure then lands on whichever test next opens a jar, not on the one that spent the descriptors.

Raise the limit in both temp-env constructors. raise_fd_limit() is getrlimit/setrlimit, so repeat calls are harmless.

Verified with the same test binary built with and without the change: at `ulimit -n 192` the unpatched binary fails 1 test and the patched one passes 89; at 128 it fails 3 and the patched one still passes 89.