### PR TITLE
feat: track all in-flight memory operations

### DIFF
--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1543,9 +1543,9 @@ mod test {
     }
 
     /// Writer message that parks `db_run` until the paired sender is dropped, so a test can pin a
-    /// real enqueued backlog behind a stalled writer. It signals `reached` just before parking, so a
-    /// test can wait deterministically for the writer to have drained up to the gate instead of
-    /// sleeping on a fixed timeout.
+    /// real enqueued backlog behind a stalled writer. It signals `reached` just before parking, so
+    /// a test can wait deterministically for the writer to have drained up to the gate instead
+    /// of sleeping on a fixed timeout.
     struct WriterGate {
         park: std::sync::mpsc::Receiver<()>,
         reached: std::sync::mpsc::Sender<()>,

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -305,10 +305,13 @@ impl<'a, DB: Database> LayeredDbTx<'a, DB> {
     /// (`record_prior_to`), so a deep floor never pays for the rows above it.
     pub fn reverse_skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
         let db = &self.db;
-        let db_first = db
-            .get::<T>(key)?
-            .map(|value| (key.clone(), value))
-            .or_else(|| db.record_prior_to::<T>(key));
+        let db_first = if self.mem_db.is_clearing::<T>() {
+            None
+        } else {
+            db.get::<T>(key)?
+                .map(|value| (key.clone(), value))
+                .or_else(|| db.record_prior_to::<T>(key))
+        };
         let db_iter: DBIter<'_, T> =
             Box::new(std::iter::successors(db_first, move |(k, _)| db.record_prior_to::<T>(k)));
 
@@ -389,6 +392,9 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
             None
         } else if let Some((_, val)) = self.mem_db.get_no_marked_check::<T>(key) {
             Some(val)
+        } else if self.mem_db.is_clearing::<T>() {
+            // Pending clear: keys not live in the cache are gone, not stale.
+            None
         } else {
             self.db.get::<T>(key)?
         };
@@ -408,6 +414,9 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
         if let Some((_, val)) = self.mem_db.get_no_marked_check::<T>(key) {
             return Ok(Some(Cow::Owned(encode(&val))));
         }
+        if self.mem_db.is_clearing::<T>() {
+            return self.cold_raw_get::<T>(key);
+        }
         match self.db.raw_get::<T>(key)? {
             Some(bytes) => Ok(Some(bytes)),
             None => self.cold_raw_get::<T>(key),
@@ -415,7 +424,11 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        let db_iter = self.db.iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.iter::<T>()
+        };
         let mem_iter = self.mem_db.iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -425,7 +438,11 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
     }
 
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        let db_iter = self.db.raw_iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.raw_iter::<T>()
+        };
         let mem_iter = self.mem_db.raw_iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -435,7 +452,11 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        let db_iter = self.db.skip_to::<T>(key)?;
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.skip_to::<T>(key)?
+        };
         let mem_iter = self.mem_db.skip_to::<T>(key)?;
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -445,7 +466,11 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
     }
 
     fn raw_skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBRawIter<'_>> {
-        let db_iter = self.db.raw_skip_to::<T>(key)?;
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.raw_skip_to::<T>(key)?
+        };
         let mem_iter = self.mem_db.raw_skip_to::<T>(key)?;
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -455,7 +480,11 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        let db_iter = self.db.reverse_iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.reverse_iter::<T>()
+        };
         let mem_iter = self.mem_db.reverse_iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -465,7 +494,11 @@ impl<'a, DB: Database> DbTx for LayeredDbTx<'a, DB> {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        let db_iter = self.db.reverse_raw_iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.reverse_raw_iter::<T>()
+        };
         let mem_iter = self.mem_db.reverse_raw_iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -843,7 +876,7 @@ fn db_run<DB: Database>(
             }
         }
     }
-    tracing::info!(target: "layered_db_runner", "Layerd DB thread Shutdown complete");
+    tracing::info!(target: "layered_db_runner", "Layered DB thread Shutdown complete");
 }
 
 /// In-memory cache layer over a persistent database with background writes.
@@ -986,10 +1019,13 @@ impl<DB: Database> LayeredDatabase<DB> {
     /// (`record_prior_to`), so a deep floor never pays for the rows above it.
     pub fn reverse_skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
         let db = &self.db;
-        let db_first = db
-            .get::<T>(key)?
-            .map(|value| (key.clone(), value))
-            .or_else(|| db.record_prior_to::<T>(key));
+        let db_first = if self.mem_db.is_clearing::<T>() {
+            None
+        } else {
+            db.get::<T>(key)?
+                .map(|value| (key.clone(), value))
+                .or_else(|| db.record_prior_to::<T>(key))
+        };
         let db_iter: DBIter<'_, T> =
             Box::new(std::iter::successors(db_first, move |(k, _)| db.record_prior_to::<T>(k)));
 
@@ -1102,12 +1138,17 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
-        let hot = if self.mem_db.is_tombstoned::<T>(key) {
-            false
-        } else {
-            self.mem_db.contains_key::<T>(key)? || self.db.contains_key::<T>(key)?
-        };
-        if hot {
+        if self.mem_db.is_tombstoned::<T>(key) {
+            return Ok(false);
+        }
+        if self.mem_db.contains_key::<T>(key)? {
+            return Ok(true);
+        }
+        if self.mem_db.is_clearing::<T>() {
+            // The table's clear is pending: keys not live in the cache are gone, not stale.
+            return self.cold_has::<T>(key);
+        }
+        if self.db.contains_key::<T>(key)? {
             return Ok(true);
         }
         self.cold_has::<T>(key)
@@ -1121,6 +1162,11 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
             None
         } else if let Some((_, val)) = self.mem_db.get_marked::<T>(key)? {
             Some(val)
+        } else if self.mem_db.is_clearing::<T>() {
+            // The table's clear is pending: keys evicted from the cache (or never cached, e.g.
+            // right after startup) are gone, not stale - do not fall through to the persistent
+            // tier.
+            None
         } else {
             self.db.get::<T>(key)?
         };
@@ -1164,7 +1210,12 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        let db_iter = self.db.iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            // Pending clear: the persistent tier is stale, so the merge must not see its rows.
+            Box::new(std::iter::empty())
+        } else {
+            self.db.iter::<T>()
+        };
         let mem_iter = self.mem_db.iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -1174,7 +1225,11 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        let db_iter = self.db.raw_iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.raw_iter::<T>()
+        };
         let mem_iter = self.mem_db.raw_iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -1184,7 +1239,11 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        let db_iter = self.db.skip_to::<T>(key)?;
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.skip_to::<T>(key)?
+        };
         let mem_iter = self.mem_db.skip_to::<T>(key)?;
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -1194,7 +1253,11 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        let db_iter = self.db.reverse_iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.reverse_iter::<T>()
+        };
         let mem_iter = self.mem_db.reverse_iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -1204,7 +1267,11 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        let db_iter = self.db.reverse_raw_iter::<T>();
+        let db_iter = if self.mem_db.is_clearing::<T>() {
+            Box::new(std::iter::empty())
+        } else {
+            self.db.reverse_raw_iter::<T>()
+        };
         let mem_iter = self.mem_db.reverse_raw_iter::<T>();
         let is_tombstoned: Box<dyn Fn(&T::Key) -> bool + '_> =
             Box::new(|k| self.mem_db.is_tombstoned::<T>(k));
@@ -1412,9 +1479,7 @@ impl<T: Table, DB: Database> ClearTrait<DB> for ClearTable<T> {
     }
 
     fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap) {
-        for key in &self.keys {
-            mem_db.on_op_applied(T::NAME, key, heap);
-        }
+        mem_db.on_clear_applied::<T>(&self.keys, heap);
     }
 }
 
@@ -1455,8 +1520,8 @@ mod test {
         mem_db::MemDatabase,
         test::*,
     };
-    use rayls_infrastructure_types::{Database, DbTxMut};
-    use std::{path::Path, time::Instant};
+    use rayls_infrastructure_types::{DBIter, DBRawIter, Database, DbTxMut, Table};
+    use std::{path::Path, sync::Arc, time::Instant};
     use tempfile::tempdir;
 
     #[cfg(feature = "redb")]
@@ -1474,6 +1539,183 @@ mod test {
         let db = LayeredDatabase::open(db);
         db.open_table::<TestTable>().expect("failed to open table!");
         db
+    }
+
+    /// A [`MemDatabase`] whose `clear_table` parks until released: lets a test hold the
+    /// producer's clear window open deterministically while the writer is parked mid-apply.
+    #[derive(Clone, Debug)]
+    struct BlockingClearDb {
+        inner: MemDatabase,
+        state: Arc<parking_lot::Mutex<BlockState>>,
+        cv: Arc<parking_lot::Condvar>,
+    }
+
+    #[derive(Debug, Default)]
+    struct BlockState {
+        /// The next `clear_table` parks until `release_clear` is called.
+        block: bool,
+        /// The writer is parked inside `clear_table`.
+        entered: bool,
+    }
+
+    impl BlockingClearDb {
+        fn new() -> Self {
+            Self {
+                inner: MemDatabase::new(),
+                state: Arc::new(parking_lot::Mutex::new(BlockState::default())),
+                cv: Arc::new(parking_lot::Condvar::new()),
+            }
+        }
+
+        /// Park the writer's next `clear_table` until [`Self::release_clear`].
+        fn block_clear(&self) {
+            self.state.lock().block = true;
+        }
+
+        /// Signal the parked writer to proceed with the persistent clear.
+        fn release_clear(&self) {
+            self.state.lock().block = false;
+            self.cv.notify_all();
+        }
+
+        /// Blocks until the writer is parked inside `clear_table`: at that point the producer's
+        /// clear window is provably still open.
+        fn wait_clear_entered(&self) {
+            let mut state = self.state.lock();
+            while !state.entered {
+                self.cv.wait(&mut state);
+            }
+        }
+    }
+
+    impl Database for BlockingClearDb {
+        type TX<'txn>
+            = crate::mem_db::MemDbTx<'txn>
+        where
+            Self: 'txn;
+
+        type TXMut<'txn>
+            = crate::mem_db::MemDbTxMut<'txn>
+        where
+            Self: 'txn;
+
+        fn open_table<T: Table>(&self) -> eyre::Result<()> {
+            self.inner.open_table::<T>()
+        }
+        fn read_txn(&self) -> eyre::Result<Self::TX<'_>> {
+            self.inner.read_txn()
+        }
+        fn write_txn(&self) -> eyre::Result<Self::TXMut<'_>> {
+            self.inner.write_txn()
+        }
+        fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
+            self.inner.contains_key::<T>(key)
+        }
+        fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
+            self.inner.get::<T>(key)
+        }
+        fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
+            self.inner.insert::<T>(key, value)
+        }
+        fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
+            self.inner.remove::<T>(key)
+        }
+        fn clear_table<T: Table>(&self) -> eyre::Result<()> {
+            {
+                let mut state = self.state.lock();
+                if state.block {
+                    state.entered = true;
+                    self.cv.notify_all();
+                    while state.block {
+                        self.cv.wait(&mut state);
+                    }
+                }
+            }
+            self.inner.clear_table::<T>()
+        }
+        fn is_empty<T: Table>(&self) -> bool {
+            self.inner.is_empty::<T>()
+        }
+        fn iter<T: Table>(&self) -> DBIter<'_, T> {
+            self.inner.iter::<T>()
+        }
+        fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
+            self.inner.raw_iter::<T>()
+        }
+        fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
+            self.inner.skip_to::<T>(key)
+        }
+        fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
+            self.inner.reverse_iter::<T>()
+        }
+        fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
+            self.inner.reverse_raw_iter::<T>()
+        }
+        fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
+            self.inner.record_prior_to::<T>(key)
+        }
+        fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
+            self.inner.last_record::<T>()
+        }
+    }
+
+    /// Releases the writer's parked clear on drop, so a panicked assertion cannot deadlock the
+    /// writer join at test teardown.
+    struct ClearRelease<'a>(&'a BlockingClearDb);
+
+    impl Drop for ClearRelease<'_> {
+        fn drop(&mut self) {
+            self.0.release_clear();
+        }
+    }
+
+    /// `clear_table` tombstones only the cached rows, so keys already evicted from the cache have
+    /// nothing to hide behind: without the pending-clear gate they read stale pre-clear values
+    /// from the persistent tier until the writer applies the clear. The pending-clear flag must
+    /// close that window for `get`, `contains_key` and every iterator.
+    #[test]
+    fn clear_hides_evicted_keys_until_the_clear_applies() {
+        let inner = BlockingClearDb::new();
+        let db = LayeredDatabase::open_with_config(inner.clone(), CacheConfig { max_size: 2 });
+        db.open_table::<TestTable>().expect("open layered table");
+
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+        db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
+        db.insert::<TestTable>(&3, &"three".to_string()).expect("insert");
+        db.sync_persist();
+        // Key 1 settled first and was evicted: it is now live only in the persistent tier.
+        assert_eq!(db.mem_db.mem_size(), 2, "key 1 must be evicted");
+        assert!(!db.mem_db.contains_key::<TestTable>(&1).unwrap());
+
+        inner.block_clear();
+        let _release = ClearRelease(&inner);
+        db.clear_table::<TestTable>().expect("clear");
+        inner.wait_clear_entered();
+        // The writer is parked inside the persistent clear: the producer's window is open.
+        assert!(db.mem_db.is_clearing::<TestTable>());
+
+        // The evicted key must not leak from the persistent tier while the clear is pending.
+        assert_eq!(db.get::<TestTable>(&1).unwrap(), None, "evicted key must read as cleared");
+        assert_eq!(db.get::<TestTable>(&2).unwrap(), None, "cached key must read as cleared");
+        assert_eq!(db.get::<TestTable>(&3).unwrap(), None, "cached key must read as cleared");
+        assert!(!db.contains_key::<TestTable>(&1).unwrap(), "evicted key must not contain");
+        assert!(
+            db.iter::<TestTable>().collect::<Vec<_>>().is_empty(),
+            "iter must not leak stale rows"
+        );
+        assert!(db.is_empty::<TestTable>(), "table must read empty while the clear is pending");
+        // Writes during the window still read through the mem overlay.
+        db.insert::<TestTable>(&4, &"four".to_string()).expect("insert");
+        assert_eq!(db.get::<TestTable>(&4).unwrap(), Some("four".to_string()));
+
+        inner.release_clear();
+        db.sync_persist();
+        assert_eq!(db.get::<TestTable>(&1).unwrap(), None, "clear must land");
+        assert!(!db.mem_db.is_clearing::<TestTable>(), "pending-clear flag must settle");
+
+        db.insert::<TestTable>(&5, &"five".to_string()).expect("insert");
+        db.sync_persist();
+        assert_eq!(db.get::<TestTable>(&5).unwrap(), Some("five".to_string()));
     }
 
     /// `evict_persistent_batch` must drop exactly the given keys from the durable layer and leave

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1272,7 +1272,7 @@ impl<T: Table, DB: Database> InsertTrait<DB> for KeyValueInsert<T> {
         txn.insert::<T>(&self.key, &self.value)
     }
     fn clear_insert_mem(&self, mem_db: &MemDatabase) {
-        let _ = mem_db.delete_removed::<T>(&self.key, false);
+        let _ = mem_db.delete_tombstoned::<T>(&self.key, false);
     }
 }
 

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     cmp::Ordering,
+    collections::BinaryHeap,
     fmt::Debug,
     future::Future,
     iter::Peekable,
@@ -20,10 +21,10 @@ use crate::{
     tables::ColdBatchLocations,
 };
 
-use crate::mem_db::{MemDatabase, MemDbTx, MemDbTxMut};
+use crate::mem_db::{EvictionHeap, MemDatabase, MemDbTx, MemDbTxMut};
 use prometheus::{default_registry, register_int_gauge_with_registry, IntGauge, Registry};
 use rayls_infrastructure_types::{
-    decode_key, encode, DBIter, DBRawIter, Database, DbTx, DbTxMut, Table,
+    decode_key, encode, encode_key, DBIter, DBRawIter, Database, DbTx, DbTxMut, Table,
 };
 use tokio::sync::oneshot::{self, error::TryRecvError};
 
@@ -231,8 +232,22 @@ fn merge_cold_raw<'i, T: Table>(
     Box::new(merged.take_while(move |_| !faulted.get()))
 }
 
-const CACHE_KEEP_TIME_SECS: u64 = 60;
-const MAX_CACHE_SIZE: usize = 10000;
+/// Default cap on total cached rows (live and tombstoned) before the writer evicts settled keys.
+const DEFAULT_MAX_CACHE_SIZE: usize = 10000;
+
+/// Eviction policy for the mem cache.
+#[derive(Clone, Copy, Debug)]
+pub struct CacheConfig {
+    /// Total cached rows (live and tombstoned) allowed before the writer evicts settled keys
+    /// (in-flight == 0) in recency order. Small in tests, the default in production.
+    pub max_size: usize,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self { max_size: DEFAULT_MAX_CACHE_SIZE }
+    }
+}
 
 pub struct LayeredDbTx<'a, DB: Database> {
     mem_db: MemDbTx<'a>,
