### PR TITLE
feat: optimize and organize mem_db.rs

### DIFF
--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1272,7 +1272,7 @@ impl<T: Table, DB: Database> InsertTrait<DB> for KeyValueInsert<T> {
         txn.insert::<T>(&self.key, &self.value)
     }
     fn clear_insert_mem(&self, mem_db: &MemDatabase) {
-        let _ = mem_db.delete_removed::<T>(&self.key, false);
+        let _ = mem_db.delete_tombstoned::<T>(&self.key, false);
     }
 }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,8 +38,6 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
-
-
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
     store: RwLockReadGuard<'a, StoreType>,
@@ -379,6 +377,16 @@ impl MemDatabase {
         Self { store, metrics, shutdown_tx: Arc::new(shutdown_tx) }
     }
 
+    /// Infallible read transaction; [`Database::read_txn`] wraps this.
+    fn read_txn_impl(&self) -> MemDbTx<'_> {
+        MemDbTx { store: self.store.read() }
+    }
+
+    /// Infallible write transaction; [`Database::write_txn`] wraps this.
+    fn write_txn_impl(&self) -> MemDbTxMut<'_> {
+        MemDbTxMut { store: self.store.write() }
+    }
+
     // gets the value with the marking for delete flag
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
         if let Some(table) = self.store.read().get(T::NAME) {
@@ -488,11 +496,11 @@ impl Database for MemDatabase {
     }
 
     fn read_txn(&self) -> eyre::Result<Self::TX<'_>> {
-        Ok(MemDbTx { store: self.store.read() })
+        Ok(self.read_txn_impl())
     }
 
     fn write_txn(&self) -> eyre::Result<MemDbTxMut<'_>> {
-        Ok(MemDbTxMut { store: self.store.write() })
+        Ok(self.write_txn_impl())
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
@@ -506,7 +514,7 @@ impl Database for MemDatabase {
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
-        self.read_txn()?.get::<T>(key)
+        self.read_txn_impl().get::<T>(key)
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
@@ -519,11 +527,11 @@ impl Database for MemDatabase {
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
-        self.write_txn()?.remove::<T>(key)
+        self.write_txn_impl().remove::<T>(key)
     }
 
     fn clear_table<T: Table>(&self) -> eyre::Result<()> {
-        self.write_txn()?.clear_table::<T>()
+        self.write_txn_impl().clear_table::<T>()
     }
 
     fn is_empty<T: Table>(&self) -> bool {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,6 +38,27 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
+fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(
+        table
+            .iter()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+            .collect(),
+    )
+}
+
+fn raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(Box::new(
+        table
+            .iter()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    ))
+}
+
 fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
     let key_bytes = encode_key(key);
@@ -117,30 +138,16 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            Box::new(std::iter::empty())
+        match iter_impl::<T>(&self.store) {
+            Some(items) => Box::new(items.into_iter()),
+            None => Box::new(std::iter::empty()),
         }
     }
 
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.get(T::NAME) {
-            // The read guard is held by `self`, so we can borrow the stored
-            // bytes for the iterator's lifetime instead of cloning them.
-            Box::new(
-                table
-                    .iter()
-                    .filter(|(_, (tombstoned, _))| !*tombstoned)
-                    .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-            )
-        } else {
-            Box::new(std::iter::empty())
+        match raw_iter_impl::<T>(&self.store) {
+            Some(iter) => iter,
+            None => Box::new(std::iter::empty()),
         }
     }
 
