### PR TITLE
fix(consensus): skip re-certifying an already-certified header

### DIFF
--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -732,6 +732,9 @@ impl<DB: Database> Certifier<DB> {
                 Some(header) = rx_headers.recv() => {
                     let digest = header.digest();
                     let round = header.round();
+                    // Rounds restart every epoch, so a round number alone does not identify a
+                    // proposal in a log. Both dedup paths and the store-error path carry it.
+                    let epoch = header.epoch();
 
                     debug!(target: "primary::certifier", ?header, "{:?} received header!", &self.authority_id);
 
@@ -739,8 +742,74 @@ impl<DB: Database> Certifier<DB> {
                         if *d == digest && !h.is_finished() {
                             debug!(
                                 target: "primary::certifier",
-                                ?digest, round,
+                                ?digest, round, epoch,
                                 "re-propose dedup: in-flight proposal for same digest, skipping",
+                            );
+                            continue;
+                        }
+                    }
+
+                    // The guard above only covers a *running* attempt. An attempt that finished
+                    // successfully leaves `is_finished() == true`, and the proposer keeps
+                    // re-proposing until it observes its own certificate come back round - a
+                    // window that is milliseconds normally but seconds wide under load. Falling
+                    // through there mints a second certificate for the same header from whatever
+                    // quorum answers this time: same digest, different signer set, different
+                    // aggregate signature.
+                    //
+                    // Consensus cannot tell the two apart (`Certificate::digest()` is the header
+                    // digest) and receivers silently drop whichever arrives second, so nodes end
+                    // up holding different bytes for the same certificate. Harmless in the DAG,
+                    // but the epoch-closing block hashes that signature into `extra_data`, so the
+                    // two nodes seal different block hashes and the chain forks with consensus
+                    // none the wiser - see 2026-08-16, where a ~10s execution stall held round 408
+                    // uncertified until both attempts completed within the same flurry.
+                    //
+                    // LOAD-BEARING ORDERING, not visible from this file: the store lookup is only
+                    // a sufficient guard because a finished task is guaranteed to have already
+                    // written its certificate. `spawn_header_proposal` awaits
+                    // `process_own_certificate`, which awaits the certificate manager's reply
+                    // before returning, so the task cannot report `is_finished()` until the write
+                    // has landed. If that await is ever removed, batched, or the own-certificate
+                    // path starts going through `try_accept_certificate`'s pending branch (which
+                    // returns without storing), this check silently stops covering the window and
+                    // duplicate certificates become possible again.
+                    let cert_digest = CertificateDigest::new(digest.into());
+                    match self.certificate_store.contains(&cert_digest) {
+                        // `info!`, unlike the in-flight case above: reaching here means a
+                        // re-propose arrived for a header that had already certified, which is
+                        // exactly the condition that used to mint a second certificate. It is
+                        // worth seeing without enabling debug, and it is not extra noise - the
+                        // proposer already emits a `warn!` for every re-propose, so this only
+                        // ever appears alongside a louder line for the same event. A rising rate
+                        // here is itself the signal that certification is racing the proposer.
+                        Ok(true) => {
+                            info!(
+                                target: "primary::certifier",
+                                ?digest, round, epoch,
+                                "re-propose dedup: header already certified, skipping",
+                            );
+                            continue;
+                        }
+                        Ok(false) => {}
+                        // Fail closed. The lookup is the only thing standing between a finished
+                        // attempt and a second certificate for the same header, so re-certifying
+                        // when we cannot answer "did this already certify?" reintroduces exactly
+                        // the fork this guard exists to prevent - and a fork is silent, survives
+                        // restarts, and killed a validator for 20 hours the one time it happened.
+                        //
+                        // The cost is real and deliberate: this skips *all* proposals while the
+                        // error persists, not just re-proposals, so a node with a broken
+                        // certificate store stops contributing certificates entirely. That is
+                        // the safer failure - a stalled node is visible in this log line and
+                        // recoverable by restarting it, whereas a forked node looks healthy until
+                        // an epoch boundary and then cannot rejoin at all.
+                        Err(e) => {
+                            error!(
+                                target: "primary::certifier",
+                                auth=?self.authority_id,
+                                ?digest, round, epoch,
+                                "certificate store lookup failed, refusing to certify: {e}",
                             );
                             continue;
                         }
@@ -758,6 +827,7 @@ impl<DB: Database> Certifier<DB> {
                         auth = ?self.authority_id,
                         ?digest,
                         round,
+                        epoch,
                         "spawning proposal task"
                     );
 

--- a/crates/consensus/primary/src/tests/certifier_tests.rs
+++ b/crates/consensus/primary/src/tests/certifier_tests.rs
@@ -355,3 +355,194 @@ async fn propose_headers_one_bad() {
         SignatureVerificationState::VerifiedDirectly(_)
     ));
 }
+
+/// Re-proposing a header that already has a certificate must not certify it again.
+///
+/// The proposer re-sends its last header whenever the max-delay timer fires and it has not yet
+/// observed its own certificate come back round. Under load that window is seconds wide - on
+/// 2026-08-16 a ~10s execution stall held a round uncertified until two certification attempts
+/// completed in the same flurry. A second attempt aggregates whatever quorum answers that time,
+/// producing a certificate with the same digest (it is just the header digest) but a different
+/// signer set and so a different aggregate signature. Consensus cannot distinguish them and
+/// receivers silently drop the later arrival, so nodes end up holding different bytes for the
+/// same certificate - which forks the chain at an epoch close, where that signature is hashed
+/// into the block's `extra_data`.
+///
+/// The in-flight guard does not cover this: an attempt that finished *successfully* reports
+/// `is_finished() == true` and falls through it. This asserts the certificate-store guard behind
+/// it, so the test must be given time for the first task to actually finish - otherwise it would
+/// pass on the in-flight guard instead and prove nothing.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn does_not_recertify_an_already_certified_header() {
+    let fixture = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().last().unwrap();
+    let id = primary.id();
+
+    let proposed_header = primary.header(&committee);
+    let proposed_digest = proposed_header.digest();
+
+    let (sender, mut network_rx) = mpsc::channel(100);
+    let network: NetworkHandle<PrimaryRequest, PrimaryResponse> = NetworkHandle::new(sender);
+
+    let mut peer_votes = HashMap::new();
+    for peer in fixture.authorities().filter(|a| a.id() != id) {
+        let name = peer.authority().protocol_key();
+        let peer_id = peer.authority().id();
+        let vote = Vote::new(&proposed_header, peer_id, peer.consensus_config().key_config());
+        peer_votes.insert(name, vote);
+    }
+
+    let cb = ConsensusBus::new();
+    let mut rx_new_certificates = cb.new_certificates().subscribe();
+    let task_manager = TaskManager::default();
+    let synchronizer =
+        StateSynchronizer::new(primary.consensus_config(), cb.clone(), task_manager.get_spawner());
+    synchronizer.spawn(&task_manager);
+    Certifier::spawn(
+        primary.consensus_config(),
+        cb.clone(),
+        synchronizer,
+        network.clone().into(),
+        &task_manager,
+    );
+
+    // First attempt: certify the header normally.
+    cb.headers().send(proposed_header.clone()).await.unwrap();
+    while let Some(req) = network_rx.recv().await {
+        if let NetworkCommand::SendRequest {
+            peer,
+            request: PrimaryRequest::Vote { header: _, parents: _ },
+            reply,
+        } = req
+        {
+            if let Some(vote) = peer_votes.remove(&peer) {
+                reply.send(Ok(PrimaryResponse::Vote(vote))).unwrap();
+            }
+        }
+        if peer_votes.is_empty() {
+            break;
+        }
+    }
+
+    let certificate = tokio::time::timeout(Duration::from_secs(10), rx_new_certificates.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(certificate.header().digest(), proposed_digest);
+
+    // The first proposal task has stored the certificate but is now blocked publishing it, and it
+    // does not finish until that reply lands. That matters: while it is unfinished the *in-flight*
+    // guard would swallow the re-propose and this test would pass without exercising the store
+    // guard at all. Answer the publish so the task actually completes.
+    //
+    // `spawn_header_proposal` skips gossip entirely under `dev-single-node-setup` (no peers to
+    // publish to), so there is nothing to answer and the task finishes without blocking. Waiting
+    // unconditionally would hang that build.
+    #[cfg(not(feature = "dev-single-node-setup"))]
+    {
+        let published = tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(req) = network_rx.recv().await {
+                if let NetworkCommand::Publish { reply, .. } = req {
+                    let _ = reply.send(Ok(rayls_consensus_network::types::MessageId::new(b"test")));
+                    return true;
+                }
+            }
+            false
+        })
+        .await
+        .unwrap_or(false);
+        assert!(published, "certifier never published the certificate, so its task cannot finish");
+    }
+
+    // Let the task unwind now that publish has returned. `start_paused` makes this exact rather
+    // than hopeful: tokio only auto-advances the clock once every task is blocked on time, so
+    // this sleep cannot return while the proposal task is still runnable. A wall-clock sleep
+    // would be a guess, and guessing too short is invisible - the re-propose would be swallowed
+    // by the in-flight guard and the test would pass while asserting nothing.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Re-propose the identical header, exactly as the proposer's max-delay timer would.
+    cb.headers().send(proposed_header).await.unwrap();
+
+    // Nothing may ask for votes on it again. Non-Vote traffic (certificate gossip from the first
+    // attempt) is expected and ignored.
+    let deadline = Duration::from_millis(750);
+    let recertified = tokio::time::timeout(deadline, async {
+        while let Some(req) = network_rx.recv().await {
+            if let NetworkCommand::SendRequest {
+                request: PrimaryRequest::Vote { header, parents: _ },
+                ..
+            } = req
+            {
+                if header.digest() == proposed_digest {
+                    return true;
+                }
+            }
+        }
+        false
+    })
+    .await
+    .unwrap_or(false);
+
+    assert!(
+        !recertified,
+        "certifier re-requested votes for an already-certified header - a second certificate \
+         with a different signer set can now exist for digest {proposed_digest:?}",
+    );
+
+    // And no second certificate reached the bus.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), rx_new_certificates.recv()).await.is_err(),
+        "a second certificate was produced for the same header",
+    );
+}
+
+/// Pins the ordering the re-propose guard depends on.
+///
+/// `does_not_recertify_an_already_certified_header` asserts the *effect* - no second vote request
+/// - but the guard is only a sufficient check because a finished proposal task has necessarily
+/// stored its certificate. That holds because `spawn_header_proposal` awaits
+/// `process_own_certificate`, which awaits the certificate manager's reply before returning.
+/// Nothing in the type system enforces it: if that await is ever removed or batched, the guard
+/// silently stops covering the window and duplicate certificates become possible again, with no
+/// test failing. This is the assertion that would fail instead.
+#[tokio::test(flavor = "current_thread")]
+async fn process_own_certificate_stores_before_returning() {
+    use rayls_infrastructure_storage::CertificateStore;
+    use rayls_infrastructure_types::Hash as _;
+
+    let fixture = CommitteeFixture::builder(MemDatabase::default).randomize_ports(true).build();
+    let committee = fixture.committee();
+    let primary = fixture.authorities().last().unwrap();
+    let config = primary.consensus_config();
+
+    let cb = ConsensusBus::new();
+    let task_manager = TaskManager::default();
+    let synchronizer =
+        StateSynchronizer::new(config.clone(), cb.clone(), task_manager.get_spawner());
+    synchronizer.spawn(&task_manager);
+
+    // Mirror what the certifier does to its own certificate before handing it over: the
+    // aggregator marks it VerifiedDirectly (votes.rs), and the manager rejects anything still
+    // Unverified coming in on the own-certificate path.
+    let mut certificate = fixture.certificate(&primary.header(&committee));
+    let signature = certificate.aggregated_signature().expect("fixture cert is signed");
+    certificate
+        .set_signature_verification_state(SignatureVerificationState::VerifiedDirectly(signature));
+    let digest = certificate.digest();
+
+    assert!(
+        !config.node_storage().contains(&digest).unwrap(),
+        "precondition: the certificate must not already be stored",
+    );
+
+    synchronizer.process_own_certificate(certificate).await.unwrap();
+
+    assert!(
+        config.node_storage().contains(&digest).unwrap(),
+        "process_own_certificate returned before storing the certificate - the certifier's \
+         re-propose guard reads this store to decide whether a header is already certified, so \
+         it no longer covers the window between an attempt finishing and its certificate landing",
+    );
+}