@@ -534,6 +549,9 @@ impl<'a, DB: Database> DbTx for LayeredDbTxMut<'a, DB> {
 
 impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     fn insert<T: Table>(&mut self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
+        // The txn producer already holds the mem write guard for its whole lifetime, so the
+        // mutation, the in-flight increment and the enqueue are one critical section by
+        // construction.
         self.mem_db.insert::<T>(key, value)?;
         let ins = Box::new(KeyValueInsert::<T> { key: key.clone(), value: value.clone() });
         self.tx.send(DBMessage::Insert(ins)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
@@ -562,8 +580,9 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     }
 
     fn clear_table<T: Table>(&mut self) -> eyre::Result<()> {
+        let keys = self.mem_db.raw_keys::<T>();
         self.mem_db.clear_table::<T>()?;
-        let clr = Box::new(ClearTable::<T> { _casper: PhantomData });
+        let clr = Box::new(ClearTable::<T> { _casper: PhantomData, keys });
         self.tx.send(DBMessage::Clear(clr)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
         Ok(())
     }
@@ -575,26 +594,22 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     }
 }
 
-/// Manage the persistent DB in a background thread with daily compaction.
-/// Drop the mem overlay for committed inserts older than `CACHE_KEEP_TIME_SECS` or beyond
-/// `MAX_CACHE_SIZE`. Only safe for committed rows: it removes them from the mem layer.
-fn evict_committed<DB: Database>(
-    committed_inserts: &mut Vec<(Instant, Box<dyn InsertTrait<DB>>)>,
-    mem_db: &MemDatabase,
-) {
-    let total_count = committed_inserts.len();
-    let mut remove_count: usize = 0;
-    for (instant, insert) in committed_inserts.iter() {
-        if instant.elapsed() > Duration::from_secs(CACHE_KEEP_TIME_SECS)
-            || total_count - remove_count > MAX_CACHE_SIZE
-        {
-            insert.clear_insert_mem(mem_db);
-            remove_count += 1;
-            continue;
+/// An op applied into a (possibly shared) write txn; its in-flight release must wait for the
+/// final commit to succeed.
+enum DeferredOp<DB: Database> {
+    Insert(Box<dyn InsertTrait<DB>>),
+    Remove(Box<dyn RemoveTrait<DB>>),
+    Clear(Box<dyn ClearTrait<DB>>),
+}
+
+impl<DB: Database> DeferredOp<DB> {
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap) {
+        match self {
+            DeferredOp::Insert(op) => op.on_applied(mem_db, heap),
+            DeferredOp::Remove(op) => op.on_applied(mem_db, heap),
+            DeferredOp::Clear(op) => op.on_applied(mem_db, heap),
         }
-        break;
     }
-    committed_inserts.drain(..remove_count);
 }
 
 /// Depth at which the writer queue is treated as a backlog: `db_run` warns (rate-limited) and
@@ -698,13 +713,15 @@ fn db_run<DB: Database>(
     mem_db: MemDatabase,
     rx: Receiver<DBMessage<DB>>,
     depth: Arc<AtomicUsize>,
+    max_size: usize,
 ) {
     let mut txn = None;
     let mut last_compact = Instant::now();
     let queue_depth_gauge = writer_queue_depth_gauge();
     let mut last_lag_warn: Option<Instant> = None;
 
-    let mut committed_inserts: Vec<(Instant, Box<dyn InsertTrait<DB>>)> = Vec::with_capacity(1000);
+    let mut eviction_heap: EvictionHeap = BinaryHeap::new();
+    let mut committed_ops: Vec<DeferredOp<DB>> = Vec::with_capacity(1000);
     // last write/commit failure since the previous CaughtUp, reported by the next persist
     let mut pending_write_error: Option<String> = None;
     if let Err(e) = db.compact() {
@@ -737,9 +754,16 @@ fn db_run<DB: Database>(
                 if let Some((current_txn, count)) = txn.take() {
                     if count <= 1 {
                         match current_txn.commit() {
-                            Ok(()) => evict_committed(&mut committed_inserts, &mem_db),
-                            // surface via persist instead of aborting; rows stay in mem, not lost
+                            Ok(()) => {
+                                for op in committed_ops.drain(..) {
+                                    op.on_applied(&mem_db, &mut eviction_heap);
+                                }
+                                mem_db.evict_if_needed(&mut eviction_heap, max_size);
+                            }
+                            // The txn's rows stay in mem with their in-flight counts, so a failed
+                            // commit is retained (not lost, not evictable) and surfaced via persist.
                             Err(e) => {
+                                committed_ops.clear();
                                 tracing::error!(target: "layered_db_runner", "consensus DB commit failed: {e}");
                                 pending_write_error = Some(format!("commit: {e}"));
                             }
@@ -752,21 +776,19 @@ fn db_run<DB: Database>(
             DBMessage::Insert(ins) => {
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = ins.insert_txn(txn) {
-                        // keep the failed row in mem (not the eviction cache) so it is not lost
+                        // keep the failed row in mem (not evictable) so it is not lost
                         tracing::error!(target: "layered_db_runner", "DB TXN Insert: {e}");
                         pending_write_error = Some(format!("insert: {e}"));
                     } else {
-                        committed_inserts.push((Instant::now(), ins));
-
-                        // Rayls: limit layer growth between commits
-                        if committed_inserts.len() > MAX_CACHE_SIZE * 2 {
-                            evict_committed(&mut committed_inserts, &mem_db);
-                        }
+                        committed_ops.push(DeferredOp::Insert(ins));
                     }
                 } else if let Err(e) = ins.insert(&db) {
+                    // keep the failed row in mem (with its in-flight count, so not evictable)
                     tracing::error!(target: "layered_db_runner", "DB Insert: {e}");
-                    ins.clear_insert_mem(&mem_db);
                     pending_write_error = Some(format!("insert: {e}"));
+                } else {
+                    ins.on_applied(&mem_db, &mut eviction_heap);
+                    mem_db.evict_if_needed(&mut eviction_heap, max_size);
                 }
             }
             DBMessage::Remove(rm) => {
@@ -774,10 +796,15 @@ fn db_run<DB: Database>(
                     if let Err(e) = rm.remove_txn(txn, &mem_db) {
                         tracing::error!(target: "layered_db_runner", "DB TXN Remove: {e}");
                         pending_write_error = Some(format!("remove: {e}"));
+                    } else {
+                        committed_ops.push(DeferredOp::Remove(rm));
                     }
                 } else if let Err(e) = rm.remove(&db, &mem_db) {
                     tracing::error!(target: "layered_db_runner", "DB Remove: {e}");
                     pending_write_error = Some(format!("remove: {e}"));
+                } else {
+                    rm.on_applied(&mem_db, &mut eviction_heap);
+                    mem_db.evict_if_needed(&mut eviction_heap, max_size);
                 }
             }
             DBMessage::Clear(clr) => {
@@ -785,15 +812,21 @@ fn db_run<DB: Database>(
                     if let Err(e) = clr.clear_table_txn(txn, &mem_db) {
                         tracing::error!("DB TXN Clear table: {e}");
                         pending_write_error = Some(format!("clear: {e}"));
+                    } else {
+                        committed_ops.push(DeferredOp::Clear(clr));
                     }
                 } else if let Err(e) = clr.clear_table(&db, &mem_db) {
                     tracing::error!("DB Clear: {e}");
                     pending_write_error = Some(format!("clear: {e}"));
+                } else {
+                    clr.on_applied(&mem_db, &mut eviction_heap);
+                    mem_db.evict_if_needed(&mut eviction_heap, max_size);
                 }
             }
             // NOTE: proves prior messages were applied, not that an open shared txn committed.
             // Safe at shutdown because consensus writers are torn down before persist runs.
             DBMessage::CaughtUp(tx) => {
+                mem_db.evict_if_needed(&mut eviction_heap, max_size);
                 let reply: Result<(), String> = match pending_write_error.take() {
                     Some(e) => Err(e),
                     None => Ok(()),
@@ -847,6 +880,12 @@ impl<DB: Database> Drop for LayeredDatabase<DB> {
 
 impl<DB: Database> LayeredDatabase<DB> {
     pub fn open(db: DB) -> Self {
+        Self::open_with_config(db, CacheConfig::default())
+    }
+
+    /// Opens the layered DB with a custom eviction policy: small caches in tests, the default in
+    /// production.
+    pub fn open_with_config(db: DB, config: CacheConfig) -> Self {
         let (tx, rx) = mpsc::channel();
         let depth = Arc::new(AtomicUsize::new(0));
         let db_cloned = db.clone();
@@ -854,7 +893,7 @@ impl<DB: Database> LayeredDatabase<DB> {
         let mem_db_clone = mem_db.clone();
         let queue_depth = Arc::clone(&depth);
         let thread = Some(Arc::new(std::thread::spawn(move || {
-            db_run(db_cloned, mem_db_clone, rx, queue_depth)
+            db_run(db_cloned, mem_db_clone, rx, queue_depth, config.max_size)
         })));
         Self {
             mem_db,
@@ -1085,24 +1124,28 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
-        self.mem_db.insert::<T>(key, value)?;
-        let ins = Box::new(KeyValueInsert::<T> { key: key.clone(), value: value.clone() });
-        self.tx.send(DBMessage::Insert(ins)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
-        Ok(())
+        // The mem mutation, the in-flight increment and the enqueue share one critical section:
+        // channel order equals mem order, so a zero in-flight count is a sound "no queued ops".
+        self.mem_db.insert_queued::<T>(key, value, || {
+            let ins = Box::new(KeyValueInsert::<T> { key: key.clone(), value: value.clone() });
+            self.tx.send(DBMessage::Insert(ins)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))
+        })
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
-        self.mem_db.remove::<T>(key)?;
-        let rm = Box::new(KeyRemove::<T> { key: key.clone() });
-        self.tx.send(DBMessage::Remove(rm)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
-        Ok(())
+        self.mem_db.remove_queued::<T>(key, || {
+            let rm = Box::new(KeyRemove::<T> { key: key.clone() });
+            self.tx.send(DBMessage::Remove(rm)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))
+        })
     }
 
     fn clear_table<T: Table>(&self) -> eyre::Result<()> {
-        self.mem_db.clear_table::<T>()?;
-        let clr = Box::new(ClearTable::<T> { _casper: PhantomData });
-        self.tx.send(DBMessage::Clear(clr)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
-        Ok(())
+        // The clear tombstones every row and bumps each in-flight count under the same lock that
+        // captures the key set for the writer, so no tombstone is evicted before the clear lands.
+        self.mem_db.clear_table_queued::<T>(|keys| {
+            let clr = Box::new(ClearTable::<T> { _casper: PhantomData, keys });
+            self.tx.send(DBMessage::Clear(clr)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))
+        })
     }
 
     fn is_empty<T: Table>(&self) -> bool {
@@ -1233,18 +1276,23 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
 trait InsertTrait<DB: Database>: Send + 'static {
     fn insert(&self, db: &DB) -> eyre::Result<()>;
     fn insert_txn(&self, txn: &mut DB::TXMut<'_>) -> eyre::Result<()>;
-    /// Clear the inserted data from the memdb.
-    fn clear_insert_mem(&self, mem_db: &MemDatabase);
+    /// Release the in-flight op for the inserted key once the write is durably applied; at zero
+    /// the key becomes an eviction candidate.
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap);
 }
 
 trait RemoveTrait<DB: Database>: Send + 'static {
     fn remove(&self, db: &DB, mem_db: &MemDatabase) -> eyre::Result<()>;
     fn remove_txn(&self, txn: &mut DB::TXMut<'_>, mem_db: &MemDatabase) -> eyre::Result<()>;
+    /// Release the in-flight op for the removed key(s) once the delete is durably applied.
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap);
 }
 
 trait ClearTrait<DB: Database>: Send + 'static {
     fn clear_table(&self, db: &DB, mem_db: &MemDatabase) -> eyre::Result<()>;
     fn clear_table_txn(&self, txn: &mut DB::TXMut<'_>, mem_db: &MemDatabase) -> eyre::Result<()>;
+    /// Release the in-flight op of every tombstoned key once the clear is durably applied.
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap);
 }
 
 struct KeyValueInsert<T: Table> {
@@ -1261,6 +1309,9 @@ struct KeyRemoveBatch<T: Table> {
 }
 
 struct ClearTable<T: Table> {
+    /// Raw keys tombstoned by the producer's clear: each must release its in-flight op when the
+    /// persistent clear applies, so no tombstone is evicted before then.
+    keys: Vec<Vec<u8>>,
     _casper: PhantomData<T>,
 }
 
@@ -1271,13 +1322,14 @@ impl<T: Table, DB: Database> InsertTrait<DB> for KeyValueInsert<T> {
     fn insert_txn(&self, txn: &mut DB::TXMut<'_>) -> eyre::Result<()> {
         txn.insert::<T>(&self.key, &self.value)
     }
-    fn clear_insert_mem(&self, mem_db: &MemDatabase) {
-        let _ = mem_db.delete_tombstoned::<T>(&self.key, false);
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap) {
+        mem_db.on_op_applied(T::NAME, &encode_key(&self.key), heap);
     }
 }
 
 // Tombstones are NOT eagerly cleared from mem after persistent delete;
 // doing so races with the main thread's reads (MDBX write not yet visible).
+// They are released by the eviction heap once their in-flight count settles.
 impl<T: Table, DB: Database> RemoveTrait<DB> for KeyRemove<T> {
     fn remove(&self, db: &DB, mem_db: &MemDatabase) -> eyre::Result<()> {
         // skip if key was re-inserted after the remove was queued
@@ -1296,6 +1348,10 @@ impl<T: Table, DB: Database> RemoveTrait<DB> for KeyRemove<T> {
             return Ok(());
         }
         txn.remove::<T>(&self.key)
+    }
+
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap) {
+        mem_db.on_op_applied(T::NAME, &encode_key(&self.key), heap);
     }
 }
 
@@ -1326,6 +1382,12 @@ impl<T: Table, DB: Database> RemoveTrait<DB> for KeyRemoveBatch<T> {
         }
         Ok(())
     }
+
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap) {
+        for key in &self.keys {
+            mem_db.on_op_applied(T::NAME, &encode_key(key), heap);
+        }
+    }
 }
 
 impl<T: Table, DB: Database> ClearTrait<DB> for ClearTable<T> {
@@ -1340,6 +1402,12 @@ impl<T: Table, DB: Database> ClearTrait<DB> for ClearTable<T> {
         _mem_db: &MemDatabase,
     ) -> eyre::Result<()> {
         txn.clear_table::<T>()
+    }
+
+    fn on_applied(&self, mem_db: &MemDatabase, heap: &mut EvictionHeap) {
+        for key in &self.keys {
+            mem_db.on_op_applied(T::NAME, key, heap);
+        }
     }
 }
 
@@ -1369,7 +1437,10 @@ impl<DB: Database> Debug for DBMessage<DB> {
 
 #[cfg(test)]
 mod test {
-    use super::{DBMessage, InsertTrait, LayeredDatabase, QUEUE_HIGH_WATER_MARK, QUEUE_PACE_SLEEP};
+    use super::{
+        CacheConfig, DBMessage, EvictionHeap, InsertTrait, LayeredDatabase, QUEUE_HIGH_WATER_MARK,
+        QUEUE_PACE_SLEEP,
+    };
     #[cfg(feature = "redb")]
     use crate::redb::ReDB;
     use crate::{
@@ -1477,7 +1548,7 @@ mod test {
             let _ = self.0.recv();
             Ok(())
         }
-        fn clear_insert_mem(&self, _mem_db: &MemDatabase) {}
+        fn on_applied(&self, _mem_db: &MemDatabase, _heap: &mut EvictionHeap) {}
     }
 
     /// A producer bursting into a seeded writer backlog must be paced above the high-water mark,
@@ -1528,17 +1599,182 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_layereddb_contains_key() {
-        let temp_dir = tempdir().expect("failed to create temp dir");
-        #[cfg(feature = "redb")]
-        {
-            let db = open_redb(temp_dir.path());
-            test_contains_key(db);
-        }
-        let db = open_mdbx(temp_dir.path());
+    /// Insert a burst of keys into a tiny cache and confirm the writer evicts settled keys in
+/// recency order until the cache fits `max_size`, with the newest rows surviving in mem.
+#[test]
+fn eviction_keeps_cache_at_max_size_and_evicts_oldest_settled() {
+    let inner = MemDatabase::new();
+    inner.open_table::<TestTable>().expect("open inner table");
+    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 3 });
+    db.open_table::<TestTable>().expect("open layered table");
+
+    for i in 0..10u64 {
+        db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
+    }
+    db.sync_persist();
+
+    assert_eq!(db.mem_db.mem_size(), 3, "cache must be trimmed to max_size");
+    // The newest rows survive hot; older ones fall through to the persistent tier.
+    for i in 0..10u64 {
+        assert_eq!(
+            db.get::<TestTable>(&i).unwrap().as_deref(),
+            Some(format!("v{i}").as_str()),
+            "every key must still be readable after eviction"
+        );
+    }
+    for i in 7..10u64 {
+        assert!(db.mem_db.contains_key::<TestTable>(&i).unwrap(), "newest key {i} must stay hot");
+    }
+    for i in 0..7u64 {
+        assert!(!db.mem_db.contains_key::<TestTable>(&i).unwrap(), "settled key {i} must be evicted");
+    }
+}
+
+/// A tombstone whose remove is still queued must not be evicted, even when the cache is over its
+/// cap: the row shields reads from the persistent tier until the delete lands. Once the remove
+/// applies, the tombstone settles and becomes an eviction candidate.
+#[test]
+fn eviction_waits_for_in_flight_ops() {
+    let inner = MemDatabase::new();
+    inner.open_table::<TestTable>().expect("open inner table");
+    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
+    db.open_table::<TestTable>().expect("open layered table");
+
+    // Two gates park the writer mid-drain so the in-flight window is observable.
+    let (release, gate1) = std::sync::mpsc::channel::<()>();
+    let (release2, gate2) = std::sync::mpsc::channel::<()>();
+    db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate1)))).expect("gate1 enqueue");
+    db.insert::<TestTable>(&1, &"one".to_string()).expect("insert k1");
+    db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate2)))).expect("gate2 enqueue");
+    db.remove::<TestTable>(&1).expect("remove k1");
+    db.insert::<TestTable>(&2, &"two".to_string()).expect("insert k2");
+
+    // Let the writer drain past K1's insert, then park again: K1's tombstone and K2's row are
+    // both in flight (count > 0), so eviction (run at every apply) must not drop anything even
+    // though the cache holds 2 rows against a cap of 1.
+    drop(release);
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert_eq!(
+        db.mem_db.mem_size(),
+        2,
+        "in-flight rows must not be evicted while ops are queued"
+    );
+    assert!(db.mem_db.is_tombstoned::<TestTable>(&1), "K1's tombstone must survive while queued");
+    drop(release2);
+    db.sync_persist();
+
+    // The remove applied, so K1's settled tombstone is now evictable; only K2 stays hot.
+    assert_eq!(db.mem_db.mem_size(), 1, "settled rows must be trimmed to max_size");
+    assert!(!db.mem_db.is_tombstoned::<TestTable>(&1), "K1 tombstone must be evicted post-apply");
+    assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "K2 must stay hot");
+    assert_eq!(db.get::<TestTable>(&1).unwrap(), None, "K1 is durably removed");
+    assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("two".to_string()));
+}
+
+/// A tombstone for a key that was never in the cache (deleted from the persistent tier only)
+/// must not leak: it settles when the remove applies and is evicted like any other row.
+#[test]
+fn removed_never_inserted_tombstone_is_evicted() {
+    let inner = MemDatabase::new();
+    inner.open_table::<TestTable>().expect("open inner table");
+    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
+    db.open_table::<TestTable>().expect("open layered table");
+
+    db.remove::<TestTable>(&999).expect("remove never-inserted key");
+    db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+    db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
+    db.sync_persist();
+
+    assert_eq!(db.get::<TestTable>(&999).unwrap(), None);
+    assert!(!db.mem_db.is_tombstoned::<TestTable>(&999), "stray tombstone must be evicted");
+    assert_eq!(db.mem_db.mem_size(), 1, "cache must be trimmed");
+}
+
+/// A `clear_table` tombstones every cached row and holds them (in flight) until the persistent
+/// clear lands; only then are the tombstones released and evicted.
+#[test]
+fn clear_tombstones_are_held_until_the_persistent_clear_lands() {
+    let inner = MemDatabase::new();
+    inner.open_table::<TestTable>().expect("open inner table");
+    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
+    db.open_table::<TestTable>().expect("open layered table");
+
+    db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+    db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
+    db.insert::<TestTable>(&3, &"three".to_string()).expect("insert");
+    db.clear_table::<TestTable>().expect("clear");
+    db.insert::<TestTable>(&4, &"four".to_string()).expect("insert");
+    db.sync_persist();
+
+    assert_eq!(db.get::<TestTable>(&1).unwrap(), None);
+    assert_eq!(db.get::<TestTable>(&2).unwrap(), None);
+    assert_eq!(db.get::<TestTable>(&3).unwrap(), None);
+    assert_eq!(db.get::<TestTable>(&4).unwrap(), Some("four".to_string()));
+    assert_eq!(db.mem_db.mem_size(), 2, "cleared tombstones settle and are evicted");
+}
+
+/// Reading a hot key refreshes its recency (lock-free, throttled), so it survives eviction over
+/// a sibling that settled at the same time but was never read since.
+#[test]
+fn read_recency_protects_a_hot_key() {
+    let inner = MemDatabase::new();
+    inner.open_table::<TestTable>().expect("open inner table");
+    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
+    db.open_table::<TestTable>().expect("open layered table");
+
+    for i in 1..=3u64 {
+        db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
+    }
+    db.sync_persist();
+    // 1 settled first and was evicted; 2 and 3 are hot.
+    assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap());
+    assert!(db.mem_db.contains_key::<TestTable>(&3).unwrap());
+
+    // Cross the recency throttle window, then read key 2: its clock bumps.
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("v2".to_string()));
+
+    // Overflow the cache: without the read bump, key 2 (settled first) would be evicted.
+    db.insert::<TestTable>(&4, &"v4".to_string()).expect("insert");
+    db.sync_persist();
+
+    assert_eq!(db.mem_db.mem_size(), 2);
+    assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "read key must stay hot");
+    assert!(db.mem_db.contains_key::<TestTable>(&4).unwrap(), "newest key must stay hot");
+    assert!(!db.mem_db.contains_key::<TestTable>(&3).unwrap(), "unread sibling must be evicted");
+}
+
+/// Remove-then-reinsert of the same key must not leak its in-flight count: the remove's apply
+/// is skipped by the re-insert guard, but it still settles, so the row stays evictable.
+#[test]
+fn guard_skipped_remove_still_settles() {
+    let inner = MemDatabase::new();
+    inner.open_table::<TestTable>().expect("open inner table");
+    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
+    db.open_table::<TestTable>().expect("open layered table");
+
+    db.insert::<TestTable>(&1, &"v1".to_string()).expect("insert");
+    db.remove::<TestTable>(&1).expect("remove");
+    db.insert::<TestTable>(&1, &"v3".to_string()).expect("reinsert");
+    db.insert::<TestTable>(&2, &"v2".to_string()).expect("insert");
+    db.insert::<TestTable>(&3, &"v3".to_string()).expect("insert");
+    db.sync_persist();
+
+    assert_eq!(db.get::<TestTable>(&1).unwrap(), Some("v3".to_string()));
+    assert_eq!(db.mem_db.mem_size(), 1, "no in-flight leak: the row is evictable");
+}
+
+#[test]
+fn test_layereddb_contains_key() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    #[cfg(feature = "redb")]
+    {
+        let db = open_redb(temp_dir.path());
         test_contains_key(db);
     }