@@ -530,15 +537,9 @@ impl Database for MemDatabase {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match iter_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -70,6 +70,16 @@ impl<'a> DbTx for MemDbTx<'a> {
         Ok(get_with_marked_check::<T>(&self.store, key))
     }
 
+    fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
+        if let Some(table) = self.store.get(T::NAME) {
+            let key_bytes = encode_key(key);
+            if let Some((tombstoned, _)) = table.get(&key_bytes) {
+                return Ok(!*tombstoned);
+            }
+        }
+        Ok(false)
+    }
+
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
         if let Some(table) = self.store.get(T::NAME) {
             let items: Vec<_> = table
@@ -504,13 +514,7 @@ impl Database for MemDatabase {
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((removed, _)) = table.get(&key_bytes) {
-                return Ok(!*removed);
-            }
-        }
-        Ok(false)
+        self.read_txn_impl().contains_key::<T>(key)
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,10 +38,7 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
-fn mark_value_for_deletion<T: Table>(value: &mut StoreTableValueType) {
-    // mark for actual deletion once tx committed
-    value.0 = true;
-}
+
 
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
@@ -181,6 +178,11 @@ pub struct MemDbTxMut<'a> {
 }
 
 impl<'a> MemDbTxMut<'a> {
+    fn mark_value_for_deletion(value: &mut StoreTableValueType) {
+        // mark for actual deletion once tx committed
+        value.0 = true;
+    }
+
     /// Hard-removes `key` from the in-memory store, leaving no tombstone.
     ///
     /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
@@ -310,7 +312,7 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             let key_bytes = encode_key(key);
             if let Some(value) = table.get_mut(&key_bytes) {
-                mark_value_for_deletion::<T>(value);
+                Self::mark_value_for_deletion(value);
             } else {
                 // tombstone for keys that only exist in the persistent layer
                 table.insert(key_bytes, (true, Vec::new()));
@@ -324,7 +326,7 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
     fn clear_table<T: Table>(&mut self) -> eyre::Result<()> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             for value in table.values_mut() {
-                mark_value_for_deletion::<T>(value);
+                Self::mark_value_for_deletion(value);
             }
             Ok(())
         } else {
@@ -504,7 +506,7 @@ impl Database for MemDatabase {
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
-        Ok(get_with_marked_check::<T>(&self.store.read(), key))
+        self.read_txn()?.get::<T>(key)
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
@@ -517,26 +519,11 @@ impl Database for MemDatabase {
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some(value) = table.get_mut(&key_bytes) {
-                mark_value_for_deletion::<T>(value);
-            } else {
-                // tombstone for keys that only exist in the persistent layer
-                table.insert(key_bytes, (true, Vec::new()));
-            }
-        }
-        Ok(())
+        self.write_txn()?.remove::<T>(key)
     }
 
     fn clear_table<T: Table>(&self) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            //mark all for deletion
-            for value in table.values_mut() {
-                mark_value_for_deletion::<T>(value);
-            }
-        }
-        Ok(())
+        self.write_txn()?.clear_table::<T>()
     }
 
     fn is_empty<T: Table>(&self) -> bool {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -298,7 +298,7 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             let key_bytes = encode_key(key);
             let value_bytes = encode(value);
-            table.insert(key_bytes.clone(), (false, value_bytes));
+            table.insert(key_bytes, (false, value_bytes));
 
             Ok(())
         } else {
@@ -518,12 +518,7 @@ impl Database for MemDatabase {
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            let value_bytes = encode(value);
-            table.insert(key_bytes, (false, value_bytes));
-        }
-        Ok(())
+        self.write_txn_impl().insert::<T>(key, value)
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -4,7 +4,6 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
-    marker::PhantomData,
     sync::{
         mpsc::{self, SyncSender},
         Arc,
@@ -12,7 +11,6 @@ use std::{
     time::Duration,
 };
 
-use ouroboros::self_referencing;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use prometheus::{default_registry, register_int_gauge_with_registry, IntGauge, Registry};
 use rayls_infrastructure_types::{
@@ -58,13 +56,7 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((tombstoned, _)) = table.get(&key_bytes) {
-                return Ok(!*tombstoned);
-            }
-        }
-        Ok(false)
+        Ok(contains_key_impl::<T>(&self.store, key))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
@@ -140,6 +132,10 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
         //if not in cache check store
         Ok(get_with_marked_check::<T>(&self.store, key))
+    }
+
+    fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
+        Ok(contains_key_impl::<T>(&self.store, key))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
@@ -478,44 +474,6 @@ impl Database for MemDatabase {
     }
 }
 
-#[self_referencing]
-struct TabAndGuard<T>
-where
-    T: Table,
-{
-    casper: PhantomData<T>,
-    table: Arc<BTreeMap<Vec<u8>, Vec<u8>>>,
-    #[borrows(table)]
-    #[covariant]
-    guard: RwLockReadGuard<'this, BTreeMap<Vec<u8>, Vec<u8>>>,
-}
-
-#[self_referencing]
-pub struct MemDBIter<T>
-where
-    T: Table,
-{
-    casper: PhantomData<T>,
-    table: TabAndGuard<T>,
-    #[borrows(table)]
-    #[not_covariant]
-    iter: Box<dyn Iterator<Item = (&'this Vec<u8>, &'this Vec<u8>)> + 'this>,
-}
-
-impl<T: Table> Iterator for MemDBIter<T> {
-    type Item = (T::Key, T::Value);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.with_mut(|fields| {
-            fields.iter.next().map(|(key_bytes, value_bytes)| {
-                let key = decode_key(key_bytes);
-                let value = decode(value_bytes);
-                (key, value)
-            })
-        })
-    }
-}
-
 #[derive(Debug)]
 struct MemDBMetrics {
     table_counts: HashMap<&'static str, IntGauge>,
@@ -558,6 +516,16 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
         }
     }
     None
