### PR TITLE
fix(consensus): keep LastProposed across mode transitions to stop same-round equivocation

### DIFF
--- a/crates/consensus/primary/src/proposer/run_loop.rs
+++ b/crates/consensus/primary/src/proposer/run_loop.rs
@@ -212,7 +212,11 @@ impl<DB: Database> Proposer<DB> {
             // the re-propose path. Epoch/round staleness of `last_proposed` IS guarded, inside the
             // re-propose block below (see `last_proposed_is_stale`). A stale header can't fork
             // regardless — the certifier rejects any header whose epoch != committee.epoch(), and
-            // `run_mode_transition` clears `LastProposed` (so repropose is a no-op there). The old
+            // re-proposing across a mode transition is *why* `run_mode_transition` deliberately
+            // preserves `LastProposed`: the header we re-send is byte-identical to the one peers
+            // already saw, so they replay their cached vote instead of scoring it as equivocation.
+            // (Rebuilding one instead would embed a newer exec anchor, changing the digest at an
+            // already-proposed round — the livelock this store entry exists to prevent.) The old
             // `is_transitioning()` check was racy (TOCTOU) and thus never a correctness guarantee.
             let should_repropose_header = !should_create_header && max_delay_timed_out;
 

--- a/crates/middleware/orchestrator/src/epoch_manager/transition.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/transition.rs
@@ -7,10 +7,7 @@ use crate::{
 use eyre::eyre;
 use rayls_consensus_primary::NodeMode;
 use rayls_infrastructure_config::RaylsDirs;
-use rayls_infrastructure_storage::{
-    tables::{EpochTransitionCheckpoints, LastProposed, LastProposedByAuthority},
-    CheckpointStore,
-};
+use rayls_infrastructure_storage::{tables::EpochTransitionCheckpoints, CheckpointStore};
 use rayls_infrastructure_types::{
     BlockHash, ConsensusHeader, ConsensusOutput, Database as ReDatabase, Epoch, Notifier,
     TaskManager, B256,
@@ -300,14 +297,25 @@ where
         // backstop so a hung engine warns and proceeds instead of stalling the transition forever.
         self.drain_engine_backlog(Duration::from_secs(15)).await;
 
-        // Phase 2: PERSISTENCE_FLUSH + clear LastProposed; a stale header would be
-        // reproposed at the same (round, epoch) with outdated parents, causing a fork
-        // if transition from Inactive to Active then it is safe to keep the LastPropose as there is
-        // so stale headers
-        if prior_mode != NodeMode::CvvInactive || target_mode != NodeMode::CvvActive {
-            self.consensus_db.clear_table::<LastProposed>()?;
-            self.consensus_db.clear_table::<LastProposedByAuthority>()?;
-        }
+        // Phase 2: PERSISTENCE_FLUSH.
+        //
+        // `LastProposed` is deliberately NOT cleared here. A mode transition never crosses an
+        // epoch, and within an epoch that entry is this node's only record of "I already proposed
+        // at round R" — the anti-equivocation guard read by `propose_next_header`. Clearing it let
+        // a demote→re-promote flap (CvvActive → CvvInactive → CvvActive at the *same* epoch and
+        // round) build a second, different header for a round already proposed: the exec anchor
+        // advances during teardown, so the digest differs. Peers keep one slot per author and
+        // reject any different digest at a same-or-older round with `AlreadyVotedForLaterRound`,
+        // which is irrecoverable *and* short-circuits ahead of the epoch check — masking the
+        // wrong-epoch rejection that would otherwise have demoted this node into a catch-up sync.
+        // Result was a permanent livelock re-proposing a header that could never certify.
+        //
+        // Keeping the entry makes the re-promoted proposer re-send the byte-identical header, for
+        // which peers replay their cached vote. Nothing is leaked across epochs: real epoch
+        // boundaries clear both tables in `clear_consensus_db_for_next_epoch`, and both readers of
+        // `LastProposed` already filter on `(round, epoch)` themselves — `propose_next_header`
+        // matches `round == current_round && epoch == current_epoch`, and the max-delay retransmit
+        // path is guarded by `last_proposed_is_stale` — so a stale entry is inert either way.
         engine.flush_persistence().await?;
         info!(target: "epoch-manager", ?target_mode, "mode-change phase 2/3: PERSISTENCE_FLUSH");
 


### PR DESCRIPTION
**The problem**

`run_mode_transition` cleared `LastProposed`/`LastProposedByAuthority` on every mode
change except Inactive→Active. A mode transition never crosses an epoch, so within an
epoch this wiped the node's only record of "I already proposed at round R" — the
anti-equivocation guard read by `propose_next_header`.

A validator that falls an epoch behind gets its headers rejected as wrong-epoch, which
trips the demotion counter and moves it to CvvInactive — the designed recovery, since
going inactive lets it sync forward and rejoin. But the demotion wipes `LastProposed`,
and `try_rejoin_consensus` can re-promote within ~350ms off a stale peer-head probe,
landing back on CvvActive at the *same* epoch and round. With the store empty the
proposer builds a *second* header for a round it already proposed — the exec anchor
advanced during teardown, so the digest differs.

Peers keep one slot per author and reject any different digest at a same-or-older round
with `AlreadyVotedForLaterRound`. That error is irrecoverable, and `check_equivocation`
short-circuits ahead of the epoch check — so the peers stop answering "wrong epoch" and
start answering "already voted", which has no arm in `handle_vote_error` and increments
no demotion counter. The node destroys the very signal that was about to rescue it and
livelocks, re-proposing a header that can never certify until the process is restarted.

Observed on a 5-validator local network: node-6 wedged at epoch 11 / round 425, emitting
`Already voted for a header in a later round … This header's round: 425. Last voted for
round: 425.` ~4.7k times over 90s. The digest switch sits exactly between a
demote/re-promote pair at all five affected rounds (394/e3, 401/e5, 421/e7, 382/e9,
425/e11). A process restart cured it: the node came up CvvInactive, stayed there long
enough to sync 11→15, and rejoined at a round no peer had a slot for.

Note this is a distinct failure mode from #86 — that fix (re-proposing a *stale-round*
header) is working; every re-propose in the logs has `last_proposed_round == self_round`.
This one is a *current-round* header with different content.

**What's changed**

Removed the clear from `run_mode_transition` so the anti-equivocation record survives a
demote→re-promote flap within an epoch. The re-promoted proposer now re-sends the
byte-identical header, for which peers replay their cached vote, and the wrong-epoch
rejection keeps flowing so the demote→sync→rejoin recovery works as designed.

Nothing leaks across epochs: real epoch boundaries still clear both tables in
`clear_consensus_db_for_next_epoch`, foreign-DB sanitization still clears in
`sanitize_foreign_consensus_db`, and both readers of `LastProposed` already filter on
`(round, epoch)` themselves — `propose_next_header` matches
`round == current_round && epoch == current_epoch`, and the max-delay retransmit path is
guarded by `last_proposed_is_stale` (#86) — so a stale entry is inert either way. That
makes the clear redundant as protection and destructive as behaviour.

`cargo test -p rayls-middleware-orchestrator` (91 + 3) and the proposer suite pass,
including `test_equivocation_protection_after_restart`, which covers the guard this
restores.