+    let db = open_mdbx(temp_dir.path());
+    test_contains_key(db);
+}
 
     #[test]
     fn test_layereddb_get() {

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -582,7 +582,7 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     fn clear_table<T: Table>(&mut self) -> eyre::Result<()> {
         let keys = self.mem_db.raw_keys::<T>();
         self.mem_db.clear_table::<T>()?;
-        let clr = Box::new(ClearTable::<T> { _casper: PhantomData, keys });
+        let clr = Box::new(ClearTable::<T> { _marker: PhantomData, keys });
         self.tx.send(DBMessage::Clear(clr)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
         Ok(())
     }
@@ -1150,7 +1150,7 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
         // The clear tombstones every row and bumps each in-flight count under the same lock that
         // captures the key set for the writer, so no tombstone is evicted before the clear lands.
         self.mem_db.clear_table_queued::<T>(|keys| {
-            let clr = Box::new(ClearTable::<T> { _casper: PhantomData, keys });
+            let clr = Box::new(ClearTable::<T> { _marker: PhantomData, keys });
             self.tx.send(DBMessage::Clear(clr)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))
         })
     }
@@ -1319,7 +1319,7 @@ struct ClearTable<T: Table> {
     /// Raw keys tombstoned by the producer's clear: each must release its in-flight op when the
     /// persistent clear applies, so no tombstone is evicted before then.
     keys: Vec<Vec<u8>>,
-    _casper: PhantomData<T>,
+    _marker: PhantomData<T>,
 }
 
 impl<T: Table, DB: Database> InsertTrait<DB> for KeyValueInsert<T> {
@@ -1567,11 +1567,7 @@ mod test {
 
     /// A `(release, reached, gate)` triple: dropping `release` lets the writer pass the gate, and
     /// `reached` fires once the writer has drained up to and parked at the gate.
-    fn writer_gate() -> (
-        std::sync::mpsc::Sender<()>,
-        std::sync::mpsc::Receiver<()>,
-        WriterGate,
-    ) {
+    fn writer_gate() -> (std::sync::mpsc::Sender<()>, std::sync::mpsc::Receiver<()>, WriterGate) {
         let (release, park) = std::sync::mpsc::channel::<()>();
         let (reached, reached_rx) = std::sync::mpsc::channel::<()>();
         (release, reached_rx, WriterGate { park, reached })
@@ -1975,7 +1971,6 @@ mod test {
         // Verify all items are accessible via the layered iterator
         let count = db.iter::<TestTable>().count();
         assert_eq!(count, 101, "Expected 101 items after clear+insert, got {}", count);
-
     }
 
     #[test]

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1543,19 +1543,38 @@ mod test {
     }
 
     /// Writer message that parks `db_run` until the paired sender is dropped, so a test can pin a
-    /// real enqueued backlog behind a stalled writer.
-    struct WriterGate(std::sync::mpsc::Receiver<()>);
+    /// real enqueued backlog behind a stalled writer. It signals `reached` just before parking, so a
+    /// test can wait deterministically for the writer to have drained up to the gate instead of
+    /// sleeping on a fixed timeout.
+    struct WriterGate {
+        park: std::sync::mpsc::Receiver<()>,
+        reached: std::sync::mpsc::Sender<()>,
+    }
 
     impl<DB: Database> InsertTrait<DB> for WriterGate {
         fn insert(&self, _db: &DB) -> eyre::Result<()> {
-            let _ = self.0.recv();
+            let _ = self.reached.send(());
+            let _ = self.park.recv();
             Ok(())
         }
         fn insert_txn(&self, _txn: &mut DB::TXMut<'_>) -> eyre::Result<()> {
-            let _ = self.0.recv();
+            let _ = self.reached.send(());
+            let _ = self.park.recv();
             Ok(())
         }
         fn on_applied(&self, _mem_db: &MemDatabase, _heap: &mut EvictionHeap) {}
+    }
+
+    /// A `(release, reached, gate)` triple: dropping `release` lets the writer pass the gate, and
+    /// `reached` fires once the writer has drained up to and parked at the gate.
+    fn writer_gate() -> (
+        std::sync::mpsc::Sender<()>,
+        std::sync::mpsc::Receiver<()>,
+        WriterGate,
+    ) {
+        let (release, park) = std::sync::mpsc::channel::<()>();
+        let (reached, reached_rx) = std::sync::mpsc::channel::<()>();
+        (release, reached_rx, WriterGate { park, reached })
     }
 
     /// A producer bursting into a seeded writer backlog must be paced above the high-water mark,
@@ -1569,8 +1588,8 @@ mod test {
         db.open_table::<TestTable>().expect("open layered table");
 
         // Park the writer behind a gate so the seeded backlog cannot drain mid-measurement.
-        let (release, gate) = std::sync::mpsc::channel::<()>();
-        db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate)))).expect("gate enqueue");
+        let (release, _reached, gate) = writer_gate();
+        db.tx.send(DBMessage::Insert(Box::new(gate))).expect("gate enqueue");
 
         // Seed one message past the mark: every enqueue here is at or below it, hence unpaced.
         let value = "v".to_string();
@@ -1654,19 +1673,21 @@ mod test {
         db.open_table::<TestTable>().expect("open layered table");
 
         // Two gates park the writer mid-drain so the in-flight window is observable.
-        let (release, gate1) = std::sync::mpsc::channel::<()>();
-        let (release2, gate2) = std::sync::mpsc::channel::<()>();
-        db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate1)))).expect("gate1 enqueue");
+        let (release, gate1_reached, gate1) = writer_gate();
+        let (release2, gate2_reached, gate2) = writer_gate();
+        db.tx.send(DBMessage::Insert(Box::new(gate1))).expect("gate1 enqueue");
         db.insert::<TestTable>(&1, &"one".to_string()).expect("insert k1");
-        db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate2)))).expect("gate2 enqueue");
+        db.tx.send(DBMessage::Insert(Box::new(gate2))).expect("gate2 enqueue");
         db.remove::<TestTable>(&1).expect("remove k1");
         db.insert::<TestTable>(&2, &"two".to_string()).expect("insert k2");
 
-        // Let the writer drain past K1's insert, then park again: K1's tombstone and K2's row are
-        // both in flight (count > 0), so eviction (run at every apply) must not drop anything even
-        // though the cache holds 2 rows against a cap of 1.
+        // Let the writer drain past K1's insert, then wait until it parks at gate2: K1's tombstone
+        // and K2's row are both in flight (count > 0), so eviction (run at every apply) must not
+        // drop anything even though the cache holds 2 rows against a cap of 1. Gate messages are
+        // processed in enqueue order, so gate2 being reached proves gate1 was drained.
         drop(release);
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        let _ = gate1_reached.recv().expect("writer drains past gate1");
+        let _ = gate2_reached.recv().expect("writer parks at gate2");
         assert_eq!(
             db.mem_db.mem_size(),
             2,

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -887,6 +887,12 @@ impl<DB: Database> LayeredDatabase<DB> {
     /// Opens the layered DB with a custom eviction policy: small caches in tests, the default in
     /// production.
     pub fn open_with_config(db: DB, config: CacheConfig) -> Self {
+        // This channel must always remain unbounded. This is necessary for the atomicity
+        // guarantee (mem mutation + enqueue in one critical section). It is safe today because
+        // mpsc::channel() is unbounded and send() never blocks. However, if the channel is ever
+        // changed to a bounded sync_channel (for backpressure), the producer would block with the
+        // write lock held while the writer thread is blocked trying to acquire the same lock to
+        // process the ops — a classic deadlock.
         let (tx, rx) = mpsc::channel();
         let depth = Arc::new(AtomicUsize::new(0));
         let db_cloned = db.clone();

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -21,7 +21,7 @@ use crate::{
     tables::ColdBatchLocations,
 };
 
-use crate::mem_db::{EvictionHeap, MemDatabase, MemDbTx, MemDbTxMut};
+use crate::mem_db::{EvictionHeap, EvictionStats, MemDatabase, MemDbTx, MemDbTxMut};
 use prometheus::{default_registry, register_int_gauge_with_registry, IntGauge, Registry};
 use rayls_infrastructure_types::{
     decode_key, encode, encode_key, DBIter, DBRawIter, Database, DbTx, DbTxMut, Table,
@@ -651,6 +651,10 @@ impl<DB: Database> DeferredOp<DB> {
 const QUEUE_HIGH_WATER_MARK: usize = 10_000;
 const QUEUE_LAG_WARN_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Cadence of the mem cache occupancy heartbeat in `db_run`: one `info` line per interval with
+/// the cache size, its cap, the writer queue depth and the open write txn count.
+const OCCUPANCY_LOG_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Pause paid by each insert/remove/clear enqueue while the queue is above
 /// [`QUEUE_HIGH_WATER_MARK`].
 ///
@@ -741,6 +745,24 @@ fn log_persist_latency(elapsed: Duration, depth: usize) {
     }
 }
 
+/// Runs one eviction pass and logs its outcome at `info`: the cache size before and after and
+/// the number of rows evicted, plus the open write transactions observed at that moment.
+/// Eviction only runs once no producer txn is open, so `open_txns` is normally 0 except at a
+/// `CaughtUp` barrier.
+fn evict_and_log(mem_db: &MemDatabase, heap: &mut EvictionHeap, max_size: usize, open_txns: usize) {
+    let EvictionStats { before, after, evicted } = mem_db.evict_if_needed(heap, max_size);
+    if evicted > 0 {
+        tracing::debug!(
+            target: "storage",
+            before,
+            after,
+            evicted,
+            open_txns,
+            "mem cache evicted"
+        );
+    }
+}
+
 fn db_run<DB: Database>(
     db: DB,
     mem_db: MemDatabase,
@@ -750,6 +772,7 @@ fn db_run<DB: Database>(
 ) {
     let mut txn = None;
     let mut last_compact = Instant::now();
+    let mut last_occupancy_log = Instant::now();
     let queue_depth_gauge = writer_queue_depth_gauge();
     let mut last_lag_warn: Option<Instant> = None;
 
@@ -791,7 +814,12 @@ fn db_run<DB: Database>(
                                 for op in committed_ops.drain(..) {
                                     op.on_applied(&mem_db, &mut eviction_heap);
                                 }
-                                mem_db.evict_if_needed(&mut eviction_heap, max_size);
+                                evict_and_log(
+                                    &mem_db,
+                                    &mut eviction_heap,
+                                    max_size,
+                                    txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
+                                );
                             }
                             // The txn's rows stay in mem with their in-flight counts, so a failed
                             // commit is retained (not lost, not evictable) and surfaced via
@@ -822,7 +850,12 @@ fn db_run<DB: Database>(
                     pending_write_error = Some(format!("insert: {e}"));
                 } else {
                     ins.on_applied(&mem_db, &mut eviction_heap);
-                    mem_db.evict_if_needed(&mut eviction_heap, max_size);
+                    evict_and_log(
+                        &mem_db,
+                        &mut eviction_heap,
+                        max_size,
+                        txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
+                    );
                 }
             }
             DBMessage::Remove(rm) => {
@@ -838,7 +871,12 @@ fn db_run<DB: Database>(
                     pending_write_error = Some(format!("remove: {e}"));
                 } else {
                     rm.on_applied(&mem_db, &mut eviction_heap);
-                    mem_db.evict_if_needed(&mut eviction_heap, max_size);
+                    evict_and_log(
+                        &mem_db,
+                        &mut eviction_heap,
+                        max_size,
+                        txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
+                    );
                 }
             }
             DBMessage::Clear(clr) => {
@@ -854,13 +892,23 @@ fn db_run<DB: Database>(
                     pending_write_error = Some(format!("clear: {e}"));
                 } else {
                     clr.on_applied(&mem_db, &mut eviction_heap);
-                    mem_db.evict_if_needed(&mut eviction_heap, max_size);
+                    evict_and_log(
+                        &mem_db,
+                        &mut eviction_heap,
+                        max_size,
+                        txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
+                    );
                 }
             }
             // NOTE: proves prior messages were applied, not that an open shared txn committed.
             // Safe at shutdown because consensus writers are torn down before persist runs.
             DBMessage::CaughtUp(tx) => {
-                mem_db.evict_if_needed(&mut eviction_heap, max_size);
+                evict_and_log(
+                    &mem_db,
+                    &mut eviction_heap,
+                    max_size,
+                    txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
+                );
                 let reply: Result<(), String> = match pending_write_error.take() {
                     Some(e) => Err(e),
                     None => Ok(()),
@@ -868,6 +916,17 @@ fn db_run<DB: Database>(
                 let _ = tx.send(reply);
             }
             DBMessage::Shutdown => break,
+        }
+        if last_occupancy_log.elapsed() >= OCCUPANCY_LOG_INTERVAL {
+            last_occupancy_log = Instant::now();
+            tracing::info!(
+                target: "storage",
+                occupancy = mem_db.mem_size(),
+                max = max_size,
+                queue = queued,
+                open_txns = txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
+                "mem cache occupancy"
+            );
         }
         if last_compact.elapsed() > Duration::from_secs(86_400) {
             last_compact = Instant::now();

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1976,9 +1976,6 @@ mod test {
         let count = db.iter::<TestTable>().count();
         assert_eq!(count, 101, "Expected 101 items after clear+insert, got {}", count);
 
-        // Verify no items are incorrectly marked as deleted
-        let deleted_keys = db.mem_db.get_deleted_keys::<TestTable>();
-        assert!(deleted_keys.is_empty(), "Expected no deleted keys, found {}", deleted_keys.len());
     }
 
     #[test]

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -761,7 +761,8 @@ fn db_run<DB: Database>(
                                 mem_db.evict_if_needed(&mut eviction_heap, max_size);
                             }
                             // The txn's rows stay in mem with their in-flight counts, so a failed
-                            // commit is retained (not lost, not evictable) and surfaced via persist.
+                            // commit is retained (not lost, not evictable) and surfaced via
+                            // persist.
                             Err(e) => {
                                 committed_ops.clear();
                                 tracing::error!(target: "layered_db_runner", "consensus DB commit failed: {e}");
@@ -1600,181 +1601,196 @@ mod test {
     }
 
     /// Insert a burst of keys into a tiny cache and confirm the writer evicts settled keys in
-/// recency order until the cache fits `max_size`, with the newest rows surviving in mem.
-#[test]
-fn eviction_keeps_cache_at_max_size_and_evicts_oldest_settled() {
-    let inner = MemDatabase::new();
-    inner.open_table::<TestTable>().expect("open inner table");
-    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 3 });
-    db.open_table::<TestTable>().expect("open layered table");
+    /// recency order until the cache fits `max_size`, with the newest rows surviving in mem.
+    #[test]
+    fn eviction_keeps_cache_at_max_size_and_evicts_oldest_settled() {
+        let inner = MemDatabase::new();
+        inner.open_table::<TestTable>().expect("open inner table");
+        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 3 });
+        db.open_table::<TestTable>().expect("open layered table");
 
-    for i in 0..10u64 {
-        db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
+        for i in 0..10u64 {
+            db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
+        }
+        db.sync_persist();
+
+        assert_eq!(db.mem_db.mem_size(), 3, "cache must be trimmed to max_size");
+        // The newest rows survive hot; older ones fall through to the persistent tier.
+        for i in 0..10u64 {
+            assert_eq!(
+                db.get::<TestTable>(&i).unwrap().as_deref(),
+                Some(format!("v{i}").as_str()),
+                "every key must still be readable after eviction"
+            );
+        }
+        for i in 7..10u64 {
+            assert!(
+                db.mem_db.contains_key::<TestTable>(&i).unwrap(),
+                "newest key {i} must stay hot"
+            );
+        }
+        for i in 0..7u64 {
+            assert!(
+                !db.mem_db.contains_key::<TestTable>(&i).unwrap(),
+                "settled key {i} must be evicted"
+            );
+        }
     }
-    db.sync_persist();
 
-    assert_eq!(db.mem_db.mem_size(), 3, "cache must be trimmed to max_size");
-    // The newest rows survive hot; older ones fall through to the persistent tier.
-    for i in 0..10u64 {
+    /// A tombstone whose remove is still queued must not be evicted, even when the cache is over
+    /// its cap: the row shields reads from the persistent tier until the delete lands. Once the
+    /// remove applies, the tombstone settles and becomes an eviction candidate.
+    #[test]
+    fn eviction_waits_for_in_flight_ops() {
+        let inner = MemDatabase::new();
+        inner.open_table::<TestTable>().expect("open inner table");
+        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
+        db.open_table::<TestTable>().expect("open layered table");
+
+        // Two gates park the writer mid-drain so the in-flight window is observable.
+        let (release, gate1) = std::sync::mpsc::channel::<()>();
+        let (release2, gate2) = std::sync::mpsc::channel::<()>();
+        db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate1)))).expect("gate1 enqueue");
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert k1");
+        db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate2)))).expect("gate2 enqueue");
+        db.remove::<TestTable>(&1).expect("remove k1");
+        db.insert::<TestTable>(&2, &"two".to_string()).expect("insert k2");
+
+        // Let the writer drain past K1's insert, then park again: K1's tombstone and K2's row are
+        // both in flight (count > 0), so eviction (run at every apply) must not drop anything even
+        // though the cache holds 2 rows against a cap of 1.
+        drop(release);
+        std::thread::sleep(std::time::Duration::from_millis(100));
         assert_eq!(
-            db.get::<TestTable>(&i).unwrap().as_deref(),
-            Some(format!("v{i}").as_str()),
-            "every key must still be readable after eviction"
+            db.mem_db.mem_size(),
+            2,
+            "in-flight rows must not be evicted while ops are queued"
+        );
+        assert!(
+            db.mem_db.is_tombstoned::<TestTable>(&1),
+            "K1's tombstone must survive while queued"
+        );
+        drop(release2);
+        db.sync_persist();
+
+        // The remove applied, so K1's settled tombstone is now evictable; only K2 stays hot.
+        assert_eq!(db.mem_db.mem_size(), 1, "settled rows must be trimmed to max_size");
+        assert!(
+            !db.mem_db.is_tombstoned::<TestTable>(&1),
+            "K1 tombstone must be evicted post-apply"
+        );
+        assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "K2 must stay hot");
+        assert_eq!(db.get::<TestTable>(&1).unwrap(), None, "K1 is durably removed");
+        assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("two".to_string()));
+    }
+
+    /// A tombstone for a key that was never in the cache (deleted from the persistent tier only)
+    /// must not leak: it settles when the remove applies and is evicted like any other row.
+    #[test]
+    fn removed_never_inserted_tombstone_is_evicted() {
+        let inner = MemDatabase::new();
+        inner.open_table::<TestTable>().expect("open inner table");
+        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
+        db.open_table::<TestTable>().expect("open layered table");
+
+        db.remove::<TestTable>(&999).expect("remove never-inserted key");
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+        db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
+        db.sync_persist();
+
+        assert_eq!(db.get::<TestTable>(&999).unwrap(), None);
+        assert!(!db.mem_db.is_tombstoned::<TestTable>(&999), "stray tombstone must be evicted");
+        assert_eq!(db.mem_db.mem_size(), 1, "cache must be trimmed");
+    }
+
+    /// A `clear_table` tombstones every cached row and holds them (in flight) until the persistent
+    /// clear lands; only then are the tombstones released and evicted.
+    #[test]
+    fn clear_tombstones_are_held_until_the_persistent_clear_lands() {
+        let inner = MemDatabase::new();
+        inner.open_table::<TestTable>().expect("open inner table");
+        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
+        db.open_table::<TestTable>().expect("open layered table");
+
+        db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
+        db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
+        db.insert::<TestTable>(&3, &"three".to_string()).expect("insert");
+        db.clear_table::<TestTable>().expect("clear");
+        db.insert::<TestTable>(&4, &"four".to_string()).expect("insert");
+        db.sync_persist();
+
+        assert_eq!(db.get::<TestTable>(&1).unwrap(), None);
+        assert_eq!(db.get::<TestTable>(&2).unwrap(), None);
+        assert_eq!(db.get::<TestTable>(&3).unwrap(), None);
+        assert_eq!(db.get::<TestTable>(&4).unwrap(), Some("four".to_string()));
+        assert_eq!(db.mem_db.mem_size(), 2, "cleared tombstones settle and are evicted");
+    }
+
+    /// Reading a hot key refreshes its recency (lock-free, throttled), so it survives eviction over
+    /// a sibling that settled at the same time but was never read since.
+    #[test]
+    fn read_recency_protects_a_hot_key() {
+        let inner = MemDatabase::new();
+        inner.open_table::<TestTable>().expect("open inner table");
+        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
+        db.open_table::<TestTable>().expect("open layered table");
+
+        for i in 1..=3u64 {
+            db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
+        }
+        db.sync_persist();
+        // 1 settled first and was evicted; 2 and 3 are hot.
+        assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap());
+        assert!(db.mem_db.contains_key::<TestTable>(&3).unwrap());
+
+        // Cross the recency throttle window, then read key 2: its clock bumps.
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("v2".to_string()));
+
+        // Overflow the cache: without the read bump, key 2 (settled first) would be evicted.
+        db.insert::<TestTable>(&4, &"v4".to_string()).expect("insert");
+        db.sync_persist();
+
+        assert_eq!(db.mem_db.mem_size(), 2);
+        assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "read key must stay hot");
+        assert!(db.mem_db.contains_key::<TestTable>(&4).unwrap(), "newest key must stay hot");
+        assert!(
+            !db.mem_db.contains_key::<TestTable>(&3).unwrap(),
+            "unread sibling must be evicted"
         );
     }
