### PR TITLE
Set testnet dynamic committee sizing activation block

### DIFF
--- a/crates/execution/evm/src/chainspec.rs
+++ b/crates/execution/evm/src/chainspec.rs
@@ -176,7 +176,7 @@ pub const LOCAL_EMPTY_OUTPUT_BLOCK_BLOCK: u64 = 0;
 pub const DEVNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = u64::MAX;
 
 /// DynamicCommitteeSizing activation block on the Rayls testnet
-pub const TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = u64::MAX;
+pub const TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = 10_934_554;
 
 /// DynamicCommitteeSizing activation block on the Rayls mainnet
 pub const MAINNET_DYNAMIC_COMMITTEE_SIZING_BLOCK: u64 = u64::MAX;


### PR DESCRIPTION
Updated TESTNET_DYNAMIC_COMMITTEE_SIZING_BLOCK from u64::MAX to 10_934_554 to schedule the DynamicCommitteeSizing hardfork activation on testnet.

<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

-

Closes #

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

<!-- Does this require a node restart, a network upgrade, a hardfork activation block, a contract migration, a config change, or any client coordination? If yes, describe. If no, write "None". -->

None.

## Test plan

<!-- What did you do to convince yourself this works? Commands, scenarios, or links to CI output. -->

- [ ]
- [ ]