+}
+
+fn contains_key_impl<T: Table>(store: &StoreType, key: &T::Key) -> bool {
+    if let Some(table) = store.get(T::NAME) {
+        let key_bytes = encode_key(key);
+        if let Some((tombstoned, _)) = table.get(&key_bytes) {
+            return !*tombstoned;
+        }
+    }
+    false
 }
 
 fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -415,19 +415,10 @@ impl Database for MemDatabase {
     }
 
     fn is_empty<T: Table>(&self) -> bool {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            // iterate table values and see if any are not marked for deletion
-            let guard = table;
-            for (tombstoned, _) in guard.values() {
-                if !*tombstoned {
-                    return false;
-                }
-            }
-
-            true
-        } else {
-            true
-        }
+        self.store
+            .read()
+            .get(T::NAME)
+            .map_or(true, |table| table.values().all(|(tombstoned, _)| *tombstoned))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -28,8 +28,8 @@ type StoreType = HashMap<&'static str, StoreTableType>;
 fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
     if let Some(table) = store.get(T::NAME) {
         let key_bytes = encode_key(key);
-        if let Some((removed, val_bytes)) = table.get(&key_bytes) {
-            if !*removed {
+        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
+            if !*tombstoned {
                 let val = decode(val_bytes);
                 return Some(val);
             }
@@ -47,10 +47,10 @@ impl<'a> MemDbTx<'a> {
     pub fn get_no_marked_check<T: Table>(&self, key: &T::Key) -> Option<(bool, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map(|(removed, val_bytes)| {
+            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
                 let val = decode(val_bytes);
-                (*removed, val)
-            });
+                return Some((*tombstoned, val));
+            }
         }
         None
     }
@@ -59,7 +59,7 @@ impl<'a> MemDbTx<'a> {
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(removed, _)| *removed);
+            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
         }
         false
     }