-    for i in 7..10u64 {
-        assert!(db.mem_db.contains_key::<TestTable>(&i).unwrap(), "newest key {i} must stay hot");
+
+    /// Remove-then-reinsert of the same key must not leak its in-flight count: the remove's apply
+    /// is skipped by the re-insert guard, but it still settles, so the row stays evictable.
+    #[test]
+    fn guard_skipped_remove_still_settles() {
+        let inner = MemDatabase::new();
+        inner.open_table::<TestTable>().expect("open inner table");
+        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
+        db.open_table::<TestTable>().expect("open layered table");
+
+        db.insert::<TestTable>(&1, &"v1".to_string()).expect("insert");
+        db.remove::<TestTable>(&1).expect("remove");
+        db.insert::<TestTable>(&1, &"v3".to_string()).expect("reinsert");
+        db.insert::<TestTable>(&2, &"v2".to_string()).expect("insert");
+        db.insert::<TestTable>(&3, &"v3".to_string()).expect("insert");
+        db.sync_persist();
+
+        assert_eq!(db.get::<TestTable>(&1).unwrap(), Some("v3".to_string()));
+        assert_eq!(db.mem_db.mem_size(), 1, "no in-flight leak: the row is evictable");
     }
-    for i in 0..7u64 {
-        assert!(!db.mem_db.contains_key::<TestTable>(&i).unwrap(), "settled key {i} must be evicted");
-    }
-}
 
-/// A tombstone whose remove is still queued must not be evicted, even when the cache is over its
-/// cap: the row shields reads from the persistent tier until the delete lands. Once the remove
-/// applies, the tombstone settles and becomes an eviction candidate.
-#[test]
-fn eviction_waits_for_in_flight_ops() {
-    let inner = MemDatabase::new();
-    inner.open_table::<TestTable>().expect("open inner table");
-    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
-    db.open_table::<TestTable>().expect("open layered table");
-
-    // Two gates park the writer mid-drain so the in-flight window is observable.
-    let (release, gate1) = std::sync::mpsc::channel::<()>();
-    let (release2, gate2) = std::sync::mpsc::channel::<()>();
-    db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate1)))).expect("gate1 enqueue");
-    db.insert::<TestTable>(&1, &"one".to_string()).expect("insert k1");
-    db.tx.send(DBMessage::Insert(Box::new(WriterGate(gate2)))).expect("gate2 enqueue");
-    db.remove::<TestTable>(&1).expect("remove k1");
-    db.insert::<TestTable>(&2, &"two".to_string()).expect("insert k2");
-
-    // Let the writer drain past K1's insert, then park again: K1's tombstone and K2's row are
-    // both in flight (count > 0), so eviction (run at every apply) must not drop anything even
-    // though the cache holds 2 rows against a cap of 1.
-    drop(release);
-    std::thread::sleep(std::time::Duration::from_millis(100));
-    assert_eq!(
-        db.mem_db.mem_size(),
-        2,
-        "in-flight rows must not be evicted while ops are queued"
-    );
-    assert!(db.mem_db.is_tombstoned::<TestTable>(&1), "K1's tombstone must survive while queued");
-    drop(release2);
-    db.sync_persist();
-
-    // The remove applied, so K1's settled tombstone is now evictable; only K2 stays hot.
-    assert_eq!(db.mem_db.mem_size(), 1, "settled rows must be trimmed to max_size");
-    assert!(!db.mem_db.is_tombstoned::<TestTable>(&1), "K1 tombstone must be evicted post-apply");
-    assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "K2 must stay hot");
-    assert_eq!(db.get::<TestTable>(&1).unwrap(), None, "K1 is durably removed");
-    assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("two".to_string()));
-}
-
-/// A tombstone for a key that was never in the cache (deleted from the persistent tier only)
-/// must not leak: it settles when the remove applies and is evicted like any other row.
-#[test]
-fn removed_never_inserted_tombstone_is_evicted() {
-    let inner = MemDatabase::new();
-    inner.open_table::<TestTable>().expect("open inner table");
-    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
-    db.open_table::<TestTable>().expect("open layered table");
-
-    db.remove::<TestTable>(&999).expect("remove never-inserted key");
-    db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
-    db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
-    db.sync_persist();
-
-    assert_eq!(db.get::<TestTable>(&999).unwrap(), None);
-    assert!(!db.mem_db.is_tombstoned::<TestTable>(&999), "stray tombstone must be evicted");
-    assert_eq!(db.mem_db.mem_size(), 1, "cache must be trimmed");
-}
-
-/// A `clear_table` tombstones every cached row and holds them (in flight) until the persistent
-/// clear lands; only then are the tombstones released and evicted.
-#[test]
-fn clear_tombstones_are_held_until_the_persistent_clear_lands() {
-    let inner = MemDatabase::new();
-    inner.open_table::<TestTable>().expect("open inner table");
-    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
-    db.open_table::<TestTable>().expect("open layered table");
-
-    db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
-    db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
-    db.insert::<TestTable>(&3, &"three".to_string()).expect("insert");
-    db.clear_table::<TestTable>().expect("clear");
-    db.insert::<TestTable>(&4, &"four".to_string()).expect("insert");
-    db.sync_persist();
-
-    assert_eq!(db.get::<TestTable>(&1).unwrap(), None);
-    assert_eq!(db.get::<TestTable>(&2).unwrap(), None);
-    assert_eq!(db.get::<TestTable>(&3).unwrap(), None);
-    assert_eq!(db.get::<TestTable>(&4).unwrap(), Some("four".to_string()));
-    assert_eq!(db.mem_db.mem_size(), 2, "cleared tombstones settle and are evicted");
-}
-
-/// Reading a hot key refreshes its recency (lock-free, throttled), so it survives eviction over
-/// a sibling that settled at the same time but was never read since.
-#[test]
-fn read_recency_protects_a_hot_key() {
-    let inner = MemDatabase::new();
-    inner.open_table::<TestTable>().expect("open inner table");
-    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
-    db.open_table::<TestTable>().expect("open layered table");
-
-    for i in 1..=3u64 {
-        db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
-    }
-    db.sync_persist();
-    // 1 settled first and was evicted; 2 and 3 are hot.
-    assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap());
-    assert!(db.mem_db.contains_key::<TestTable>(&3).unwrap());
-
-    // Cross the recency throttle window, then read key 2: its clock bumps.
-    std::thread::sleep(std::time::Duration::from_millis(150));
-    assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("v2".to_string()));
-
-    // Overflow the cache: without the read bump, key 2 (settled first) would be evicted.
-    db.insert::<TestTable>(&4, &"v4".to_string()).expect("insert");
-    db.sync_persist();
-
-    assert_eq!(db.mem_db.mem_size(), 2);
-    assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "read key must stay hot");
-    assert!(db.mem_db.contains_key::<TestTable>(&4).unwrap(), "newest key must stay hot");
-    assert!(!db.mem_db.contains_key::<TestTable>(&3).unwrap(), "unread sibling must be evicted");
-}
-
-/// Remove-then-reinsert of the same key must not leak its in-flight count: the remove's apply
-/// is skipped by the re-insert guard, but it still settles, so the row stays evictable.
-#[test]
-fn guard_skipped_remove_still_settles() {
-    let inner = MemDatabase::new();
-    inner.open_table::<TestTable>().expect("open inner table");
-    let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 1 });
-    db.open_table::<TestTable>().expect("open layered table");
-
-    db.insert::<TestTable>(&1, &"v1".to_string()).expect("insert");
-    db.remove::<TestTable>(&1).expect("remove");
-    db.insert::<TestTable>(&1, &"v3".to_string()).expect("reinsert");
-    db.insert::<TestTable>(&2, &"v2".to_string()).expect("insert");
-    db.insert::<TestTable>(&3, &"v3".to_string()).expect("insert");
-    db.sync_persist();
-
-    assert_eq!(db.get::<TestTable>(&1).unwrap(), Some("v3".to_string()));
-    assert_eq!(db.mem_db.mem_size(), 1, "no in-flight leak: the row is evictable");
-}
-
-#[test]
-fn test_layereddb_contains_key() {
-    let temp_dir = tempdir().expect("failed to create temp dir");
-    #[cfg(feature = "redb")]
-    {
-        let db = open_redb(temp_dir.path());
+    #[test]
+    fn test_layereddb_contains_key() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        #[cfg(feature = "redb")]
+        {
+            let db = open_redb(temp_dir.path());
+            test_contains_key(db);
+        }
+        let db = open_mdbx(temp_dir.path());
         test_contains_key(db);
     }
-    let db = open_mdbx(temp_dir.path());
-    test_contains_key(db);
-}
 
     #[test]
     fn test_layereddb_get() {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,8 +38,6 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
-
-
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
     store: RwLockReadGuard<'a, StoreType>,
@@ -379,6 +377,16 @@ impl MemDatabase {
         Self { store, metrics, shutdown_tx: Arc::new(shutdown_tx) }
     }
 
+    /// Infallible read transaction; [`Database::read_txn`] wraps this.
+    fn read_txn_impl(&self) -> MemDbTx<'_> {
+        MemDbTx { store: self.store.read() }
+    }
+
+    /// Infallible write transaction; [`Database::write_txn`] wraps this.
+    fn write_txn_impl(&self) -> MemDbTxMut<'_> {
+        MemDbTxMut { store: self.store.write() }
+    }
+
     // gets the value with the marking for delete flag
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
         if let Some(table) = self.store.read().get(T::NAME) {
@@ -488,11 +496,11 @@ impl Database for MemDatabase {
     }
 
     fn read_txn(&self) -> eyre::Result<Self::TX<'_>> {
-        Ok(MemDbTx { store: self.store.read() })
+        Ok(self.read_txn_impl())
     }
 
     fn write_txn(&self) -> eyre::Result<MemDbTxMut<'_>> {