--- a/crates/infrastructure/types/src/primary/output.rs
+++ b/crates/infrastructure/types/src/primary/output.rs
@@ -17,7 +17,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::mpsc;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 /// A global sequence number assigned to every CommittedSubDag.
 pub type SequenceNumber = u64;
@@ -142,11 +142,32 @@ impl ConsensusOutput {
     /// NOTE: this cannot fail - uses [BlsSignature::default] and is considered acceptable with
     /// permissioned validator set, but should never happen.
     pub fn keccak_leader_sigs(&self) -> B256 {
-        let randomness = self.leader().aggregated_signature().unwrap_or_else(|| {
+        let leader = self.leader();
+        let randomness = leader.aggregated_signature().unwrap_or_else(|| {
             error!(target: "engine", ?self, "BLS signature missing for leader - using default for closing epoch");
             BlsSignature::default()
         });
-        keccak256(randomness.to_bytes())
+        let randomness = keccak256(randomness.to_bytes());
+
+        // The aggregate signature is NOT part of the consensus commitment
+        // (`CommittedSubDag::digest` hashes certificate digests only), so two nodes can hold
+        // different certificates for the same leader header and stamp different `extra_data`
+        // into the epoch-closing block - a fork that consensus cannot see. Log the signer set
+        // that produced this value so a divergence can be attributed directly instead of being
+        // inferred from block hashes after the fact. Once per epoch close.
+        info!(
+            target: "engine",
+            epoch = leader.epoch(),
+            round = leader.round(),
+            leader = %leader.origin(),
+            header_digest = ?leader.digest(),
+            signer_count = leader.signed_authorities().len(),
+            signers = ?leader.signed_authorities().iter().collect::<Vec<_>>(),
+            ?randomness,
+            "epoch-close randomness derived from leader certificate",
+        );
+
+        randomness
     }
 }
 

--- a/crates/middleware/processor/src/execution/orchestrator.rs
+++ b/crates/middleware/processor/src/execution/orchestrator.rs
@@ -254,6 +254,14 @@ impl<DB: Database> Processor<DB> {
             output_number = output.number,
             output_ms = %output_elapsed.as_millis(),
             head = canonical_header.number,
+            // Which authority's certificate Bullshark picked as leader for this commit. Every
+            // validator logs `spawning proposal task` for its *own* header each round, so those
+            // lines cannot identify the leader - it is only decided here, at commit. Without
+            // this, attributing a commit to an authority means reading the certificate out of
+            // the node database after the fact.
+            leader = %output.leader().origin(),
+            leader_round = output.leader_round(),
+            epoch,
             "output executed"
         );
 


### PR DESCRIPTION
**The problem**

The local network forked on 2026-08-16. validator-3 diverged on the epoch-1323 close block
282993 — `0x70f8efc5…` on val1/2/4, `0x02ec3e82…` on val3 — with identical parent, batches,
`txs: 0`, reward tally and consensus header (`0xc0b04872…`, `reached=true` on all four). It never
recovered: the epoch record embeds that block hash, so val3 computed record `0xca0feeb4…` while
the others certified `0x674bc4ed…`, and every later record chained off a parent it could not
reproduce. Losing val3 took the committee from 5 to exactly quorum; when the fifth node went down
12 minutes later the chain halted for 20 hours.

Confirmed from the node databases. The `Certificates` table is cleared at each epoch boundary,
but `ConsensusBlocks` is the complete historic record and embeds the full subdag:

    validator-1  signers [0,2,3,4]  keccak(agg sig) 0x7efb96c4…
    validator-2  signers [0,2,3,4]  keccak(agg sig) 0x7efb96c4…
    validator-3  signers [0,1,2,3]  keccak(agg sig) 0xf0443d2a…
    validator-4  signers [0,2,3,4]  keccak(agg sig) 0x7efb96c4…

    all four: leader E4zSTX… round=408 epoch=1323
              leader digest EuKUk3bdV…  consensus header 0xc0b04872…

Committee indices sort by BLS key (0=validator-1, 1=validator-4, 2=validator-3, 3=validator-2,
4=the relayed node), so the two certificates differ by exactly one voter.

**How the diagnosis evolved**

The first reading was that the epoch-closing block derives `extra_data` from
`keccak256(leader_cert.aggregated_signature())`, and that signature is deliberately excluded from
the consensus commitment — `CommittedSubDag::digest()` hashes certificate *digests* only, and a
certificate digest is just its header digest. Two nodes holding different certificates therefore
agree on the consensus header and still seal different block hashes. The first version of this PR
changed that derivation behind a hardfork.

Review pushed back with the right question: **why did the leader certify the same header twice?**
Chasing that turned the randomness change into a symptom fix. It makes duplicate certificates
harmless; it does not stop them being created.

What actually happened: every node spent ~10.6s executing consensus output 252164
(`output_ms=10621/11299/10578/10677`). Round 408's first certification attempt could not reach
quorum inside that freeze, so the proposer's 1s max-delay timer re-proposed. The existing dedup
guard keys on `AbortHandle::is_finished()` — "is the attempt over?" — which cannot distinguish a
task that *succeeded* from one that died. When the stall cleared, both attempts completed in the
same flurry (no node could propose round 409 until 15.42–15.94, confirming 408 was uncertified
until then) and both certificates were gossiped a fraction of a second apart. Receivers keep
whichever lands first and drop the other silently, so validator-3 ended up on the opposite side
of that race.

**What's changed**

- The certifier checks the certificate store before re-certifying, answering the question the
  abort handle cannot: not "is the attempt over?" but "did it produce a certificate?"
- Correctness rests on an ordering spanning three modules — a proposal task cannot report
  `is_finished()` until `process_own_certificate` has awaited the certificate manager's reply, so
  a finished task has necessarily stored its certificate. Recorded at the check, since it is
  invisible from `certifier.rs`.
- A failed store lookup fails closed. Re-certifying when we cannot answer "did this already
  certify?" reintroduces the fork. The cost is deliberate: it skips all proposals while the error
  persists, so a node with a broken certificate store stops contributing — a stalled node is
  visible in the log and restarts fine, a forked node looks healthy until an epoch boundary and
  then cannot rejoin at all.
- Regression test, verified to fail without the guard. Runs on a paused clock, so the wait for
  the first task to finish is exact rather than hopeful — tokio only advances time once every
  task is blocked, so it cannot return while the proposal task is still runnable. Answering the
  certificate publish in the mock network is load-bearing too: without it the first task never
  finishes and the in-flight guard swallows the re-propose, so the test would pass while
  asserting nothing.
- The ordering itself has a test: `process_own_certificate_stores_before_returning` asserts the
  certificate is in the store the moment that call returns. If that await is ever removed or
  batched, this assertion fails rather than a chain forking 1300 epochs later.
- The already-certified skip logs at `info!` while the in-flight skip stays at `debug!`. The
  former only fires when a duplicate certificate was actually prevented, and the proposer already
  warns on every re-propose, so it adds no noise floor. A rising rate there is itself the signal
  that certification is racing the proposer.
- The leader, header digest and signer bitmap are logged once per epoch close, so a divergence of
  this kind is attributable from logs rather than a forensic read of the node databases.

**What this deliberately does not address**

The executed block still depends on which valid certificate a node holds. Excluding signatures
from the commitment is intentional — any quorum is a valid proof of the same header, and that
interchangeability is what keeps the DAG consistent when nodes hold different copies. But it has
two consequences worth weighing:

1. The epoch-close block hash depends on a value consensus never agreed on. This PR closes the
   known path to producing two certificates, but it is a check rather than an invariant:
   `try_accept_certificate`'s pending branch returns without storing, and the ordering the check
   relies on is pinned by a test but not by any type.
2. Because the signer set is not committed, the chain keeps no accountable record of who actually
   signed a header. Anything that later wants attribution — slashing, participation-based rewards,
   fraud proofs — cannot assume the certificate it holds matches what other nodes hold.

Deriving the randomness from the consensus header digest instead was implemented and then dropped
from this PR. It would make signer variance harmless by construction rather than by check, but it
is a hardfork and therefore a separate decision.

**Follow-ups (not in this PR)**

- A diverged node retries an impossible catch-up indefinitely instead of rolling back to the last
  certified epoch record. Recovery must be *loud* — a distinct error, a metric, ideally a
  persisted fork report — not a silent self-heal, which would have hidden this bug entirely.
- `cert_validator` drops a duplicate certificate with only a `trace!`, without comparing
  signatures. Warning on a mismatch would surface this class immediately. Needs care on the hot
  path: the current check is a key lookup, and comparing signatures naively adds a BCS decode per
  duplicate.
- A node that lacks a certified previous-epoch record cannot restart: `request_epoch_cert` fires
  three attempts into an empty peer set (it selects from already-connected peers and never dials)
  and the failure is fatal. This is what made the fifth node unbootable.
- One consensus output taking 10.6s to execute is what opened this window and is untouched here.
  The same period shows 24,192 orphan transactions being reintroduced and batches stuck at
  `Sealed` for 288s.