@@ -84,7 +84,7 @@ impl<'a> DbTx for MemDbTx<'a> {
         if let Some(table) = self.store.get(T::NAME) {
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -100,7 +100,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             Box::new(
                 table
                     .iter()
-                    .filter(|(_, (removed, _))| !*removed)
+                    .filter(|(_, (tombstoned, _))| !*tombstoned)
                     .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
             )
         } else {
@@ -113,7 +113,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             let key_bytes = encode_key(key);
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .skip_while(|(k, _)| **k < key_bytes)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
@@ -128,7 +128,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             let items: Vec<_> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -143,7 +143,7 @@ impl<'a> DbTx for MemDbTx<'a> {
                 table
                     .iter()
                     .rev()
-                    .filter(|(_, (removed, _))| !*removed)
+                    .filter(|(_, (tombstoned, _))| !*tombstoned)
                     .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
             )
         } else {
@@ -153,8 +153,8 @@ impl<'a> DbTx for MemDbTx<'a> {
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (removed, value_bytes)) in table.iter().rev() {
-                if !*removed {
+            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
+                if !*tombstoned {
                     return Some((decode_key(key_bytes), decode(value_bytes)));
                 }
             }
@@ -170,7 +170,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             table
                 .range(..key_bytes)
                 .rev()
-                .find(|(_, (removed, _))| !*removed)
+                .find(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key(k), decode(v)))
         } else {
             None
@@ -236,7 +236,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
             let key_bytes = encode_key(key);
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .skip_while(|(k, _)| **k < key_bytes)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
@@ -251,7 +251,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
             let items: Vec<_> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -266,7 +266,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
                 table
                     .iter()
                     .rev()
-                    .filter(|(_, (removed, _))| !*removed)
+                    .filter(|(_, (tombstoned, _))| !*tombstoned)
                     .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
             )
         } else {
@@ -276,8 +276,8 @@ impl<'a> DbTx for MemDbTxMut<'a> {
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (removed, value_bytes)) in table.iter().rev() {
-                if !*removed {
+            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
+                if !*tombstoned {
                     return Some((decode_key(key_bytes), decode(value_bytes)));
                 }
             }
@@ -293,7 +293,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
             table
                 .range(..key_bytes)
                 .rev()
-                .find(|(_, (removed, _))| !*removed)
+                .find(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key(k), decode(v)))
         } else {
             None
@@ -399,24 +399,12 @@ impl MemDatabase {
 
     // gets the value with the marking for delete flag
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
-                let val = decode(val_bytes);
-                return Ok(Some((*tombstoned, val)));
-            }
-        }
-
-        Ok(None)
+        Ok(self.read_txn_impl().get_no_marked_check::<T>(key))
     }
 
     /// Check if a key is tombstoned (marked for deletion) without deserializing the value.
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
-        }
-        false
+        self.read_txn_impl().is_tombstoned::<T>(key)
     }
 
     pub fn delete_tombstoned<T: Table>(
@@ -537,8 +525,8 @@ impl Database for MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             // iterate table values and see if any are not marked for deletion
             let guard = table;
-            for (removed, _) in guard.values() {
-                if !*removed {
+            for (tombstoned, _) in guard.values() {
+                if !*tombstoned {
                     return false;
                 }
             }
@@ -553,7 +541,7 @@ impl Database for MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -568,7 +556,7 @@ impl Database for MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
                 .collect();
             Box::new(items.into_iter())
@@ -582,7 +570,7 @@ impl Database for MemDatabase {
             let key_bytes = encode_key(key);
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .skip_while(|(k, _)| **k < key_bytes)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
@@ -597,7 +585,7 @@ impl Database for MemDatabase {
             let items: Vec<_> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -611,7 +599,7 @@ impl Database for MemDatabase {
             let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
                 .collect();
             Box::new(items.into_iter())
@@ -620,33 +608,12 @@ impl Database for MemDatabase {
         }
     }
 
-    fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            table
-                .range(..key_bytes)
-                .rev()
-                .find(|(_, v)| !v.0)
-                .map(|(k, v)| (decode_key(k), decode(&v.1)))
-        } else {
-            None
-        }
+    fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
+        self.read_txn_impl().last_record::<T>()
     }
 
-    fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            //redo with reverse iter
-            for (key_bytes, marked_value_bytes) in table.iter().rev() {
-                if marked_value_bytes.0 == false {
-                    let key = decode_key(key_bytes);
-                    let value = decode(&marked_value_bytes.1);
-                    return Some((key, value));
-                }
-            }
-            None
-        } else {
-            None
-        }
+    fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
+        self.read_txn_impl().record_prior_to::<T>(key)
     }
 
     /// Execute a write operation with automatic commit/abort.

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -103,29 +103,11 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
-                if !*tombstoned {
-                    return Some((decode_key(key_bytes), decode(value_bytes)));
-                }
-            }
-            None
-        } else {
-            None
-        }
+        last_record_impl::<T>(&self.store)
     }
 
     fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            table
-                .range(..key_bytes)
-                .rev()
-                .find(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key(k), decode(v)))
-        } else {
-            None
-        }
+        record_prior_to_impl::<T>(&self.store, key)
     }
 
     fn disable_long_read_safety(&self) {}
@@ -204,29 +186,11 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
-                if !*tombstoned {
-                    return Some((decode_key(key_bytes), decode(value_bytes)));
-                }
-            }
-            None
-        } else {
-            None
-        }
+        last_record_impl::<T>(&self.store)
     }
 
     fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            table
-                .range(..key_bytes)
-                .rev()
-                .find(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key(k), decode(v)))
-        } else {
-            None
-        }
+        record_prior_to_impl::<T>(&self.store, key)
     }
 
     fn disable_long_read_safety(&self) {}
@@ -376,7 +340,7 @@ impl Drop for MemDatabase {
         // shutdown_tx is a sync sender with no buffer so this should block until the thread
         // reads it and shuts down.
         if let Err(e) = self.shutdown_tx.send(()) {
-            tracing::error!(target: "rayls::memdb", "Error while trying to send shutdown to MemDatabase metrics thread {e}"  );
+            tracing::error!(target: "rayls::memdb", "Error while trying to send shutdown to MemDatabase metrics thread {e}");
         }
     }
 }