-        Ok(MemDbTxMut { store: self.store.write() })
+        Ok(self.write_txn_impl())
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
@@ -506,7 +514,7 @@ impl Database for MemDatabase {
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
-        self.read_txn()?.get::<T>(key)
+        self.read_txn_impl().get::<T>(key)
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
@@ -519,11 +527,11 @@ impl Database for MemDatabase {
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
-        self.write_txn()?.remove::<T>(key)
+        self.write_txn_impl().remove::<T>(key)
     }
 
     fn clear_table<T: Table>(&self) -> eyre::Result<()> {
-        self.write_txn()?.clear_table::<T>()
+        self.write_txn_impl().clear_table::<T>()
     }
 
     fn is_empty<T: Table>(&self) -> bool {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -84,6 +84,7 @@ impl StoreEntry {
     }
 
     fn dec_in_flight(&mut self) {
+        debug_assert!(self.in_flight() == 0, "in-flight op count is 0 before decrementing it");
         self.packed -= 2;
     }
 
@@ -107,7 +108,7 @@ impl StoreEntry {
 /// Only the background writer pushes (when a key's in-flight count settles to zero) and pops
 /// (during eviction), so no lock guards it. Entries go stale when the key is re-inserted or the
 /// table is cleared; they are validated at pop under the store write lock and skipped.
-pub type EvictionHeap = BinaryHeap<Reverse<(u64, &'static str, Vec<u8>)>>;
+pub(crate) type EvictionHeap = BinaryHeap<Reverse<(u64, &'static str, Vec<u8>)>>;
 
 type StoreTableType = BTreeMap<Vec<u8>, StoreEntry>;
 type StoreType = HashMap<&'static str, StoreTableType>;

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -88,7 +88,7 @@ impl StoreEntry {
     }
 
     /// Refreshes the recency clock if the previous bump is older than the throttle window.
-    fn bump_last_used(&self) {
+    fn touch_approximately(&self) {
         let now = now_nanos();
         let last = self.last_used.load(AtomicOrdering::Relaxed);
         if now.saturating_sub(last) >= RECENCY_BUMP_THRESHOLD.as_nanos() as u64 {
@@ -123,7 +123,7 @@ impl<'a> MemDbTx<'a> {
             let key_bytes = encode_key(key);
             if let Some(entry) = table.get(&key_bytes) {
                 if !entry.tombstoned() {
-                    entry.bump_last_used();
+                    entry.touch_approximately();
                 }
                 let val = decode(&entry.value);
                 return Some((entry.tombstoned(), val));
@@ -217,10 +217,7 @@ impl<'a> MemDbTxMut<'a> {
     /// Raw keys of the table, for a `Clear` message: the writer needs the exact set that was
     /// tombstoned (and counted) by this clear to release each key's in-flight op at apply time.
     pub fn raw_keys<T: Table>(&self) -> Vec<Vec<u8>> {
-        self.store
-            .get(T::NAME)
-            .map(|table| table.keys().cloned().collect())
-            .unwrap_or_default()
+        self.store.get(T::NAME).map(|table| table.keys().cloned().collect()).unwrap_or_default()
     }
 }
 
@@ -457,11 +454,7 @@ impl MemDatabase {
     /// Returns keys marked for deletion in the given table.
     pub fn get_deleted_keys<T: Table>(&self) -> std::collections::HashSet<Vec<u8>> {
         if let Some(table) = self.store.read().get(T::NAME) {
-            table
-                .iter()
-                .filter(|(_, entry)| entry.tombstoned())
-                .map(|(k, _)| k.clone())
-                .collect()
+            table.iter().filter(|(_, entry)| entry.tombstoned()).map(|(k, _)| k.clone()).collect()
         } else {
             std::collections::HashSet::new()
         }
@@ -649,7 +642,11 @@ impl Default for MemDBMetrics {
 
 /// Mutate + count a row: value replaced, tombstone cleared, one in-flight op registered, recency
 /// touched. Shared by the txn producers (guard already held) and the `*_queued` entry points.
-fn insert_impl<T: Table>(store: &mut StoreType, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
+fn insert_impl<T: Table>(
+    store: &mut StoreType,
+    key: &T::Key,
+    value: &T::Value,
+) -> eyre::Result<()> {
     let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
     let key_bytes = encode_key(key);
     match table.get_mut(&key_bytes) {
@@ -708,7 +705,7 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
         let key_bytes = encode_key(key);
         if let Some(entry) = table.get(&key_bytes) {
             if !entry.tombstoned() {
-                entry.bump_last_used();
+                entry.touch_approximately();
                 let val = decode(&entry.value);
                 return Some(val);
             }
@@ -724,7 +721,7 @@ fn contains_key_impl<T: Table>(store: &StoreType, key: &T::Key) -> bool {
             if entry.tombstoned() {
                 return false;
             }
-            entry.bump_last_used();
+            entry.touch_approximately();
             return true;
         }
     }

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,6 +38,27 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
+fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(
+        table
+            .iter()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+            .collect(),
+    )
+}
+
+fn raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(Box::new(
+        table
+            .iter()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    ))
+}
+
 fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
     let key_bytes = encode_key(key);
@@ -117,30 +138,16 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            Box::new(std::iter::empty())
+        match iter_impl::<T>(&self.store) {
+            Some(items) => Box::new(items.into_iter()),
+            None => Box::new(std::iter::empty()),
         }
     }
 
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.get(T::NAME) {
-            // The read guard is held by `self`, so we can borrow the stored
-            // bytes for the iterator's lifetime instead of cloning them.
-            Box::new(
-                table
-                    .iter()
-                    .filter(|(_, (tombstoned, _))| !*tombstoned)
-                    .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-            )
-        } else {
-            Box::new(std::iter::empty())
+        match raw_iter_impl::<T>(&self.store) {
+            Some(iter) => iter,
+            None => Box::new(std::iter::empty()),
         }
     }
 
@@ -530,15 +537,9 @@ impl Database for MemDatabase {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match iter_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -451,15 +451,6 @@ impl MemDatabase {
     pub fn mem_size(&self) -> usize {
         self.store.read().values().map(|table| table.len()).sum()
     }
-
-    /// Returns keys marked for deletion in the given table.
-    pub fn get_deleted_keys<T: Table>(&self) -> std::collections::HashSet<Vec<u8>> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            table.iter().filter(|(_, entry)| entry.tombstoned()).map(|(k, _)| k.clone()).collect()
-        } else {
-            std::collections::HashSet::new()
-        }
-    }
 }
 
 impl Drop for MemDatabase {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -70,6 +70,16 @@ impl<'a> DbTx for MemDbTx<'a> {
         Ok(get_with_marked_check::<T>(&self.store, key))
     }
 
+    fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
+        if let Some(table) = self.store.get(T::NAME) {
+            let key_bytes = encode_key(key);
+            if let Some((tombstoned, _)) = table.get(&key_bytes) {
+                return Ok(!*tombstoned);
+            }
+        }
+        Ok(false)
+    }
+
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
         if let Some(table) = self.store.get(T::NAME) {
             let items: Vec<_> = table
@@ -504,13 +514,7 @@ impl Database for MemDatabase {
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((removed, _)) = table.get(&key_bytes) {
-                return Ok(!*removed);
-            }
-        }
-        Ok(false)
+        self.read_txn_impl().contains_key::<T>(key)
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,10 +38,7 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
-fn mark_value_for_deletion<T: Table>(value: &mut StoreTableValueType) {
-    // mark for actual deletion once tx committed
-    value.0 = true;
-}
+
 
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
@@ -181,6 +178,11 @@ pub struct MemDbTxMut<'a> {
 }
 
 impl<'a> MemDbTxMut<'a> {
+    fn mark_value_for_deletion(value: &mut StoreTableValueType) {
+        // mark for actual deletion once tx committed
+        value.0 = true;
+    }
+
     /// Hard-removes `key` from the in-memory store, leaving no tombstone.
     ///
     /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
@@ -310,7 +312,7 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             let key_bytes = encode_key(key);
             if let Some(value) = table.get_mut(&key_bytes) {
-                mark_value_for_deletion::<T>(value);
+                Self::mark_value_for_deletion(value);
             } else {
                 // tombstone for keys that only exist in the persistent layer
                 table.insert(key_bytes, (true, Vec::new()));
@@ -324,7 +326,7 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
     fn clear_table<T: Table>(&mut self) -> eyre::Result<()> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             for value in table.values_mut() {
-                mark_value_for_deletion::<T>(value);
+                Self::mark_value_for_deletion(value);
             }
             Ok(())
         } else {
@@ -504,7 +506,7 @@ impl Database for MemDatabase {
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
-        Ok(get_with_marked_check::<T>(&self.store.read(), key))
+        self.read_txn()?.get::<T>(key)
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
@@ -517,26 +519,11 @@ impl Database for MemDatabase {
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some(value) = table.get_mut(&key_bytes) {
-                mark_value_for_deletion::<T>(value);
-            } else {
-                // tombstone for keys that only exist in the persistent layer
-                table.insert(key_bytes, (true, Vec::new()));
-            }
-        }
-        Ok(())
+        self.write_txn()?.remove::<T>(key)
     }
 
     fn clear_table<T: Table>(&self) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            //mark all for deletion
-            for value in table.values_mut() {
-                mark_value_for_deletion::<T>(value);
-            }
-        }
-        Ok(())
+        self.write_txn()?.clear_table::<T>()
     }
 
     fn is_empty<T: Table>(&self) -> bool {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -298,7 +298,7 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             let key_bytes = encode_key(key);
             let value_bytes = encode(value);
-            table.insert(key_bytes.clone(), (false, value_bytes));
+            table.insert(key_bytes, (false, value_bytes));
 
             Ok(())
         } else {
@@ -518,12 +518,7 @@ impl Database for MemDatabase {
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            let value_bytes = encode(value);
-            table.insert(key_bytes, (false, value_bytes));
-        }
-        Ok(())
+        self.write_txn_impl().insert::<T>(key, value)
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -4,7 +4,6 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
-    marker::PhantomData,
     sync::{
         mpsc::{self, SyncSender},
         Arc,
@@ -12,7 +11,6 @@ use std::{
     time::Duration,
 };
 
-use ouroboros::self_referencing;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use prometheus::{default_registry, register_int_gauge_with_registry, IntGauge, Registry};
 use rayls_infrastructure_types::{
@@ -58,13 +56,7 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((tombstoned, _)) = table.get(&key_bytes) {
-                return Ok(!*tombstoned);
-            }
-        }
-        Ok(false)
+        Ok(contains_key_impl::<T>(&self.store, key))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
@@ -140,6 +132,10 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
         //if not in cache check store
         Ok(get_with_marked_check::<T>(&self.store, key))
+    }
+
+    fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
+        Ok(contains_key_impl::<T>(&self.store, key))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
@@ -478,44 +474,6 @@ impl Database for MemDatabase {
     }
 }
 
-#[self_referencing]
-struct TabAndGuard<T>
-where
-    T: Table,
-{
-    casper: PhantomData<T>,
-    table: Arc<BTreeMap<Vec<u8>, Vec<u8>>>,
-    #[borrows(table)]
-    #[covariant]
-    guard: RwLockReadGuard<'this, BTreeMap<Vec<u8>, Vec<u8>>>,
-}
-
-#[self_referencing]
-pub struct MemDBIter<T>
-where
-    T: Table,
-{
-    casper: PhantomData<T>,
-    table: TabAndGuard<T>,
-    #[borrows(table)]
-    #[not_covariant]
-    iter: Box<dyn Iterator<Item = (&'this Vec<u8>, &'this Vec<u8>)> + 'this>,
-}
-
-impl<T: Table> Iterator for MemDBIter<T> {
-    type Item = (T::Key, T::Value);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.with_mut(|fields| {
-            fields.iter.next().map(|(key_bytes, value_bytes)| {
-                let key = decode_key(key_bytes);
-                let value = decode(value_bytes);
-                (key, value)
-            })
-        })
-    }
-}
-
 #[derive(Debug)]
 struct MemDBMetrics {
     table_counts: HashMap<&'static str, IntGauge>,
@@ -558,6 +516,16 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
         }
     }
     None
+}
+
+fn contains_key_impl<T: Table>(store: &StoreType, key: &T::Key) -> bool {
+    if let Some(table) = store.get(T::NAME) {
+        let key_bytes = encode_key(key);
+        if let Some((tombstoned, _)) = table.get(&key_bytes) {
+            return !*tombstoned;
+        }
+    }
+    false
 }
 
 fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -415,19 +415,10 @@ impl Database for MemDatabase {
     }
 
     fn is_empty<T: Table>(&self) -> bool {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            // iterate table values and see if any are not marked for deletion
-            let guard = table;
-            for (tombstoned, _) in guard.values() {
-                if !*tombstoned {
-                    return false;
-                }
-            }
-
-            true
-        } else {
-            true
-        }
+        self.store
+            .read()
+            .get(T::NAME)
+            .map_or(true, |table| table.values().all(|(tombstoned, _)| *tombstoned))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -84,7 +84,7 @@ impl StoreEntry {
     }
 
     fn dec_in_flight(&mut self) {
-        debug_assert!(self.in_flight() == 0, "in-flight op count is 0 before decrementing it");
+        debug_assert!(self.in_flight() != 0, "in-flight op count is 0 before decrementing it");
         self.packed -= 2;
     }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -28,8 +28,8 @@ type StoreType = HashMap<&'static str, StoreTableType>;
 fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
     if let Some(table) = store.get(T::NAME) {
         let key_bytes = encode_key(key);
-        if let Some((removed, val_bytes)) = table.get(&key_bytes) {
-            if !*removed {
+        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
+            if !*tombstoned {
                 let val = decode(val_bytes);
                 return Some(val);
             }
@@ -47,10 +47,10 @@ impl<'a> MemDbTx<'a> {
     pub fn get_no_marked_check<T: Table>(&self, key: &T::Key) -> Option<(bool, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map(|(removed, val_bytes)| {
+            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
                 let val = decode(val_bytes);
-                (*removed, val)
-            });
+                return Some((*tombstoned, val));
+            }
         }
         None
     }
@@ -59,7 +59,7 @@ impl<'a> MemDbTx<'a> {
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(removed, _)| *removed);
+            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
         }
         false
     }
@@ -84,7 +84,7 @@ impl<'a> DbTx for MemDbTx<'a> {
         if let Some(table) = self.store.get(T::NAME) {
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -100,7 +100,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             Box::new(
                 table
                     .iter()
-                    .filter(|(_, (removed, _))| !*removed)
+                    .filter(|(_, (tombstoned, _))| !*tombstoned)
                     .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
             )
         } else {
@@ -113,7 +113,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             let key_bytes = encode_key(key);
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .skip_while(|(k, _)| **k < key_bytes)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
@@ -128,7 +128,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             let items: Vec<_> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -143,7 +143,7 @@ impl<'a> DbTx for MemDbTx<'a> {
                 table
                     .iter()
                     .rev()
-                    .filter(|(_, (removed, _))| !*removed)
+                    .filter(|(_, (tombstoned, _))| !*tombstoned)
                     .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
             )
         } else {
@@ -153,8 +153,8 @@ impl<'a> DbTx for MemDbTx<'a> {
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (removed, value_bytes)) in table.iter().rev() {
-                if !*removed {
+            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
+                if !*tombstoned {
                     return Some((decode_key(key_bytes), decode(value_bytes)));
                 }
             }
@@ -170,7 +170,7 @@ impl<'a> DbTx for MemDbTx<'a> {
             table
                 .range(..key_bytes)
                 .rev()
-                .find(|(_, (removed, _))| !*removed)
+                .find(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key(k), decode(v)))
         } else {
             None
@@ -236,7 +236,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
             let key_bytes = encode_key(key);
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .skip_while(|(k, _)| **k < key_bytes)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
@@ -251,7 +251,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
             let items: Vec<_> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -266,7 +266,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
                 table
                     .iter()
                     .rev()
-                    .filter(|(_, (removed, _))| !*removed)
+                    .filter(|(_, (tombstoned, _))| !*tombstoned)
                     .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
             )
         } else {
@@ -276,8 +276,8 @@ impl<'a> DbTx for MemDbTxMut<'a> {
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (removed, value_bytes)) in table.iter().rev() {
-                if !*removed {
+            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
+                if !*tombstoned {
                     return Some((decode_key(key_bytes), decode(value_bytes)));
                 }
             }
@@ -293,7 +293,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
             table
                 .range(..key_bytes)
                 .rev()
-                .find(|(_, (removed, _))| !*removed)
+                .find(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key(k), decode(v)))
         } else {
             None
@@ -399,24 +399,12 @@ impl MemDatabase {
 
     // gets the value with the marking for delete flag
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
-                let val = decode(val_bytes);
-                return Ok(Some((*tombstoned, val)));
-            }
-        }
-
-        Ok(None)
+        Ok(self.read_txn_impl().get_no_marked_check::<T>(key))
     }
 
     /// Check if a key is tombstoned (marked for deletion) without deserializing the value.
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
-        }
-        false
+        self.read_txn_impl().is_tombstoned::<T>(key)
     }
 
     pub fn delete_tombstoned<T: Table>(
@@ -537,8 +525,8 @@ impl Database for MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             // iterate table values and see if any are not marked for deletion
             let guard = table;
-            for (removed, _) in guard.values() {
-                if !*removed {
+            for (tombstoned, _) in guard.values() {
+                if !*tombstoned {
                     return false;
                 }
             }
@@ -553,7 +541,7 @@ impl Database for MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -568,7 +556,7 @@ impl Database for MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
                 .collect();
             Box::new(items.into_iter())
@@ -582,7 +570,7 @@ impl Database for MemDatabase {
             let key_bytes = encode_key(key);
             let items: Vec<_> = table
                 .iter()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .skip_while(|(k, _)| **k < key_bytes)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
@@ -597,7 +585,7 @@ impl Database for MemDatabase {
             let items: Vec<_> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
                 .collect();
             Box::new(items.into_iter())
@@ -611,7 +599,7 @@ impl Database for MemDatabase {
             let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
                 .iter()
                 .rev()
-                .filter(|(_, (removed, _))| !*removed)
+                .filter(|(_, (tombstoned, _))| !*tombstoned)
                 .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
                 .collect();
             Box::new(items.into_iter())
@@ -620,33 +608,12 @@ impl Database for MemDatabase {
         }
     }
 
-    fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            table
-                .range(..key_bytes)
-                .rev()
-                .find(|(_, v)| !v.0)
-                .map(|(k, v)| (decode_key(k), decode(&v.1)))
-        } else {
-            None
-        }
+    fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
+        self.read_txn_impl().last_record::<T>()
     }
 
-    fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            //redo with reverse iter
-            for (key_bytes, marked_value_bytes) in table.iter().rev() {
-                if marked_value_bytes.0 == false {
-                    let key = decode_key(key_bytes);
-                    let value = decode(&marked_value_bytes.1);
-                    return Some((key, value));
-                }
-            }
-            None
-        } else {
-            None
-        }
+    fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
+        self.read_txn_impl().record_prior_to::<T>(key)
     }
 
     /// Execute a write operation with automatic commit/abort.

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -103,29 +103,11 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
-                if !*tombstoned {
-                    return Some((decode_key(key_bytes), decode(value_bytes)));
-                }
-            }
-            None
-        } else {
-            None
-        }
+        last_record_impl::<T>(&self.store)
     }
 
     fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            table
-                .range(..key_bytes)
-                .rev()
-                .find(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key(k), decode(v)))
-        } else {
-            None
-        }
+        record_prior_to_impl::<T>(&self.store, key)
     }
 
     fn disable_long_read_safety(&self) {}
@@ -204,29 +186,11 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn last_record<T: Table>(&self) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
-                if !*tombstoned {
-                    return Some((decode_key(key_bytes), decode(value_bytes)));
-                }
-            }
-            None
-        } else {
-            None
-        }
+        last_record_impl::<T>(&self.store)
     }
 
     fn record_prior_to<T: Table>(&self, key: &T::Key) -> Option<(T::Key, T::Value)> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            table
-                .range(..key_bytes)
-                .rev()
-                .find(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key(k), decode(v)))
-        } else {
-            None
-        }
+        record_prior_to_impl::<T>(&self.store, key)
     }
 
     fn disable_long_read_safety(&self) {}
@@ -376,7 +340,7 @@ impl Drop for MemDatabase {
         // shutdown_tx is a sync sender with no buffer so this should block until the thread
         // reads it and shuts down.
         if let Err(e) = self.shutdown_tx.send(()) {
-            tracing::error!(target: "rayls::memdb", "Error while trying to send shutdown to MemDatabase metrics thread {e}"  );
+            tracing::error!(target: "rayls::memdb", "Error while trying to send shutdown to MemDatabase metrics thread {e}");
         }
     }
 }
@@ -671,6 +635,26 @@ fn reverse_raw_iter_owned_impl<T: Table>(
 ) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
     let table = store.get(T::NAME)?;
     Some(collect_raw_owned(table.iter().rev()))
+}
+
+fn last_record_impl<T: Table>(store: &StoreType) -> Option<(T::Key, T::Value)> {
+    let table = store.get(T::NAME)?;
+    for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
+        if !*tombstoned {
+            return Some((decode_key(key_bytes), decode(value_bytes)));
+        }
+    }
+    None
+}
+
+fn record_prior_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<(T::Key, T::Value)> {
+    let table = store.get(T::NAME)?;
+    let key_bytes = encode_key(key);
+    table
+        .range(..key_bytes)
+        .rev()
+        .find(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (decode_key(k), decode(v)))
 }
 
 #[cfg(test)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -110,8 +110,23 @@ impl StoreEntry {
 /// table is cleared; they are validated at pop under the store write lock and skipped.
 pub(crate) type EvictionHeap = BinaryHeap<Reverse<(u64, &'static str, Vec<u8>)>>;
 
-type StoreTableType = BTreeMap<Vec<u8>, StoreEntry>;
-type StoreType = HashMap<&'static str, StoreTableType>;
+/// One cached table: the rows plus a flag set while the producer's clear is queued but not yet
+/// applied to the persistent tier. `clearing` is set under the same write lock that enqueues the
+/// `Clear` message, so any reader that sees it is guaranteed the clear will land after all
+/// previously queued ops; it is cleared by the writer once the persistent clear applied.
+#[derive(Debug)]
+struct StoreTable {
+    rows: BTreeMap<Vec<u8>, StoreEntry>,
+    clearing: bool,
+}
+
+impl StoreTable {
+    fn new() -> Self {
+        Self { rows: BTreeMap::new(), clearing: false }
+    }
+}
+
+type StoreType = HashMap<&'static str, StoreTable>;
 
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
@@ -122,7 +137,7 @@ impl<'a> MemDbTx<'a> {
     pub fn get_no_marked_check<T: Table>(&self, key: &T::Key) -> Option<(bool, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            if let Some(entry) = table.get(&key_bytes) {
+            if let Some(entry) = table.rows.get(&key_bytes) {
                 if !entry.tombstoned() {
                     entry.touch_approximately();
                 }
@@ -137,9 +152,15 @@ impl<'a> MemDbTx<'a> {
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).is_some_and(|entry| entry.tombstoned());
+            return table.rows.get(&key_bytes).is_some_and(|entry| entry.tombstoned());
         }
         false
+    }
+
+    /// Whether the table's clear is queued but not yet applied to the persistent tier (see
+    /// [`MemDatabase::is_clearing`]).
+    pub fn is_clearing<T: Table>(&self) -> bool {
+        self.store.get(T::NAME).is_some_and(|table| table.clearing)
     }
 }
 
@@ -211,14 +232,17 @@ impl<'a> MemDbTxMut<'a> {
     /// a lower tier, whereas a tombstone would shadow it and never be reclaimed.
     pub fn hard_delete<T: Table>(&mut self, key: &T::Key) {
         if let Some(table) = self.store.get_mut(T::NAME) {
-            table.remove(&encode_key(key));
+            table.rows.remove(&encode_key(key));
         }
     }
 
     /// Raw keys of the table, for a `Clear` message: the writer needs the exact set that was
     /// tombstoned (and counted) by this clear to release each key's in-flight op at apply time.
     pub fn raw_keys<T: Table>(&self) -> Vec<Vec<u8>> {
-        self.store.get(T::NAME).map(|table| table.keys().cloned().collect()).unwrap_or_default()
+        self.store
+            .get(T::NAME)
+            .map(|table| table.rows.keys().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -233,18 +257,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
-        // if let Some(table) = self.store.get(T::NAME) {
-        //     let items: Vec<_> = table
-        //         .read()
-        //         .iter()
-        //         .filter(|(_, (removed, _))| !*removed)
-        //         .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-        //         .collect();
-        //     Box::new(items.into_iter())
-        // } else {
-        //     Box::new(std::iter::empty())
-        // }
-        //To implement this we need to merge results from cache and store in a temporary vector and
+        // To implement this we need to merge results from cache and store in a temporary vector and
         // return iterator over that. This is not expected to used in a transaction, so
         // should be safe.
         panic!("Should not be called on a tx mut!");
@@ -334,7 +347,7 @@ impl MemDatabase {
                 let read_guard = store_cloned.read();
                 for (key, table) in read_guard.iter() {
                     if let Some(m) = metrics_cloned.read().table_counts.get(key) {
-                        m.set(table.len().try_into().unwrap_or(-1));
+                        m.set(table.rows.len().try_into().unwrap_or(-1));
                     }
                 }
             }
@@ -404,7 +417,7 @@ impl MemDatabase {
     pub fn on_op_applied(&self, table: &'static str, key_bytes: &[u8], heap: &mut EvictionHeap) {
         let mut store = self.store.write();
         let Some(table_map) = store.get_mut(table) else { return };
-        let Some(entry) = table_map.get_mut(key_bytes) else { return };
+        let Some(entry) = table_map.rows.get_mut(key_bytes) else { return };
         entry.dec_in_flight();
         if entry.in_flight() == 0 {
             heap.push(Reverse((
@@ -415,6 +428,42 @@ impl MemDatabase {
         }
     }
 
+    /// Whether the table's clear is queued but not yet applied to the persistent tier.
+    ///
+    /// While set, layered reads must treat every key that is not live in the cache as deleted:
+    /// keys evicted before the clear (or never cached, e.g. right after startup) would otherwise
+    /// fall through to the persistent tier and surface stale pre-clear values. The flag is set
+    /// under the same write lock that enqueues the `Clear` message and cleared by the writer once
+    /// the persistent clear applied, so it is only ever observed while a clear is genuinely
+    /// pending.
+    pub fn is_clearing<T: Table>(&self) -> bool {
+        self.store.read().get(T::NAME).is_some_and(|table| table.clearing)
+    }
+
+    /// Clears the pending-clear flag and releases the in-flight op of every key the clear
+    /// tombstoned, in one critical section: the writer calls this after the persistent clear
+    /// applied, so once it returns the cache matches the (now empty) persistent tier again.
+    ///
+    /// If the persistent clear failed, this is never called: the flag stays set and the table
+    /// keeps reading as empty until a later clear retries and lands (same philosophy as rows
+    /// retained in mem on failure, surfaced by the next persist).
+    pub fn on_clear_applied<T: Table>(&self, keys: &[Vec<u8>], heap: &mut EvictionHeap) {
+        let mut store = self.store.write();
+        let Some(table) = store.get_mut(T::NAME) else { return };
+        table.clearing = false;
+        for key in keys {
+            let Some(entry) = table.rows.get_mut(key) else { continue };
+            entry.dec_in_flight();
+            if entry.in_flight() == 0 {
+                heap.push(Reverse((
+                    entry.last_used.load(AtomicOrdering::Relaxed),
+                    T::NAME,
+                    key.clone(),
+                )));
+            }
+        }
+    }
+
     /// Evicts settled keys (in-flight == 0) in recency order until the cache fits `max_size`.
     /// Candidates are validated at pop: a key re-inserted since its settle, or a row cleared
     /// away, is skipped. A key whose recency was refreshed by a read since it settled is
@@ -422,14 +471,14 @@ impl MemDatabase {
     /// producers never touch it. Every pop removes one entry, so the loop always terminates.
     pub fn evict_if_needed(&self, heap: &mut EvictionHeap, max_size: usize) {
         let mut store = self.store.write();
-        let mut total: usize = store.values().map(|table| table.len()).sum();
+        let mut total: usize = store.values().map(|table| table.rows.len()).sum();
         if total <= max_size {
             return;
         }
         while total > max_size {
             let Some(Reverse((heap_last_used, table, key))) = heap.pop() else { break };
             let Some(table_map) = store.get_mut(table) else { continue };
-            let Some(entry) = table_map.get(&key) else { continue };
+            let Some(entry) = table_map.rows.get(&key) else { continue };
             if entry.in_flight() != 0 {
                 continue;
             }
@@ -441,7 +490,7 @@ impl MemDatabase {
                 heap.push(Reverse((current_last_used, table, key)));
                 continue;
             }
-            table_map.remove(&key);
+            table_map.rows.remove(&key);
             total -= 1;
         }
     }
@@ -449,7 +498,7 @@ impl MemDatabase {
     /// Total rows (live and tombstoned) held in the cache; the writer keeps this at or below the
     /// configured max size.
     pub fn mem_size(&self) -> usize {
-        self.store.read().values().map(|table| table.len()).sum()
+        self.store.read().values().map(|table| table.rows.len()).sum()
     }
 }
 
@@ -490,7 +539,7 @@ impl Database for MemDatabase {
         Self: 'txn;
 
     fn open_table<T: Table>(&self) -> eyre::Result<()> {
-        self.store.write().insert(T::NAME, BTreeMap::new());
+        self.store.write().insert(T::NAME, StoreTable::new());
         match register_int_gauge_with_registry!(
             format!("memdb_{}_count", T::NAME),
             format!("Entries in the {} memory table.", T::NAME),
@@ -541,7 +590,7 @@ impl Database for MemDatabase {
         self.store
             .read()
             .get(T::NAME)
-            .is_none_or(|table| table.values().all(|entry| entry.tombstoned()))
+            .is_none_or(|table| table.rows.values().all(|entry| entry.tombstoned()))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
@@ -641,7 +690,7 @@ fn insert_impl<T: Table>(
 ) -> eyre::Result<()> {
     let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
     let key_bytes = encode_key(key);
-    match table.get_mut(&key_bytes) {
+    match table.rows.get_mut(&key_bytes) {
         Some(entry) => {
             entry.value = encode(value);
             entry.clear_tombstone();
@@ -651,7 +700,7 @@ fn insert_impl<T: Table>(
         None => {
             let mut entry = StoreEntry::new(encode(value));
             entry.add_in_flight();
-            table.insert(key_bytes, entry);
+            table.rows.insert(key_bytes, entry);
         }
     }
     Ok(())
@@ -663,7 +712,7 @@ fn insert_impl<T: Table>(
 fn remove_impl<T: Table>(store: &mut StoreType, key: &T::Key) -> eyre::Result<()> {
     let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
     let key_bytes = encode_key(key);
-    match table.get_mut(&key_bytes) {
+    match table.rows.get_mut(&key_bytes) {
         Some(entry) => {
             entry.mark_tombstone();
             entry.add_in_flight();
@@ -673,7 +722,7 @@ fn remove_impl<T: Table>(store: &mut StoreType, key: &T::Key) -> eyre::Result<()
             let mut entry = StoreEntry::new(Vec::new());
             entry.mark_tombstone();
             entry.add_in_flight();
-            table.insert(key_bytes, entry);
+            table.rows.insert(key_bytes, entry);
         }
     }
     Ok(())
@@ -682,20 +731,26 @@ fn remove_impl<T: Table>(store: &mut StoreType, key: &T::Key) -> eyre::Result<()
 /// Tombstone every row of the table (the persistent clear is deferred) and bump each in-flight
 /// count so no tombstone is evicted before the clear applies. Returns the raw keys, which the
 /// writer needs to release each count once the clear lands.
+///
+/// Also raises the table's `clearing` flag: both callers enqueue the `Clear` message while still
+/// holding the write lock, so a reader that sees the flag can rely on the persistent tier being
+/// wiped shortly; until the writer applies the clear, reads must not fall through to it (keys
+/// evicted from the cache would otherwise surface stale pre-clear values).
 fn clear_table_impl<T: Table>(store: &mut StoreType) -> eyre::Result<Vec<Vec<u8>>> {
     let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
-    let keys: Vec<Vec<u8>> = table.keys().cloned().collect();
-    for entry in table.values_mut() {
+    let keys: Vec<Vec<u8>> = table.rows.keys().cloned().collect();
+    for entry in table.rows.values_mut() {
         entry.mark_tombstone();
         entry.add_in_flight();
     }
+    table.clearing = true;
     Ok(keys)
 }
 
 fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
     if let Some(table) = store.get(T::NAME) {
         let key_bytes = encode_key(key);
-        if let Some(entry) = table.get(&key_bytes) {
+        if let Some(entry) = table.rows.get(&key_bytes) {
             if !entry.tombstoned() {
                 entry.touch_approximately();
                 let val = decode(&entry.value);
@@ -709,7 +764,7 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
 fn contains_key_impl<T: Table>(store: &StoreType, key: &T::Key) -> bool {
     if let Some(table) = store.get(T::NAME) {
         let key_bytes = encode_key(key);
-        if let Some(entry) = table.get(&key_bytes) {
+        if let Some(entry) = table.rows.get(&key_bytes) {
             if entry.tombstoned() {
                 return false;
             }
@@ -750,47 +805,47 @@ where
 
 fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
-    Some(collect_typed::<T, _>(table.iter()))
+    Some(collect_typed::<T, _>(table.rows.iter()))
 }
 
 fn raw_iter_borrowed_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
     let table = store.get(T::NAME)?;
-    Some(collect_raw_borrowed(table.iter()))
+    Some(collect_raw_borrowed(table.rows.iter()))
 }
 
 fn raw_iter_owned_impl<T: Table>(
     store: &StoreType,
 ) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
     let table = store.get(T::NAME)?;
-    Some(collect_raw_owned(table.iter()))
+    Some(collect_raw_owned(table.rows.iter()))
 }
 
 fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
     let key_bytes = encode_key(key);
-    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
+    Some(collect_typed::<T, _>(table.rows.iter().skip_while(|(k, _)| **k < key_bytes)))
 }
 
 fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
-    Some(collect_typed::<T, _>(table.iter().rev()))
+    Some(collect_typed::<T, _>(table.rows.iter().rev()))
 }
 
 fn reverse_raw_iter_borrowed_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
     let table = store.get(T::NAME)?;
-    Some(collect_raw_borrowed(table.iter().rev()))
+    Some(collect_raw_borrowed(table.rows.iter().rev()))
 }
 
 fn reverse_raw_iter_owned_impl<T: Table>(
     store: &StoreType,
 ) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
     let table = store.get(T::NAME)?;
-    Some(collect_raw_owned(table.iter().rev()))
+    Some(collect_raw_owned(table.rows.iter().rev()))
 }
 
 fn last_record_impl<T: Table>(store: &StoreType) -> Option<(T::Key, T::Value)> {
     let table = store.get(T::NAME)?;
-    for (key_bytes, entry) in table.iter().rev() {
+    for (key_bytes, entry) in table.rows.iter().rev() {
         if !entry.tombstoned() {
             return Some((decode_key(key_bytes), decode(&entry.value)));
         }
@@ -802,6 +857,7 @@ fn record_prior_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<(T:
     let table = store.get(T::NAME)?;
     let key_bytes = encode_key(key);
     table
+        .rows
         .range(..key_bytes)
         .rev()
         .find(|(_, entry)| !entry.tombstoned())

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,6 +38,42 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
+fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    let key_bytes = encode_key(key);
+    Some(
+        table
+            .iter()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .skip_while(|(k, _)| **k < key_bytes)
+            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+            .collect(),
+    )
+}
+
+fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(
+        table
+            .iter()
+            .rev()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+            .collect(),
+    )
+}
+
+fn reverse_raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(Box::new(
+        table
+            .iter()
+            .rev()
+            .filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    ))
+}
+
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
     store: RwLockReadGuard<'a, StoreType>,
@@ -109,45 +145,23 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .skip_while(|(k, _)| **k < key_bytes)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Ok(Box::new(items.into_iter()))
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
+        match skip_to_impl::<T>(&self.store, key) {
+            Some(items) => Ok(Box::new(items.into_iter())),
+            None => Err(eyre::eyre!("Invalid table {}", T::NAME)),
         }
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_iter_impl::<T>(&self.store) {
+            Some(items) => Box::new(items.into_iter()),
+            None => Box::new(std::iter::empty()),
         }
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.get(T::NAME) {
-            Box::new(
-                table
-                    .iter()
-                    .rev()
-                    .filter(|(_, (tombstoned, _))| !*tombstoned)
-                    .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-            )
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_raw_iter_impl::<T>(&self.store) {
+            Some(iter) => iter,
+            None => Box::new(std::iter::empty()),
         }
     }
 
@@ -232,45 +246,23 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let key_bytes = encode_key(key);
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .skip_while(|(k, _)| **k < key_bytes)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Ok(Box::new(items.into_iter()))
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
+        match skip_to_impl::<T>(&self.store, key) {
+            Some(items) => Ok(Box::new(items.into_iter())),
+            None => Err(eyre::eyre!("Invalid table {}", T::NAME)),
         }
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_iter_impl::<T>(&self.store) {
+            Some(items) => Box::new(items.into_iter()),
+            None => Box::new(std::iter::empty()),
         }
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.get(T::NAME) {
-            Box::new(
-                table
-                    .iter()
-                    .rev()
-                    .filter(|(_, (tombstoned, _))| !*tombstoned)
-                    .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-            )
-        } else {
-            Box::new(std::iter::empty())
+        match reverse_raw_iter_impl::<T>(&self.store) {
+            Some(iter) => iter,
+            None => Box::new(std::iter::empty()),
         }
     }
 
@@ -566,31 +558,16 @@ impl Database for MemDatabase {
     }
 
     fn skip_to<T: Table>(&self, key: &T::Key) -> eyre::Result<DBIter<'_, T>> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let key_bytes = encode_key(key);
-            let items: Vec<_> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .skip_while(|(k, _)| **k < key_bytes)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Ok(Box::new(items.into_iter()))
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
+        match skip_to_impl::<T>(&self.store.read(), key) {
+            Some(items) => Ok(Box::new(items.into_iter())),
+            None => Err(eyre::eyre!("Invalid table {}", T::NAME)),
         }
     }
 
     fn reverse_iter<T: Table>(&self) -> DBIter<'_, T> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<_> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match reverse_iter_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -24,6 +24,11 @@ use crate::open_default_tables;
 /// Bit 0 of a row's packed word: the row is a tombstone (deleted in mem, pending/durable removal).
 const TOMBSTONE_BIT: u32 = 1;
 
+/// One in-flight op occupies bit 1 onward, i.e. the count field starts at bit 1, so each count
+/// increment is `1 << TOMBSTONE_BIT` (2) on the packed word. It is even on purpose: adding or
+/// subtracting it can never touch bit 0, keeping the tombstone flag intact through arithmetic.
+const IN_FLIGHT_UNIT: u32 = 1 << TOMBSTONE_BIT;
+
 /// Writes to a hot row's recency clock are throttled to one per window: reads only need a coarse
 /// ordering, and every store lands on the same cache line while the read lock is held.
 const RECENCY_BUMP_THRESHOLD: Duration = Duration::from_millis(100);
@@ -64,7 +69,7 @@ impl StoreEntry {
     }
 
     fn in_flight(&self) -> u32 {
-        self.packed >> 1
+        self.packed >> TOMBSTONE_BIT
     }
 
     fn mark_tombstone(&mut self) {
@@ -77,15 +82,15 @@ impl StoreEntry {
 
     fn add_in_flight(&mut self) {
         debug_assert!(
-            self.in_flight() < u32::MAX >> 1,
+            self.in_flight() < u32::MAX >> TOMBSTONE_BIT,
             "in-flight op count overflow for a single key"
         );
-        self.packed += 2;
+        self.packed += IN_FLIGHT_UNIT;
     }
 
     fn dec_in_flight(&mut self) {
         debug_assert!(self.in_flight() != 0, "in-flight op count is 0 before decrementing it");
-        self.packed -= 2;
+        self.packed -= IN_FLIGHT_UNIT;
     }
 
     /// Refreshes the recency clock if the previous bump is older than the throttle window.

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -354,9 +354,9 @@ impl MemDatabase {
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
         if let Some(table) = self.store.read().get(T::NAME) {
             let key_bytes = encode_key(key);
-            if let Some((removed, val_bytes)) = table.get(&key_bytes) {
+            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
                 let val = decode(val_bytes);
-                return Ok(Some((*removed, val)));
+                return Ok(Some((*tombstoned, val)));
             }
         }
 
@@ -367,21 +367,22 @@ impl MemDatabase {
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
         if let Some(table) = self.store.read().get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(removed, _)| *removed);
+            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
         }
         false
     }
 
-    pub fn delete_removed<T: Table>(&self, key: &T::Key, require_marked: bool) -> eyre::Result<()> {
+    pub fn delete_tombstoned<T: Table>(
+        &self,
+        key: &T::Key,
+        require_marked: bool,
+    ) -> eyre::Result<()> {
         if let Some(table) = self.store.write().get_mut(T::NAME) {
             let key_bytes = encode_key(key);
-            if let Some((removed, _)) = table.get(&key_bytes) {
-                if !*removed && require_marked {
-                    // Value was re-inserted after the remove was queued — keep it.
-                    return Ok(());
+            if let Some((tombstoned, _)) = table.get(&key_bytes) {
+                if *tombstoned || !require_marked {
+                    table.remove(&key_bytes);
                 }
-
-                table.remove(&key_bytes);
             }
         }
         Ok(())
@@ -390,7 +391,11 @@ impl MemDatabase {
     /// Returns keys marked for deletion in the given table.
     pub fn get_deleted_keys<T: Table>(&self) -> std::collections::HashSet<Vec<u8>> {
         if let Some(table) = self.store.read().get(T::NAME) {
-            table.iter().filter(|(_, (removed, _))| *removed).map(|(k, _)| k.clone()).collect()
+            table
+                .iter()
+                .filter(|(_, (tombstoned, _))| *tombstoned)
+                .map(|(k, _)| k.clone())
+                .collect()
         } else {
             std::collections::HashSet::new()
         }

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -110,6 +110,17 @@ impl StoreEntry {
 /// table is cleared; they are validated at pop under the store write lock and skipped.
 pub(crate) type EvictionHeap = BinaryHeap<Reverse<(u64, &'static str, Vec<u8>)>>;
 
+/// Outcome of one eviction pass, for the layered writer's cache-pressure logs.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct EvictionStats {
+    /// Total cached rows (live and tombstoned) when the pass started.
+    pub before: usize,
+    /// Total cached rows after the pass.
+    pub after: usize,
+    /// Rows removed during the pass.
+    pub evicted: usize,
+}
+
 /// One cached table: the rows plus a flag set while the producer's clear is queued but not yet
 /// applied to the persistent tier. `clearing` is set under the same write lock that enqueues the
 /// `Clear` message, so any reader that sees it is guaranteed the clear will land after all
@@ -469,12 +480,13 @@ impl MemDatabase {
     /// away, is skipped. A key whose recency was refreshed by a read since it settled is
     /// re-pushed with the fresh clock so hot keys survive eviction. The heap stays writer-owned;
     /// producers never touch it. Every pop removes one entry, so the loop always terminates.
-    pub fn evict_if_needed(&self, heap: &mut EvictionHeap, max_size: usize) {
+    pub fn evict_if_needed(&self, heap: &mut EvictionHeap, max_size: usize) -> EvictionStats {
         let mut store = self.store.write();
         let mut total: usize = store.values().map(|table| table.rows.len()).sum();
         if total <= max_size {
-            return;
+            return EvictionStats { before: total, after: total, evicted: 0 };
         }
+        let mut evicted = 0usize;
         while total > max_size {
             let Some(Reverse((heap_last_used, table, key))) = heap.pop() else { break };
             let Some(table_map) = store.get_mut(table) else { continue };
@@ -492,7 +504,9 @@ impl MemDatabase {
             }
             table_map.rows.remove(&key);
             total -= 1;
+            evicted += 1;
         }
+        EvictionStats { before: total + evicted, after: total, evicted }
     }
 
     /// Total rows (live and tombstoned) held in the cache; the writer keeps this at or below the

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -2,13 +2,15 @@
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap},
+    cmp::Reverse,
+    collections::{BTreeMap, BinaryHeap, HashMap},
     fmt::Debug,
     sync::{
+        atomic::{AtomicU64, Ordering as AtomicOrdering},
         mpsc::{self, SyncSender},
-        Arc,
+        Arc, LazyLock,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -19,8 +21,95 @@ use rayls_infrastructure_types::{
 
 use crate::open_default_tables;
 
-type StoreTableValueType = (bool, Vec<u8>);
-type StoreTableType = BTreeMap<Vec<u8>, StoreTableValueType>;
+/// Bit 0 of a row's packed word: the row is a tombstone (deleted in mem, pending/durable removal).
+const TOMBSTONE_BIT: u32 = 1;
+
+/// Writes to a hot row's recency clock are throttled to one per window: reads only need a coarse
+/// ordering, and every store lands on the same cache line while the read lock is held.
+const RECENCY_BUMP_THRESHOLD: Duration = Duration::from_millis(100);
+
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// Monotonic nanos since process start; cheap (vDSO) and lock-free.
+fn now_nanos() -> u64 {
+    PROCESS_START.elapsed().as_nanos() as u64
+}
+
+/// A single cached row: the encoded value plus a packed `(tombstoned, in_flight)` word and a
+/// lock-free recency clock.
+///
+/// `packed` bit 0 is the tombstone flag; bits 1..=31 are the number of writer ops queued for
+/// this key (the "in flight" count). It is a plain `u32` because every access happens under the
+/// store `RwLock`: producers increment under the write lock, the writer thread decrements under
+/// the write lock, and reads peek at the flag under the read lock. A count of zero means no
+/// queued op remains for the key, so the mem row exactly matches the persistent tier and the
+/// key is safe to evict.
+///
+/// `last_used` is an atomic so a hot read can refresh recency while holding only the read lock;
+/// writes are throttled to [`RECENCY_BUMP_THRESHOLD`] to keep the atomic cache line quiet.
+#[derive(Debug)]
+struct StoreEntry {
+    value: Vec<u8>,
+    packed: u32,
+    last_used: AtomicU64,
+}
+
+impl StoreEntry {
+    fn new(value: Vec<u8>) -> Self {
+        Self { value, packed: 0, last_used: AtomicU64::new(now_nanos()) }
+    }
+
+    fn tombstoned(&self) -> bool {
+        self.packed & TOMBSTONE_BIT != 0
+    }
+
+    fn in_flight(&self) -> u32 {
+        self.packed >> 1
+    }
+
+    fn mark_tombstone(&mut self) {
+        self.packed |= TOMBSTONE_BIT;
+    }
+
+    fn clear_tombstone(&mut self) {
+        self.packed &= !TOMBSTONE_BIT;
+    }
+
+    fn add_in_flight(&mut self) {
+        debug_assert!(
+            self.in_flight() < u32::MAX >> 1,
+            "in-flight op count overflow for a single key"
+        );
+        self.packed += 2;
+    }
+
+    fn dec_in_flight(&mut self) {
+        self.packed -= 2;
+    }
+
+    /// Refreshes the recency clock if the previous bump is older than the throttle window.
+    fn bump_last_used(&self) {
+        let now = now_nanos();
+        let last = self.last_used.load(AtomicOrdering::Relaxed);
+        if now.saturating_sub(last) >= RECENCY_BUMP_THRESHOLD.as_nanos() as u64 {
+            self.last_used.store(now, AtomicOrdering::Relaxed);
+        }
+    }
+
+    /// Unconditional recency refresh; used on writes, which already serialize on the write lock.
+    fn touch(&mut self) {
+        self.last_used.store(now_nanos(), AtomicOrdering::Relaxed);
+    }
+}
+
+/// Writer-owned min-heap of evictable keys ordered by recency: `Reverse<(last_used, table, key)>`.
+///
+/// Only the background writer pushes (when a key's in-flight count settles to zero) and pops
+/// (during eviction), so no lock guards it. Entries go stale when the key is re-inserted or the
+/// table is cleared; they are validated at pop under the store write lock and skipped.
+pub type EvictionHeap = BinaryHeap<Reverse<(u64, &'static str, Vec<u8>)>>;
+
+type StoreTableType = BTreeMap<Vec<u8>, StoreEntry>;
 type StoreType = HashMap<&'static str, StoreTableType>;
 
 #[derive(Debug)]
@@ -32,9 +121,12 @@ impl<'a> MemDbTx<'a> {
     pub fn get_no_marked_check<T: Table>(&self, key: &T::Key) -> Option<(bool, T::Value)> {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
-                let val = decode(val_bytes);
-                return Some((*tombstoned, val));
+            if let Some(entry) = table.get(&key_bytes) {
+                if !entry.tombstoned() {
+                    entry.bump_last_used();
+                }
+                let val = decode(&entry.value);
+                return Some((entry.tombstoned(), val));
             }
         }
         None
@@ -44,7 +136,7 @@ impl<'a> MemDbTx<'a> {
     pub fn is_tombstoned<T: Table>(&self, key: &T::Key) -> bool {
         if let Some(table) = self.store.get(T::NAME) {
             let key_bytes = encode_key(key);
-            return table.get(&key_bytes).map_or(false, |(tombstoned, _)| *tombstoned);
+            return table.get(&key_bytes).is_some_and(|entry| entry.tombstoned());
         }
         false
     }
@@ -111,11 +203,6 @@ pub struct MemDbTxMut<'a> {
 }
 
 impl<'a> MemDbTxMut<'a> {
-    fn mark_value_for_deletion(value: &mut StoreTableValueType) {
-        // mark for actual deletion once tx committed
-        value.0 = true;
-    }
-
     /// Hard-removes `key` from the in-memory store, leaving no tombstone.
     ///
     /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
@@ -125,6 +212,15 @@ impl<'a> MemDbTxMut<'a> {
         if let Some(table) = self.store.get_mut(T::NAME) {
             table.remove(&encode_key(key));
         }
+    }
+
+    /// Raw keys of the table, for a `Clear` message: the writer needs the exact set that was
+    /// tombstoned (and counted) by this clear to release each key's in-flight op at apply time.
+    pub fn raw_keys<T: Table>(&self) -> Vec<Vec<u8>> {
+        self.store
+            .get(T::NAME)
+            .map(|table| table.keys().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -194,41 +290,15 @@ impl<'a> DbTx for MemDbTxMut<'a> {
 
 impl<'a> DbTxMut for MemDbTxMut<'a> {
     fn insert<T: Table>(&mut self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
-        if let Some(table) = self.store.get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            let value_bytes = encode(value);
-            table.insert(key_bytes, (false, value_bytes));
-
-            Ok(())
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
-        }
+        insert_impl::<T>(&mut self.store, key, value)
     }
 
     fn remove<T: Table>(&mut self, key: &T::Key) -> eyre::Result<()> {
-        if let Some(table) = self.store.get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some(value) = table.get_mut(&key_bytes) {
-                Self::mark_value_for_deletion(value);
-            } else {
-                // tombstone for keys that only exist in the persistent layer
-                table.insert(key_bytes, (true, Vec::new()));
-            }
-            Ok(())
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
-        }
+        remove_impl::<T>(&mut self.store, key)
     }
 
     fn clear_table<T: Table>(&mut self) -> eyre::Result<()> {
-        if let Some(table) = self.store.get_mut(T::NAME) {
-            for value in table.values_mut() {
-                Self::mark_value_for_deletion(value);
-            }
-            Ok(())
-        } else {
-            Err(eyre::eyre!("Invalid table {}", T::NAME))
-        }
+        clear_table_impl::<T>(&mut self.store).map(|_| ())
     }
 
     fn commit(self) -> eyre::Result<()> {
@@ -296,20 +366,92 @@ impl MemDatabase {
         self.read_txn_impl().is_tombstoned::<T>(key)
     }
 
-    pub fn delete_tombstoned<T: Table>(
+    /// Enqueue a mem mutation and its writer message in one critical section: the in-flight count
+    /// is bumped under the same write lock that mutates the cache, and `on_queued` (the `send`)
+    /// runs before the lock is released, so the channel order matches the mem mutation order.
+    pub fn insert_queued<T: Table>(
         &self,
         key: &T::Key,
-        require_marked: bool,
+        value: &T::Value,
+        on_queued: impl FnOnce() -> eyre::Result<()>,
     ) -> eyre::Result<()> {
-        if let Some(table) = self.store.write().get_mut(T::NAME) {
-            let key_bytes = encode_key(key);
-            if let Some((tombstoned, _)) = table.get(&key_bytes) {
-                if *tombstoned || !require_marked {
-                    table.remove(&key_bytes);
-                }
-            }
+        let mut store = self.store.write();
+        insert_impl::<T>(&mut store, key, value)?;
+        on_queued()
+    }
+
+    pub fn remove_queued<T: Table>(
+        &self,
+        key: &T::Key,
+        on_queued: impl FnOnce() -> eyre::Result<()>,
+    ) -> eyre::Result<()> {
+        let mut store = self.store.write();
+        remove_impl::<T>(&mut store, key)?;
+        on_queued()
+    }
+
+    pub fn clear_table_queued<T: Table>(
+        &self,
+        on_queued: impl FnOnce(Vec<Vec<u8>>) -> eyre::Result<()>,
+    ) -> eyre::Result<()> {
+        let mut store = self.store.write();
+        let keys = clear_table_impl::<T>(&mut store)?;
+        on_queued(keys)
+    }
+
+    /// Releases one in-flight op for `key` after its writer message applied (or the txn
+    /// committed). When the count reaches zero the key is pushed onto the eviction heap: no
+    /// queued op remains, so the mem row equals the persistent tier and eviction cannot expose
+    /// a stale value.
+    pub fn on_op_applied(&self, table: &'static str, key_bytes: &[u8], heap: &mut EvictionHeap) {
+        let mut store = self.store.write();
+        let Some(table_map) = store.get_mut(table) else { return };
+        let Some(entry) = table_map.get_mut(key_bytes) else { return };
+        entry.dec_in_flight();
+        if entry.in_flight() == 0 {
+            heap.push(Reverse((
+                entry.last_used.load(AtomicOrdering::Relaxed),
+                table,
+                key_bytes.to_vec(),
+            )));
         }
-        Ok(())
+    }
+
+    /// Evicts settled keys (in-flight == 0) in recency order until the cache fits `max_size`.
+    /// Candidates are validated at pop: a key re-inserted since its settle, or a row cleared
+    /// away, is skipped. A key whose recency was refreshed by a read since it settled is
+    /// re-pushed with the fresh clock so hot keys survive eviction. The heap stays writer-owned;
+    /// producers never touch it. Every pop removes one entry, so the loop always terminates.
+    pub fn evict_if_needed(&self, heap: &mut EvictionHeap, max_size: usize) {
+        let mut store = self.store.write();
+        let mut total: usize = store.values().map(|table| table.len()).sum();
+        if total <= max_size {
+            return;
+        }
+        while total > max_size {
+            let Some(Reverse((heap_last_used, table, key))) = heap.pop() else { break };
+            let Some(table_map) = store.get_mut(table) else { continue };
+            let Some(entry) = table_map.get(&key) else { continue };
+            if entry.in_flight() != 0 {
+                continue;
+            }
+            let current_last_used = entry.last_used.load(AtomicOrdering::Relaxed);
+            if current_last_used != heap_last_used {
+                // A read refreshed the key after it settled: it is no longer least-recently
+                // used. Re-push with the fresh clock; recency bumps are throttled (~100ms), so
+                // each hot key pays at most ~10 re-pushes per second.
+                heap.push(Reverse((current_last_used, table, key)));
+                continue;
+            }
+            table_map.remove(&key);
+            total -= 1;
+        }
+    }
+
+    /// Total rows (live and tombstoned) held in the cache; the writer keeps this at or below the
+    /// configured max size.
+    pub fn mem_size(&self) -> usize {
+        self.store.read().values().map(|table| table.len()).sum()
     }
 
     /// Returns keys marked for deletion in the given table.
@@ -317,7 +459,7 @@ impl MemDatabase {
         if let Some(table) = self.store.read().get(T::NAME) {
             table
                 .iter()
-                .filter(|(_, (tombstoned, _))| *tombstoned)
+                .filter(|(_, entry)| entry.tombstoned())
                 .map(|(k, _)| k.clone())
                 .collect()
         } else {
@@ -414,7 +556,7 @@ impl Database for MemDatabase {
         self.store
             .read()
             .get(T::NAME)
-            .map_or(true, |table| table.values().all(|(tombstoned, _)| *tombstoned))
+            .is_none_or(|table| table.values().all(|entry| entry.tombstoned()))
     }
 
     fn iter<T: Table>(&self) -> DBIter<'_, T> {
@@ -505,12 +647,69 @@ impl Default for MemDBMetrics {
     }
 }
 
+/// Mutate + count a row: value replaced, tombstone cleared, one in-flight op registered, recency
+/// touched. Shared by the txn producers (guard already held) and the `*_queued` entry points.
+fn insert_impl<T: Table>(store: &mut StoreType, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
+    let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
+    let key_bytes = encode_key(key);
+    match table.get_mut(&key_bytes) {
+        Some(entry) => {
+            entry.value = encode(value);
+            entry.clear_tombstone();
+            entry.add_in_flight();
+            entry.touch();
+        }
+        None => {
+            let mut entry = StoreEntry::new(encode(value));
+            entry.add_in_flight();
+            table.insert(key_bytes, entry);
+        }
+    }
+    Ok(())
+}
+
+/// Tombstone + count a row: the row is hidden from reads immediately, and its in-flight op keeps
+/// it in the cache until the persistent remove applies. A tombstone is inserted for keys that
+/// only exist in the persistent layer.
+fn remove_impl<T: Table>(store: &mut StoreType, key: &T::Key) -> eyre::Result<()> {
+    let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
+    let key_bytes = encode_key(key);
+    match table.get_mut(&key_bytes) {
+        Some(entry) => {
+            entry.mark_tombstone();
+            entry.add_in_flight();
+            entry.touch();
+        }
+        None => {
+            let mut entry = StoreEntry::new(Vec::new());
+            entry.mark_tombstone();
+            entry.add_in_flight();
+            table.insert(key_bytes, entry);
+        }
+    }
+    Ok(())
+}
+
+/// Tombstone every row of the table (the persistent clear is deferred) and bump each in-flight
+/// count so no tombstone is evicted before the clear applies. Returns the raw keys, which the
+/// writer needs to release each count once the clear lands.
+fn clear_table_impl<T: Table>(store: &mut StoreType) -> eyre::Result<Vec<Vec<u8>>> {
+    let table = store.get_mut(T::NAME).ok_or_else(|| eyre::eyre!("Invalid table {}", T::NAME))?;
+    let keys: Vec<Vec<u8>> = table.keys().cloned().collect();
+    for entry in table.values_mut() {
+        entry.mark_tombstone();
+        entry.add_in_flight();
+    }
+    Ok(keys)
+}
+
 fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
     if let Some(table) = store.get(T::NAME) {
         let key_bytes = encode_key(key);
-        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
-            if !*tombstoned {
-                let val = decode(val_bytes);
+        if let Some(entry) = table.get(&key_bytes) {
+            if !entry.tombstoned() {
+                entry.bump_last_used();
+                let val = decode(&entry.value);
                 return Some(val);
             }
         }
@@ -521,8 +720,12 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
 fn contains_key_impl<T: Table>(store: &StoreType, key: &T::Key) -> bool {
     if let Some(table) = store.get(T::NAME) {
         let key_bytes = encode_key(key);
-        if let Some((tombstoned, _)) = table.get(&key_bytes) {
-            return !*tombstoned;
+        if let Some(entry) = table.get(&key_bytes) {
+            if entry.tombstoned() {
+                return false;
+            }
+            entry.bump_last_used();
+            return true;
         }
     }
     false
@@ -530,29 +733,29 @@ fn contains_key_impl<T: Table>(store: &StoreType, key: &T::Key) -> bool {
 
 fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
 where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+    I: Iterator<Item = (&'t Vec<u8>, &'t StoreEntry)>,
 {
-    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+    iter.filter(|(_, entry)| !entry.tombstoned())
+        .map(|(k, entry)| (decode_key::<T::Key>(k), decode::<T::Value>(&entry.value)))
         .collect()
 }
 
 fn collect_raw_borrowed<'t, I>(iter: I) -> DBRawIter<'t>
 where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
+    I: Iterator<Item = (&'t Vec<u8>, &'t StoreEntry)> + 't,
 {
     Box::new(
-        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+        iter.filter(|(_, entry)| !entry.tombstoned())
+            .map(|(k, entry)| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(entry.value.as_slice()))),
     )
 }
 
 fn collect_raw_owned<'t, I>(iter: I) -> Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>
 where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+    I: Iterator<Item = (&'t Vec<u8>, &'t StoreEntry)>,
 {
-    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-        .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
+    iter.filter(|(_, entry)| !entry.tombstoned())
+        .map(|(k, entry)| (Cow::Owned(k.clone()), Cow::Owned(entry.value.clone())))
         .collect()
 }
 
@@ -598,9 +801,9 @@ fn reverse_raw_iter_owned_impl<T: Table>(
 
 fn last_record_impl<T: Table>(store: &StoreType) -> Option<(T::Key, T::Value)> {
     let table = store.get(T::NAME)?;
-    for (key_bytes, (tombstoned, value_bytes)) in table.iter().rev() {
-        if !*tombstoned {
-            return Some((decode_key(key_bytes), decode(value_bytes)));
+    for (key_bytes, entry) in table.iter().rev() {
+        if !entry.tombstoned() {
+            return Some((decode_key(key_bytes), decode(&entry.value)));
         }
     }
     None
@@ -612,8 +815,8 @@ fn record_prior_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<(T:
     table
         .range(..key_bytes)
         .rev()
-        .find(|(_, (tombstoned, _))| !*tombstoned)
-        .map(|(k, (_, v))| (decode_key(k), decode(v)))
+        .find(|(_, entry)| !entry.tombstoned())
+        .map(|(k, entry)| (decode_key(k), decode(&entry.value)))
 }
 
 #[cfg(test)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -25,64 +25,6 @@ type StoreTableValueType = (bool, Vec<u8>);
 type StoreTableType = BTreeMap<Vec<u8>, StoreTableValueType>;
 type StoreType = HashMap<&'static str, StoreTableType>;
 
-fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
-    if let Some(table) = store.get(T::NAME) {
-        let key_bytes = encode_key(key);
-        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
-            if !*tombstoned {
-                let val = decode(val_bytes);
-                return Some(val);
-            }
-        }
-    }
-    None
-}
-
-fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
-where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
-{
-    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-        .collect()
-}
-
-fn collect_raw<'t, I>(iter: I) -> DBRawIter<'t>
-where
-    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
-{
-    Box::new(
-        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-    )
-}
-
-fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_typed::<T, _>(table.iter()))
-}
-
-fn raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_raw(table.iter()))
-}
-
-fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
-    let table = store.get(T::NAME)?;
-    let key_bytes = encode_key(key);
-    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
-}
-
-fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_typed::<T, _>(table.iter().rev()))
-}
-
-fn reverse_raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
-    let table = store.get(T::NAME)?;
-    Some(collect_raw(table.iter().rev()))
-}
-
 #[derive(Debug)]
 pub struct MemDbTx<'a> {
     store: RwLockReadGuard<'a, StoreType>,
@@ -133,7 +75,7 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        match raw_iter_impl::<T>(&self.store) {
+        match raw_iter_borrowed_impl::<T>(&self.store) {
             Some(iter) => iter,
             None => Box::new(std::iter::empty()),
         }
@@ -154,7 +96,7 @@ impl<'a> DbTx for MemDbTx<'a> {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        match reverse_raw_iter_impl::<T>(&self.store) {
+        match reverse_raw_iter_borrowed_impl::<T>(&self.store) {
             Some(iter) => iter,
             None => Box::new(std::iter::empty()),
         }
@@ -255,7 +197,7 @@ impl<'a> DbTx for MemDbTxMut<'a> {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        match reverse_raw_iter_impl::<T>(&self.store) {
+        match reverse_raw_iter_borrowed_impl::<T>(&self.store) {
             Some(iter) => iter,
             None => Box::new(std::iter::empty()),
         }
@@ -534,15 +476,9 @@ impl Database for MemDatabase {
     fn raw_iter<T: Table>(&self) -> DBRawIter<'_> {
         // The guard is a temporary here (not held by `self`), so the bytes must
         // be owned rather than borrowed for the iterator's lifetime.
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
-                .iter()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match raw_iter_owned_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 
@@ -561,16 +497,9 @@ impl Database for MemDatabase {
     }
 
     fn reverse_raw_iter<T: Table>(&self) -> DBRawIter<'_> {
-        if let Some(table) = self.store.read().get(T::NAME) {
-            let items: Vec<(Cow<'_, [u8]>, Cow<'_, [u8]>)> = table
-                .iter()
-                .rev()
-                .filter(|(_, (tombstoned, _))| !*tombstoned)
-                .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
-                .collect();
-            Box::new(items.into_iter())
-        } else {
-            panic!("Invalid table {}", T::NAME);
+        match reverse_raw_iter_owned_impl::<T>(&self.store.read()) {
+            Some(items) => Box::new(items.into_iter()),
+            None => panic!("Invalid table {}", T::NAME),
         }
     }
 
@@ -661,6 +590,87 @@ impl Default for MemDBMetrics {
             }
         }
     }
+}
+
+fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T::Value> {
+    if let Some(table) = store.get(T::NAME) {
+        let key_bytes = encode_key(key);
+        if let Some((tombstoned, val_bytes)) = table.get(&key_bytes) {
+            if !*tombstoned {
+                let val = decode(val_bytes);
+                return Some(val);
+            }
+        }
+    }
+    None
+}
+
+fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+{
+    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+        .collect()
+}
+
+fn collect_raw_borrowed<'t, I>(iter: I) -> DBRawIter<'t>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
+{
+    Box::new(
+        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    )
+}
+
+fn collect_raw_owned<'t, I>(iter: I) -> Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+{
+    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (Cow::Owned(k.clone()), Cow::Owned(v.clone())))
+        .collect()
+}
+
+fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_typed::<T, _>(table.iter()))
+}
+
+fn raw_iter_borrowed_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_borrowed(table.iter()))
+}
+
+fn raw_iter_owned_impl<T: Table>(
+    store: &StoreType,
+) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_owned(table.iter()))
+}
+
+fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    let key_bytes = encode_key(key);
+    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
+}
+
+fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_typed::<T, _>(table.iter().rev()))
+}
+
+fn reverse_raw_iter_borrowed_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_borrowed(table.iter().rev()))
+}
+
+fn reverse_raw_iter_owned_impl<T: Table>(
+    store: &StoreType,
+) -> Option<Vec<(Cow<'static, [u8]>, Cow<'static, [u8]>)>> {
+    let table = store.get(T::NAME)?;
+    Some(collect_raw_owned(table.iter().rev()))
 }
 
 #[cfg(test)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -38,61 +38,49 @@ fn get_with_marked_check<T: Table>(store: &StoreType, key: &T::Key) -> Option<T:
     None
 }
 
+fn collect_typed<'t, T: Table, I>(iter: I) -> Vec<(T::Key, T::Value)>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))>,
+{
+    iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+        .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
+        .collect()
+}
+
+fn collect_raw<'t, I>(iter: I) -> DBRawIter<'t>
+where
+    I: Iterator<Item = (&'t Vec<u8>, &'t (bool, Vec<u8>))> + 't,
+{
+    Box::new(
+        iter.filter(|(_, (tombstoned, _))| !*tombstoned)
+            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
+    )
+}
+
 fn iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
-    Some(
-        table
-            .iter()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-            .collect(),
-    )
+    Some(collect_typed::<T, _>(table.iter()))
 }
 
 fn raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
     let table = store.get(T::NAME)?;
-    Some(Box::new(
-        table
-            .iter()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-    ))
+    Some(collect_raw(table.iter()))
 }
 
 fn skip_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
     let key_bytes = encode_key(key);
-    Some(
-        table
-            .iter()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .skip_while(|(k, _)| **k < key_bytes)
-            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-            .collect(),
-    )
+    Some(collect_typed::<T, _>(table.iter().skip_while(|(k, _)| **k < key_bytes)))
 }
 
 fn reverse_iter_impl<T: Table>(store: &StoreType) -> Option<Vec<(T::Key, T::Value)>> {
     let table = store.get(T::NAME)?;
-    Some(
-        table
-            .iter()
-            .rev()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (decode_key::<T::Key>(k), decode::<T::Value>(v)))
-            .collect(),
-    )
+    Some(collect_typed::<T, _>(table.iter().rev()))
 }
 
 fn reverse_raw_iter_impl<T: Table>(store: &StoreType) -> Option<DBRawIter<'_>> {
     let table = store.get(T::NAME)?;
-    Some(Box::new(
-        table
-            .iter()
-            .rev()
-            .filter(|(_, (tombstoned, _))| !*tombstoned)
-            .map(|(k, (_, v))| (Cow::Borrowed(k.as_slice()), Cow::Borrowed(v.as_slice()))),
-    ))
+    Some(collect_raw(table.iter().rev()))
 }
 
 #[derive(Debug)]

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -180,6 +180,19 @@ pub struct MemDbTxMut<'a> {
     store: RwLockWriteGuard<'a, StoreType>,
 }
 
+impl<'a> MemDbTxMut<'a> {
+    /// Hard-removes `key` from the in-memory store, leaving no tombstone.
+    ///
+    /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
+    /// dropped outright rather than tombstoned: this frees the cache and lets reads fall through to
+    /// a lower tier, whereas a tombstone would shadow it and never be reclaimed.
+    pub fn hard_delete<T: Table>(&mut self, key: &T::Key) {
+        if let Some(table) = self.store.get_mut(T::NAME) {
+            table.remove(&encode_key(key));
+        }
+    }
+}
+
 impl<'a> DbTx for MemDbTxMut<'a> {
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
         //if not in cache check store
@@ -325,19 +338,6 @@ impl<'a> DbTxMut for MemDbTxMut<'a> {
     }
 }
 
-impl<'a> MemDbTxMut<'a> {
-    /// Hard-removes `key` from the in-memory store, leaving no tombstone.
-    ///
-    /// Persistent eviction archives a row permanently (never re-inserted), so the cache entry is
-    /// dropped outright rather than tombstoned: this frees the cache and lets reads fall through to
-    /// a lower tier, whereas a tombstone would shadow it and never be reclaimed.
-    pub fn hard_delete<T: Table>(&mut self, key: &T::Key) {
-        if let Some(table) = self.store.get_mut(T::NAME) {
-            table.remove(&encode_key(key));
-        }
-    }
-}
-
 /// Implement the Database trait with an in-memory store.
 /// This means no persistance.
 /// This DB also plays loose with transactions, but since it is in-memory and we do not do
@@ -350,6 +350,33 @@ pub struct MemDatabase {
 }
 
 impl MemDatabase {
+    pub fn new() -> Self {
+        let store: Arc<RwLock<StoreType>> = Arc::new(RwLock::new(HashMap::new()));
+        let metrics = Arc::new(RwLock::new(MemDBMetrics::default()));
+        let (shutdown_tx, rx) = mpsc::sync_channel::<()>(0);
+
+        let store_cloned: Arc<RwLock<StoreType>> = Arc::clone(&store);
+        let metrics_cloned = metrics.clone();
+
+        // Spawn thread to update metrics from MemDB stats every 30 seconds.
+        std::thread::spawn(move || {
+            tracing::info!(target: "rayls::memdb", "Starting MemDB metrics thread");
+            while let Err(mpsc::RecvTimeoutError::Timeout) =
+                rx.recv_timeout(Duration::from_secs(30))
+            {
+                let read_guard = store_cloned.read();
+                for (key, table) in read_guard.iter() {
+                    if let Some(m) = metrics_cloned.read().table_counts.get(key) {
+                        m.set(table.len().try_into().unwrap_or(-1));
+                    }
+                }
+            }
+            tracing::info!(target: "rayls::memdb", "Ending MemDB metrics thread");
+        });
+
+        Self { store, metrics, shutdown_tx: Arc::new(shutdown_tx) }
+    }
+
     // gets the value with the marking for delete flag
     pub fn get_marked<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<(bool, T::Value)>> {
         if let Some(table) = self.store.read().get(T::NAME) {
@@ -404,44 +431,16 @@ impl MemDatabase {
 
 impl Drop for MemDatabase {
     fn drop(&mut self) {
-        if Arc::strong_count(&self.shutdown_tx) <= 1 {
-            tracing::info!(target: "rayls::memdb", "MemDatabase Dropping, shutting down metrics thread");
-            // shutdown_tx is a sync sender with no buffer so this should block until the thread
-            // reads it and shuts down.
-            if let Err(e) = self.shutdown_tx.send(()) {
-                tracing::error!(target: "rayls::memdb",
-                    "Error while trying to send shutdown to MemDatabase metrics thread {e}"
-                );
-            }
+        if Arc::strong_count(&self.shutdown_tx) > 1 {
+            return;
         }
-    }
-}
 
-impl MemDatabase {
-    pub fn new() -> Self {
-        let store: Arc<RwLock<StoreType>> = Arc::new(RwLock::new(HashMap::new()));
-        let metrics = Arc::new(RwLock::new(MemDBMetrics::default()));
-        let (shutdown_tx, rx) = mpsc::sync_channel::<()>(0);
-
-        let store_cloned: Arc<RwLock<StoreType>> = Arc::clone(&store);
-        let metrics_cloned = metrics.clone();
-        // Spawn thread to update metrics from MemDB stats every 30 seconds.
-        std::thread::spawn(move || {
-            tracing::info!(target: "rayls::memdb", "Starting MemDB metrics thread");
-            while let Err(mpsc::RecvTimeoutError::Timeout) =
-                rx.recv_timeout(Duration::from_secs(30))
-            {
-                let read_guard = store_cloned.read();
-                for (key, table) in read_guard.iter() {
-                    if let Some(m) = metrics_cloned.read().table_counts.get(key) {
-                        m.set(table.len().try_into().unwrap_or(-1));
-                    }
-                }
-            }
-            tracing::info!(target: "rayls::memdb", "Ending MemDB metrics thread");
-        });
-
-        Self { store, metrics, shutdown_tx: Arc::new(shutdown_tx) }
+        tracing::info!(target: "rayls::memdb", "MemDatabase Dropping, shutting down metrics thread");
+        // shutdown_tx is a sync sender with no buffer so this should block until the thread
+        // reads it and shuts down.
+        if let Err(e) = self.shutdown_tx.send(()) {
+            tracing::error!(target: "rayls::memdb", "Error while trying to send shutdown to MemDatabase metrics thread {e}"  );
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

- Fix stale mem-cache entries in the layered consensus DB: a row (live or tombstoned) is now only evicted once its queued write has been applied durably to the persistent tier. Each row tracks an in-flight op count bumped under the same lock that mutates the cache, so channel order equals mem order and a zero count means the cache exactly matches persistence.
- Replace the old time/age-based eviction (`clear_insert_mem` after `CACHE_KEEP_TIME_SECS` / `MAX_CACHE_SIZE`) with a writer-owned recency (LRU) min-heap of settled keys, guarded by a lock-free, throttled (~100ms) recency clock so hot reads keep keys alive. The cache cap is configurable via a new `CacheConfig` / `open_with_config` (default 10000, small in tests).
- Refactor `mem_db.rs`: deduplicate the iter/raw_iter/skip_to/last_record/record_prior_to implementations into shared `_impl` helpers, delegate `contains_key`/`insert`/`clear_table` through transactions, and drop dead code (`get_deleted_keys` cleanup, metrics-thread shutdown dedup, etc.).

Closes #N/A

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

<!-- Does this require a node restart, a network upgrade, a hardfork activation block, a contract migration, a config change, or any client coordination? If yes, describe. If no, write "None". -->

None. Eviction is an internal mem-cache detail; the default cache cap is unchanged (10000 rows), reads always fall through to the persistent tier, and no config, restart, or client coordination is required.

## Test plan

<!-- What did you do to convince yourself this works? Commands, scenarios, or links to CI output. -->

- [x] `cargo test -p rayls-infrastructure-storage -- --test-threads 1` — 143 passed, 0 failed. Includes 6 new tests covering the eviction invariants: `eviction_keeps_cache_at_max_size_and_evicts_oldest_settled`, `eviction_waits_for_in_flight_ops`, `removed_never_inserted_tombstone_is_evicted`, `clear_tombstones_are_held_until_the_persistent_clear_lands`, `read_recency_protects_a_hot_key`, `guard_skipped_remove_still_settles`.
- [x] `cargo +nightly fmt --all --check` — clean.
- [x] `cargo clippy -p rayls-infrastructure-storage --all-targets` — no new warnings (only pre-existing `Box<dyn Fn>` dead-code noise on `main`).