@@ -671,6 +635,26 @@ fn reverse_raw_iter_owned_impl<T: Table>(
 ) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
     let table = store.get(T::NAME)?;
     Some(collect_raw_owned(table.iter().rev()))
+}
+
+fn last_record_impl<T: Table>(store: &StoreType) -> Option<(T::Key, T::Value)> {
+    let table = store.get(T::NAME)?;
+    for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
+        if !*tombstoned {
+            return Some((decode_key(key_bytes), decode(value_bytes)));
+        }
+    }
+    None
+}
+
+fn record_prior_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<(T::Key, T::Value)> {
+    let table = store.get(T::NAME)?;
+    let key_bytes = encode_key(key);
+    table
+        .range(..key_bytes)
+        .rev()
+        .find(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (decode_key(k), decode(v)))
 }
 
 #[cfg(test)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,6 +38,42 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
+fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    let key_bytes = encode_key(key);
+    Some(
+        table
+            .iter()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .skip_while(|(k, _)| **k < key_bytes)
+            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+            .collect(),
+    )
+}
+
+fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(
+        table
+            .iter()
+            .rev()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+            .collect(),
+    )
+}
+
+fn reverse_raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(Box::new(
+        table
+            .iter()
+            .rev()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    ))
+}
+
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
     store: RwLockReadGuard<'a, StoreType>,
@@ -109,45 +145,23 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .skip_while(|(k, _)| **k < key_bytes)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Ok(Box::new(items.into_iter()))
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
+        match skip_to_impl::<T>(&self.store, key) {
+            Some(items) => Ok(Box::new(items.into_iter())),
+            None => Err(eyre::eyre!("Invalid table {}", T::NAME)),
         }
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_iter_impl::<T>(&self.store) {
+            Some(items) => Box::new(items.into_iter()),
+            None => Box::new(std::iter::empty()),
         }
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.get(T::NAME) {
-            Box::new(
-                table
-                    .iter()
-                    .rev()
-                    .filter(|(_, (tombstoned, _))| !*tombstoned)
-                    .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-            )
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_raw_iter_impl::<T>(&self.store) {
+            Some(iter) => iter,
+            None => Box::new(std::iter::empty()),
         }
     }
 
@@ -232,45 +246,23 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .skip_while(|(k, _)| **k < key_bytes)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Ok(Box::new(items.into_iter()))
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
+        match skip_to_impl::<T>(&self.store, key) {
+            Some(items) => Ok(Box::new(items.into_iter())),
+            None => Err(eyre::eyre!("Invalid table {}", T::NAME)),
         }
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_iter_impl::<T>(&self.store) {
+            Some(items) => Box::new(items.into_iter()),
+            None => Box::new(std::iter::empty()),
         }
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.get(T::NAME) {
-            Box::new(
-                table
-                    .iter()
-                    .rev()
-                    .filter(|(_, (tombstoned, _))| !*tombstoned)
-                    .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-            )
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_raw_iter_impl::<T>(&self.store) {
+            Some(iter) => iter,
+            None => Box::new(std::iter::empty()),
         }
     }
 
@@ -566,31 +558,16 @@ impl Database for MemDatabase {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .skip_while(|(k, _)| **k < key_bytes)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Ok(Box::new(items.into_iter()))
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
+        match skip_to_impl::<T>(&self.store.read(), key) {
+            Some(items) => Ok(Box::new(items.into_iter())),
+            None => Err(eyre::eyre!("Invalid table {}", T::NAME)),
         }
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match reverse_iter_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -354,9 +354,9 @@ impl MemDatabase {
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
         if let Some(table) = self.store.read().get(T::NAME) {
             let key_bytes = encode_key(key);
-            if let Some((removed, val_bytes)) = table.get(&key_bytes) {
+            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
                 let val = decode(val_bytes);
-                return Ok(Some((*removed, val)));
+                return Ok(Some((*tombstoned, val)));
             }
         }
 
@@ -367,21 +367,22 @@ impl MemDatabase {
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
         if let Some(table) = self.store.read().get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(removed, _)| *removed);
+            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
         }
         false
     }
 
-    pub fn delete_removed<T: Table>(&self, key: &T::Key, require_marked: bool) -> eyre::Result<()> {
+    pub fn delete_tombstoned<T: Table>(
+        &self,
+        key: &T::Key,
+        require_marked: bool,
+    ) -> eyre::Result<()> {
         if let Some(table) = self.store.write().get_mut(T::NAME) {
             let key_bytes = encode_key(key);
-            if let Some((removed, _)) = table.get(&key_bytes) {
-                if !*removed && require_marked {
-                    // Value was re-inserted after the remove was queued — keep it.
-                    return Ok(());
+            if let Some((tombstoned, _)) = table.get(&key_bytes) {
+                if *tombstoned || !require_marked {
+                    table.remove(&key_bytes);
                 }
-
-                table.remove(&key_bytes);
             }
         }
         Ok(())
@@ -390,7 +391,11 @@ impl MemDatabase {
     /// Returns keys marked for deletion in the given table.
     pub fn get_deleted_keys<T: Table>(&self) -> std::collections::HashSet<Vec<u8>> {
         if let Some(table) = self.store.read().get(T::NAME) {
-            table.iter().filter(|(_, (removed, _))| *removed).map(|(k, _)| k.clone()).collect()
+            table
+                .iter()
+                .filter(|(_, (tombstoned, _))| *tombstoned)
+                .map(|(k, _)| k.clone())
+                .collect()
         } else {
             std::collections::HashSet::new()
         }

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -25,64 +25,6 @@ type StoreTableValueType = (bool, Vec<u8>);
 type StoreTableType = BTreeMap<Vec<u8>, StoreTableValueType>;
 type StoreType = HashMap<&'static str, StoreTableType>;
 
-fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
-    if let Some(table) = store.get(T::NAME) {
-        let key_bytes = encode_key(key);
-        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
-            if !*tombstoned {
-                let val = decode(val_bytes);
-                return Some(val);
-            }
-        }
-    }
-    None
-}
-
-fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
-where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
-{
-    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-        .collect()
-}
-
-fn collect_raw<'t, I>(iter: I) -> DBRawIter<'t>
-where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
-{
-    Box::new(
-        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-    )
-}
-
-fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_typed::<T, _>(table.iter()))
-}
-
-fn raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_raw(table.iter()))
-}
-
-fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
-    let table = store.get(T::NAME)?;
-    let key_bytes = encode_key(key);
-    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
-}
-
-fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_typed::<T, _>(table.iter().rev()))
-}
-
-fn reverse_raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_raw(table.iter().rev()))
-}
-
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
     store: RwLockReadGuard<'a, StoreType>,
@@ -133,7 +75,7 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        match raw_iter_impl::<T>(&self.store) {
+        match raw_iter_borrowed_impl::<T>(&self.store) {
             Some(iter) => iter,
             None => Box::new(std::iter::empty()),
         }
@@ -154,7 +96,7 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        match reverse_raw_iter_impl::<T>(&self.store) {
+        match reverse_raw_iter_borrowed_impl::<T>(&self.store) {
             Some(iter) => iter,
             None => Box::new(std::iter::empty()),
         }
@@ -255,7 +197,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        match reverse_raw_iter_impl::<T>(&self.store) {
+        match reverse_raw_iter_borrowed_impl::<T>(&self.store) {
             Some(iter) => iter,
             None => Box::new(std::iter::empty()),
         }
@@ -534,15 +476,9 @@ impl Database for MemDatabase {
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
         // The guard is a temporary here (not held by `self`), so the bytes must
         // be owned rather than borrowed for the iterator's lifetime.
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match raw_iter_owned_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 
@@ -561,16 +497,9 @@ impl Database for MemDatabase {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match reverse_raw_iter_owned_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 
@@ -661,6 +590,87 @@ impl Default for MemDBMetrics {
             }
         }
     }
+}
+
+fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
+    if let Some(table) = store.get(T::NAME) {
+        let key_bytes = encode_key(key);
+        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
+            if !*tombstoned {
+                let val = decode(val_bytes);
+                return Some(val);
+            }
+        }
+    }
+    None
+}
+
+fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+{
+    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+        .collect()
+}
+
+fn collect_raw_borrowed<'t, I>(iter: I) -> DBRawIter<'t>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
+{
+    Box::new(
+        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    )
+}
+
+fn collect_raw_owned<'t, I>(iter: I) -> Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+{
+    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
+        .collect()
+}
+
+fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_typed::<T, _>(table.iter()))
+}
+
+fn raw_iter_borrowed_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_borrowed(table.iter()))
+}
+
+fn raw_iter_owned_impl<T: Table>(
+    store: &StoreType,
+) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_owned(table.iter()))
+}
+
+fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    let key_bytes = encode_key(key);
+    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
+}
+
+fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_typed::<T, _>(table.iter().rev()))
+}
+
+fn reverse_raw_iter_borrowed_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_borrowed(table.iter().rev()))
+}
+
+fn reverse_raw_iter_owned_impl<T: Table>(
+    store: &StoreType,
+) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_owned(table.iter().rev()))
 }
 
 #[cfg(test)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,61 +38,49 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
+fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+{
+    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+        .collect()
+}
+
+fn collect_raw<'t, I>(iter: I) -> DBRawIter<'t>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
+{
+    Box::new(
+        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    )
+}
+
 fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
-    Some(
-        table
-            .iter()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-            .collect(),
-    )
+    Some(collect_typed::<T, _>(table.iter()))
 }
 
 fn raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
     let table = store.get(T::NAME)?;
-    Some(Box::new(
-        table
-            .iter()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-    ))
+    Some(collect_raw(table.iter()))
 }
 
 fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
     let key_bytes = encode_key(key);
-    Some(
-        table
-            .iter()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .skip_while(|(k, _)| **k < key_bytes)
-            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-            .collect(),
-    )
+    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
 }
 
 fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
-    Some(
-        table
-            .iter()
-            .rev()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-            .collect(),
-    )
+    Some(collect_typed::<T, _>(table.iter().rev()))
 }
 
 fn reverse_raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
     let table = store.get(T::NAME)?;
-    Some(Box::new(
-        table
-            .iter()
-            .rev()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-    ))
+    Some(collect_raw(table.iter().rev()))
 }
 
 #[derive(Debug)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -180,6 +180,19 @@ pub struct MemDbTxMut<'a> {
     store: RwLockWriteGuard<'a, StoreType>,
 }
 
+impl<'a> MemDbTxMut<'a> {
+    /// Hard-removes `key` from the in-memory store, leaving no tombstone.
+    ///
+    /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
+    /// dropped outright rather than tombstoned: this frees the cache and lets reads fall through to
+    /// a lower tier, whereas a tombstone would shadow it and never be reclaimed.
+    pub fn hard_delete<T: Table>(&mut self, key: &T::Key) {
+        if let Some(table) = self.store.get_mut(T::NAME) {
+            table.remove(&encode_key(key));
+        }
+    }
+}
+
 impl<'a> DbTx for MemDbTxMut<'a> {
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
         //if not in cache check store
@@ -325,19 +338,6 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
     }
 }
 
-impl<'a> MemDbTxMut<'a> {
-    /// Hard-removes `key` from the in-memory store, leaving no tombstone.
-    ///
-    /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
-    /// dropped outright rather than tombstoned: this frees the cache and lets reads fall through to
-    /// a lower tier, whereas a tombstone would shadow it and never be reclaimed.
-    pub fn hard_delete<T: Table>(&mut self, key: &T::Key) {
-        if let Some(table) = self.store.get_mut(T::NAME) {
-            table.remove(&encode_key(key));
-        }
-    }
-}
-
 /// Implement the Database trait with an in-memory store.
 /// This means no persistance.
 /// This DB also plays loose with transactions, but since it is in-memory and we do not do
@@ -350,6 +350,33 @@ pub struct MemDatabase {
 }
 
 impl MemDatabase {
+    pub fn new() -> Self {
+        let store: Arc<RwLock<StoreType>> = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(RwLock::new(MemDBMetrics::default()));
+        let (shutdown_tx, rx) = mpsc::sync_channel::<()>(0);
+
+        let store_cloned: Arc<RwLock<StoreType>> = Arc::clone(&store);
+        let metrics_cloned = metrics.clone();
+
+        // Spawn thread to update metrics from MemDB stats every 30 seconds.
+        std::thread::spawn(move || {
+            tracing::info!(target: "rayls::memdb", "Starting MemDB metrics thread");
+            while let Err(mpsc::RecvTimeoutError::Timeout) =
+                rx.recv_timeout(Duration::from_secs(30))
+            {
+                let read_guard = store_cloned.read();
+                for (key, table) in read_guard.iter() {
+                    if let Some(m) = metrics_cloned.read().table_counts.get(key) {
+                        m.set(table.len().try_into().unwrap_or(-1));
+                    }
+                }
+            }
+            tracing::info!(target: "rayls::memdb", "Ending MemDB metrics thread");
+        });
+
+        Self { store, metrics, shutdown_tx: Arc::new(shutdown_tx) }
+    }
+
     // gets the value with the marking for delete flag
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
         if let Some(table) = self.store.read().get(T::NAME) {
@@ -404,44 +431,16 @@ impl MemDatabase {
 
 impl Drop for MemDatabase {
     fn drop(&mut self) {
-        if Arc::strong_count(&self.shutdown_tx) <= 1 {
-            tracing::info!(target: "rayls::memdb", "MemDatabase Dropping, shutting down metrics thread");
-            // shutdown_tx is a sync sender with no buffer so this should block until the thread
-            // reads it and shuts down.
-            if let Err(e) = self.shutdown_tx.send(()) {
-                tracing::error!(target: "rayls::memdb",
-                    "Error while trying to send shutdown to MemDatabase metrics thread {e}"
-                );
-            }
+        if Arc::strong_count(&self.shutdown_tx) > 1 {
+            return;
         }
-    }
-}
 
-impl MemDatabase {
-    pub fn new() -> Self {
-        let store: Arc<RwLock<StoreType>> = Arc::new(RwLock::new(HashMap::new()));
-        let metrics = Arc::new(RwLock::new(MemDBMetrics::default()));
-        let (shutdown_tx, rx) = mpsc::sync_channel::<()>(0);
-
-        let store_cloned: Arc<RwLock<StoreType>> = Arc::clone(&store);
-        let metrics_cloned = metrics.clone();
-        // Spawn thread to update metrics from MemDB stats every 30 seconds.
-        std::thread::spawn(move || {
-            tracing::info!(target: "rayls::memdb", "Starting MemDB metrics thread");
-            while let Err(mpsc::RecvTimeoutError::Timeout) =
-                rx.recv_timeout(Duration::from_secs(30))
-            {
-                let read_guard = store_cloned.read();
-                for (key, table) in read_guard.iter() {
-                    if let Some(m) = metrics_cloned.read().table_counts.get(key) {
-                        m.set(table.len().try_into().unwrap_or(-1));
-                    }
-                }
-            }
-            tracing::info!(target: "rayls::memdb", "Ending MemDB metrics thread");
-        });
-
-        Self { store, metrics, shutdown_tx: Arc::new(shutdown_tx) }
+        tracing::info!(target: "rayls::memdb", "MemDatabase Dropping, shutting down metrics thread");
+        // shutdown_tx is a sync sender with no buffer so this should block until the thread
+        // reads it and shuts down.
+        if let Err(e) = self.shutdown_tx.send(()) {
+            tracing::error!(target: "rayls::memdb", "Error while trying to send shutdown to MemDatabase metrics thread {e}"  );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Delegate `MemDatabase` read/write operations (`get`, `contains_key`, `insert`, `remove`, `clear_table`, `get_marked`, `is_tombstoned`, `last_record`, `record_prior_to`) to the tx types via infallible `read_txn_impl`/`write_txn_impl`, removing ~60 lines of duplicated store access.
- Extract shared iterator logic into private `collect_*` / `*_impl` helpers over `&StoreType`, deduplicating `iter`, `raw_iter`, `reverse_iter`, `reverse_raw_iter`, and `skip_to` across `MemDbTx`, `MemDbTxMut`, and `MemDatabase` (net −59 lines). Raw iterators keep the Borrowed (tx, guard held) vs Owned (`MemDatabase`, temporary guard) split.
- Rename tombstone terminology: `removed` flag → `tombstoned`, `delete_removed` → `delete_tombstoned` (incl. the layered_db call site).
- Behavior alignment: `MemDatabase::insert` on a missing table now returns `Err("Invalid table …")` instead of silently succeeding — consistent with `MemDbTxMut` and the ReDB backend.
- No external behavior change otherwise; per-class missing-table semantics (empty vs panic) preserved.

## Surface areas touched

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None — internal refactor of the in-memory (test) storage backend only; no node restart, network upgrade, or coordination required.

## Test plan

- [x] `cargo check -p rayls-infrastructure-storage` — clean
- [x] `cargo test -p rayls-infrastructure-storage --lib` — 137 passed, 0 failed (includes all 15 mem_db tests)
- [x] `cargo clippy -p rayls-infrastructure-storage` — no new warnings (pre-existing `map_or` / `type_complexity` only)
- [ ] `cargo fmt --check` (CI gate — run before pushing)
