### PR TITLE
feat: in-flight transaction tracker for the txpool and batch sealer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7886,6 +7886,8 @@ dependencies = [
  "futures",
  "jsonrpsee",
  "parking_lot",
+ "prometheus",
+ "proptest",
  "rand 0.9.3",
  "rayls-consensus-worker",
  "rayls-execution-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ tokio = { version = "1.44", default-features = false }
 tracing = { version = "0.1.0", features = ["release_max_level_info"] }
 tracing-appender = "0.2"
 tracing-subscriber = "0.3.20"
-metrics = "0.23.0"                                     # Needed for `metrics-macro` to resolve the crate using `::metrics` notation
+metrics = "0.24"                                       # MUST match the version reth's prometheus recorder registers against, or gauge!/counter! bind to a second global and become no-ops
 serde_json = "1.0.94"
 humantime-serde = "1.1"
 fdlimit = "0.3.0"

--- a/crates/consensus/worker/src/batch-builder/src/batch.rs
+++ b/crates/consensus/worker/src/batch-builder/src/batch.rs
@@ -63,7 +63,7 @@ pub fn build_batch<P: TxPool>(
     // Disable live transaction updates to prevent intra-sender nonce gaps.
     // The default BestTransactions iterator receives new pending transactions via a
     // broadcast channel during iteration. If a transaction arrives whose predecessor
-    // is not in the snapshot, it starts a new independent nonce chain — producing
+    // is not in the snapshot, it starts a new independent nonce chain, producing
     // batches with non-contiguous nonces that cause nonce_too_high at execution.
     best_txs.no_updates();
 
@@ -81,6 +81,15 @@ pub fn build_batch<P: TxPool>(
     // begin loop through sorted "best" transactions in pending pool
     // and execute them to build the block
     while let Some(pool_tx) = best_txs.next() {
+        // skip a transaction already sealed into a batch still in flight, so a stuck inclusion
+        // backlog is not re-sealed batch after batch. The skip cannot open a nonce gap: an
+        // in-flight tx stays pending, so its descendants still trail it here, and same-authority
+        // batches execute in seq order, so the in-flight prefix and this batch stay
+        // nonce-contiguous at execution.
+        if pool.is_in_flight(pool_tx.hash()) {
+            continue;
+        }
+
         // ensure block has capacity (in gas) for this transaction
         if total_possible_gas + pool_tx.gas_limit() > gas_limit {
             // the tx could exceed max gas limit for the block

--- a/crates/consensus/worker/src/batch-builder/src/lib.rs
+++ b/crates/consensus/worker/src/batch-builder/src/lib.rs
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 //! The block builder maintains the transaction pool and builds the next block.
 //!
-//! The block builder listens for canonical state changes from the engine and updates the
-//! transaction pool. These updates move transactions to the correct sub-pools. Only transactions in
-//! the pending pool are considered for the next block.
-//!
-//! Upon successfully building the next block, the block builder forwards to the worker's block
-//! provider. The worker's block provider reliably broadcasts the block and tries to reach quorum
-//! within a time limit. If quorum fails, the block builder receives the error and does not mine the
-//! transactions. If quorum is reached, the transactions are mined and removed from the pending
-//! pool. When this task removes transactions from the pending pool, it uses the current canonical
-//! tip and basefee calculated for the round. Only the engine's canonical updates affect the pool's
-//! tracked `tip`, basefee, and blob fees sorting transactions into sub-pools.
+//! Only the engine's canonical updates move transactions between sub-pools, and only the pending
+//! sub-pool feeds the next block. A built block goes to the worker's block provider, which
+//! publishes it to peers and seeks quorum within a time limit. On quorum failure the transactions
+//! are left untouched for the next round; on success they are marked in flight so the next round
+//! skips them, and they stay pending until the engine's canonical update mines them and releases
+//! the marks.
 
 // it tests
 #![allow(unused_crate_dependencies)]
@@ -20,7 +15,9 @@ pub use batch::{build_batch, BatchBuilderOutput};
 use error::{BatchBuilderError, BatchBuilderResult};
 use futures_util::{FutureExt, StreamExt};
 use rayls_execution_evm::{
-    reth_env::RethEnv, CanonStateNotificationStream, TxPool as _, WorkerTxPool,
+    in_flight::{DuePolicy, SealMarks},
+    reth_env::RethEnv,
+    CanonStateNotificationStream, TxPool as _, WorkerTxPool,
 };
 use rayls_infrastructure_types::{
     error::BlockSealError, gas_accumulator::BaseFeeContainer, Address, BatchBuilderArgs,
@@ -43,6 +40,11 @@ pub mod test_utils;
 /// Result from a batch build attempt: mined tx hashes and the seq number used.
 type BuildResult = oneshot::Receiver<BatchBuilderResult<(Vec<TxHash>, u64)>>;
 
+/// How long a sealed transaction stays marked in flight before [`InFlightTracker::sweep_due`] may
+/// presume its batch lost and release it for resealing. Reconcile against the pending sub-pool
+/// releases marks on execution well before this, so the sweep is the backstop, not the norm.
+const IN_FLIGHT_TTL: Duration = Duration::from_secs(60);
+
 /// The type that builds blocks for workers to propose.
 ///
 /// This is a future that:
@@ -56,12 +58,16 @@ pub struct BatchBuilder {
     pending_task: Option<BuildResult>,
     /// The transaction pool with pending transactions.
     pool: WorkerTxPool,
+    /// Sealing capability over the pool's in-flight tracker: marks a batch's hashes on quorum so
+    /// the next round skips them until execution releases them. Armed once per (epoch-scoped)
+    /// builder.
+    in_flight: SealMarks,
     /// The sending side to the worker's batch maker.
     ///
-    /// Sending the new block through this channel triggers a broadcast to all peers.
+    /// Sending the new block through this channel publishes it to all peers.
     ///
     /// The worker's block maker sends an ack once the block has been stored in db
-    /// which guarantees the worker will attempt to broadcast the new block until
+    /// which guarantees the worker will keep publishing the new block until
     /// quorum is reached.
     to_worker: BatchSender,
     /// The address for batch's beneficiary.
@@ -115,9 +121,11 @@ impl BatchBuilder {
         let max_delay_interval = tokio::time::interval(max_delay);
         let state_changed = reth_env.canonical_block_stream();
         let last_canonical_update = Self::latest_canon_block(reth_env);
+        let in_flight = pool.in_flight().arm_sealing(DuePolicy::ttl(IN_FLIGHT_TTL));
         Self {
             pending_task: None,
             pool,
+            in_flight,
             to_worker,
             address,
             max_delay_interval,
@@ -133,16 +141,8 @@ impl BatchBuilder {
         }
     }
 
-    /// Spawns a task to build the batch and propose to peers.
-    ///
-    /// This approach allows the batch builder to yield back to the runtime while mining batches.
-    ///
-    /// The task performs the following actions:
-    /// - create a batch
-    /// - send the batch to worker's batch proposer
-    /// - wait for ack that quorum was reached
-    /// - convert result to fatal/non-fatal
-    /// - return result
+    /// Spawns a blocking task that builds the batch, sends it to the worker's batch proposer, and
+    /// waits for the quorum ack, so the builder yields to the runtime meanwhile.
     ///
     /// Workers only propose one batch at a time.
     fn spawn_execution_task(&mut self) -> BuildResult {
@@ -155,7 +155,7 @@ impl BatchBuilder {
         let (result, done) = oneshot::channel();
         let worker_id = self.worker_id;
         let base_fee = self.base_fee.base_fee();
-        // Use the current seq but do NOT increment yet — only advance on quorum success.
+        // Use the current seq but do NOT increment yet: only advance on quorum success.
         let seq = self.next_batch_seq;
         let gas_limit = self.gas_limit;
 
@@ -266,7 +266,7 @@ impl Future for BatchBuilder {
             // subscriber enforces. If execution lags commit, our cutoff trails the subscriber's by
             // that gap, so we may seal a few extra batches just past the boundary. That's benign:
             // those batches don't make it into this epoch's blocks and are rescued next epoch by
-            // orphan_batches — no data loss.
+            // orphan_batches, so nothing is lost.
             if this.pending_task.is_none()
                 && this.last_canonical_update.timestamp >= this.epoch_boundary
             {
@@ -278,8 +278,14 @@ impl Future for BatchBuilder {
 
             // only propose one block at a time
             if this.pending_task.is_none() {
-                // check for pending transactions
-                if this.pool.best_transactions().next().is_none() {
+                // Seal only when some pending transaction is not already in flight: sealed txs
+                // stay pending until execution releases them, so `best_transactions` keeps
+                // yielding them and gating on the bare iterator would spin sealing empty batches.
+                // The scan is O(pending) only when every pending tx is in flight, which the next
+                // canonical update (release + wake) clears.
+                let has_sealable =
+                    this.pool.best_transactions().any(|tx| !this.pool.is_in_flight(tx.hash()));
+                if !has_sealable {
                     // reset interval to wake up after some time
                     //
                     // only need to reset here if there is no pending block being built
@@ -288,7 +294,7 @@ impl Future for BatchBuilder {
                     // tick interval to ensure it advances
                     let _ = this.max_delay_interval.poll_tick(cx);
 
-                    // nothing pending
+                    // nothing to seal
                     break;
                 }
 
@@ -309,7 +315,7 @@ impl Future for BatchBuilder {
 
                         // NOTE: empty vec returned for non-fatal error during block proposal
                         if mined_transactions.is_empty() {
-                            // Quorum failed — do NOT advance next_batch_seq so the same
+                            // Quorum failed: do NOT advance next_batch_seq so the same
                             // seq number is reused for the next attempt, avoiding gaps.
                             // reset interval to prevent immediate re-wake from stale tick
                             this.max_delay_interval.reset();
@@ -318,24 +324,15 @@ impl Future for BatchBuilder {
                             break;
                         }
 
-                        // Quorum succeeded — advance the seq counter past the one we just used.
+                        // Quorum succeeded: advance the seq counter past the one we just used.
                         this.next_batch_seq = seq + 1;
 
-                        debug!(target: "block-builder", "applying block builder's update");
+                        debug!(target: "block-builder", "marking sealed transactions in flight");
 
-                        let base_fee_per_gas = this
-                            .last_canonical_update
-                            .base_fee_per_gas
-                            .unwrap_or_else(|| this.pool.get_pending_base_fee());
-
-                        // update pool to remove mined transactions
-                        this.pool.update_canonical_state(
-                            &this.last_canonical_update,
-                            base_fee_per_gas,
-                            Some(u128::MAX), // set max fee for blobs
-                            mined_transactions,
-                            vec![],
-                        );
+                        // Mark rather than evict: the txs stay pending (RPC-visible) until
+                        // execution, and `is_in_flight` keeps the next seal from re-proposing
+                        // them across the quorum-to-execution window.
+                        this.in_flight.mark(mined_transactions);
 
                         // loop again to check for any other pending transactions
                         // and possibly start building the next block
@@ -887,8 +884,71 @@ mod tests {
         // yield to try and give pool a chance to update
         tokio::task::yield_now().await;
 
-        // assert all transactions mined
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 0);
+        // Sealed transactions are marked in flight rather than evicted, so all four stay pending
+        // (RPC-visible) until execution; both batches reached quorum, so none is re-sealable.
+        let pending = txpool.pending_transactions();
+        assert_eq!(pending.len(), 4);
+        assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
+    }
+
+    /// A transaction sealed into a batch is marked in flight and skipped by the next seal, so the
+    /// same txs are not re-sealed across the quorum-to-execution window while they stay pending.
+    #[tokio::test]
+    async fn in_flight_txs_are_skipped_on_the_next_seal() {
+        let tmp_dir = TempDir::new().unwrap();
+        // keep task_manager alive: dropping it tears down the pool's validation service
+        let TestTools { mut tx_factory, execution_components, task_manager: _task_manager } =
+            get_test_tools(tmp_dir.path()).await;
+        let TestExecutionComponents { reth_env, txpool, chain } = execution_components;
+        let address = Address::from(U160::from(33));
+
+        let gas_price = reth_env.get_gas_price().unwrap();
+        let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 fits U256");
+
+        // three txs from one sender: sequential nonces, all land in the pending sub-pool
+        for _ in 0..3 {
+            tx_factory
+                .create_and_submit_eip1559_pool_tx(
+                    chain.clone(),
+                    gas_price,
+                    Address::ZERO,
+                    value,
+                    txpool.clone(),
+                )
+                .await;
+        }
+        assert_eq!(txpool.pool_size().pending, 3);
+
+        let base_fee = txpool.get_pending_base_fee();
+        let gas_limit = ETHEREUM_BLOCK_GAS_LIMIT_56BITS;
+
+        // first seal takes all three
+        let first = build_batch(
+            BatchBuilderArgs::new(txpool.clone(), address, 0),
+            0,
+            base_fee,
+            0,
+            gas_limit,
+        );
+        assert_eq!(first.mined_transactions.len(), 3);
+
+        // mark them in flight through the sealing capability, as quorum success does
+        let seal = txpool.in_flight().arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+        seal.mark(first.mined_transactions.clone());
+
+        // the txs are still pending but now skipped, so the next seal is empty
+        assert_eq!(txpool.pool_size().pending, 3);
+        let second = build_batch(
+            BatchBuilderArgs::new(txpool.clone(), address, 0),
+            0,
+            base_fee,
+            1,
+            gas_limit,
+        );
+        assert!(second.mined_transactions.is_empty(), "in-flight txs must not be re-sealed");
+
+        // reconcile keeps the marks while the txs remain pending (not yet executed)
+        txpool.reconcile_in_flight();
+        assert!(txpool.is_in_flight(first.mined_transactions.first().unwrap()));
     }
 }

--- a/crates/consensus/worker/src/batch-builder/src/test_utils.rs
+++ b/crates/consensus/worker/src/batch-builder/src/test_utils.rs
@@ -49,6 +49,11 @@ impl TxPool for TestPool {
         self.transactions.retain(|tx| !tx.is_eip4844());
         self.by_id.retain(|_, tx| !tx.is_eip4844());
     }
+
+    fn is_in_flight(&self, _tx_hash: &TxHash) -> bool {
+        // the test pool holds no in-flight tracker; seal-dedup is covered against the real pool.
+        false
+    }
 }
 
 impl TestPool {

--- a/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
@@ -11,7 +11,7 @@ use rayls_consensus_worker::{
 };
 use rayls_execution_evm::{
     payload::BuildArguments, recover_raw_transaction, reth_env::RethEnv,
-    test_utils::TransactionFactory, RethChainSpec,
+    test_utils::TransactionFactory, RethChainSpec, TxPool as _,
 };
 use rayls_infrastructure_network_types::{local::LocalNetwork, MockWorkerToPrimary};
 use rayls_infrastructure_storage::{open_db, tables::Batches};
@@ -197,11 +197,13 @@ async fn test_make_batch_el_to_cl() {
         .expect("batch in store");
     assert_eq!(batch_from_store.beneficiary, address);
 
-    // txpool should be empty after mining
-    // test_make_batch_no_ack_txs_in_pool_still tests for txs in pool without mining event
-    let pending_pool_len = txpool.pool_size().pending;
+    // Sealed transactions are marked in flight, not evicted, so they stay pending (RPC-visible)
+    // until execution drains them; every pending tx here reached quorum, so none is re-sealable.
+    // (test_make_batch_no_ack_txs_in_pool_still covers the no-quorum case.)
+    let pending = txpool.pending_transactions();
     debug!("pool_size(): {:?}", txpool.pool_size());
-    assert_eq!(pending_pool_len, 0);
+    assert_eq!(pending.len(), 3);
+    assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
 }
 
 /// Create 5 transactions.
@@ -391,10 +393,13 @@ async fn test_batch_builder_produces_valid_batches() {
     // yield to try and give pool a chance to update
     tokio::task::yield_now().await;
 
-    // assert all transactions mined/removed
+    // Sealed transactions are marked in flight, not evicted: they stay pending until execution.
+    // All four reached quorum across the two batches, so all are in flight; the blob was discarded.
     let pool_size = txpool.pool_size();
-    assert_eq!(pool_size.pending, 0);
+    assert_eq!(pool_size.pending, 4);
     assert_eq!(pool_size.blob, 0);
+    let pending = txpool.pending_transactions();
+    assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
 }
 
 /// Create 4 transactions.
@@ -573,8 +578,11 @@ async fn test_canonical_notification_updates_pool() {
     // yield to try and give pool a chance to update
     tokio::task::yield_now().await;
 
-    // assert pool empty
+    // tx1-3 executed and drained; the 4th was sealed to quorum, so it is marked in flight and
+    // stays pending (RPC-visible) until it too executes.
     let pool_size = txpool.pool_size();
     assert_eq!(pool_size.queued, 0);
-    assert_eq!(pool_size.pending, 0);
+    assert_eq!(pool_size.pending, 1);
+    let pending = txpool.pending_transactions();
+    assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
 }

--- a/crates/execution/evm/Cargo.toml
+++ b/crates/execution/evm/Cargo.toml
@@ -76,12 +76,14 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time"] }
 reth-ethereum-primitives = { workspace = true }
 secp256k1 = { workspace = true, optional = true }
+prometheus = { workspace = true }
 
 [dev-dependencies]
 rayls-infrastructure-types = { workspace = true, features = ["test-utils"] }
 rayls-execution-evm = { path = ".", features = ["test-utils"] }
 secp256k1 = { workspace = true }
 criterion = "0.5"
+proptest = { workspace = true }
 
 [features]
 default = []

--- a/crates/execution/evm/src/in_flight/marks.rs
+++ b/crates/execution/evm/src/in_flight/marks.rs
@@ -1,0 +1,214 @@
+use crate::in_flight::InFlightTracker;
+use alloy::primitives::TxHash;
+use std::time::{Duration, Instant};
+
+/// Governs when a mark becomes eligible for release: a base wait, an exponential backoff cap
+/// on repeated resends, and a minimum execution-anchor advance since the mark was last set.
+#[derive(Copy, Clone, Debug)]
+pub struct DuePolicy {
+    /// Base wait before a fresh mark is due.
+    pub after: Duration,
+    /// Upper bound on the backoff shift applied per resend attempt, so wait time plateaus
+    /// instead of growing unbounded under a stuck transaction.
+    pub backoff_shift_cap: u32,
+    /// Minimum execution-anchor advance required since the mark was set, in addition to the
+    /// time-based wait, so a mark cannot come due before at least one new block was seen.
+    pub min_anchor_advance: u64,
+}
+
+impl DuePolicy {
+    /// Builds a pure time-based policy with no backoff or anchor requirement.
+    pub const fn ttl(after: Duration) -> Self {
+        Self { after, backoff_shift_cap: 0, min_anchor_advance: 0 }
+    }
+}
+
+/// The state of one tracked hash: sent and awaiting a due check, or acknowledged stale by the
+/// forwarder. `AckedStale` is a terminal state outside the resend/expiry cycle - see `is_due`.
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum Mark {
+    /// Sent at `at` while the execution anchor was `anchor`, after `attempts` prior resends.
+    Sent { at: Instant, anchor: u64, attempts: u32 },
+    /// Confirmed no longer live by the forwarder; never due, released only by reconcile or clear.
+    AckedStale,
+}
+
+impl Mark {
+    /// Returns whether this mark is eligible for release under the given policy at `now`/`anchor`.
+    ///
+    /// An `AckedStale` mark is never due: it is released only by an explicit reconcile or clear,
+    /// never by a TTL sweep, since the forwarder already knows the transaction is stale.
+    pub(crate) fn is_due(&self, now: Instant, anchor: u64, policy: &DuePolicy) -> bool {
+        match *self {
+            Mark::Sent { at, anchor: mark_anchor, attempts } => {
+                let shift = attempts.min(policy.backoff_shift_cap).min(31);
+                let wait = policy.after.saturating_mul(1u32 << shift);
+                now.duration_since(at) >= wait
+                    && anchor >= mark_anchor.saturating_add(policy.min_anchor_advance)
+            }
+            Mark::AckedStale => false,
+        }
+    }
+
+    /// Refreshes a `Sent` mark to the given time/anchor and bumps its attempt count; a no-op
+    /// on an `AckedStale` mark, which never resends.
+    pub(crate) fn resend(&mut self, now: Instant, anchor: u64) {
+        if let Self::Sent { attempts, .. } = self {
+            *self = Self::Sent { at: now, anchor, attempts: attempts.saturating_add(1) };
+        }
+    }
+}
+
+/// The role the tracker is currently armed for, carrying the policy sealing needs to decide
+/// when a mark is due (forwarding decides due-ness per call via its own stored policy instead).
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum Armed {
+    /// The block builder, with the policy its TTL sweep releases under.
+    Sealing(DuePolicy),
+    /// The gossip forwarder, which decides due-ness per call through its own handle.
+    Forwarding,
+}
+
+/// A capability handle scoping mark writes to the sealing role, returned by
+/// `InFlightTracker::arm_sealing` so a caller cannot mark hashes without first arming.
+#[derive(Debug)]
+pub struct SealMarks {
+    tracker: InFlightTracker,
+}
+
+impl SealMarks {
+    /// Wraps a tracker already armed for sealing.
+    pub fn new(tracker: InFlightTracker) -> Self {
+        Self { tracker }
+    }
+
+    /// Marks the given hashes as freshly sent, resetting their due clock.
+    pub fn mark(&self, hashes: impl IntoIterator<Item = TxHash>) {
+        self.tracker.track_all(hashes, Mark::Sent { at: Instant::now(), anchor: 0, attempts: 0 });
+    }
+}
+
+/// A point-in-time read of one hash's forwarding state, combining presence and due-ness so a
+/// caller need not take the tracker lock twice to answer both questions consistently.
+#[derive(Debug, Copy, Clone)]
+pub struct ForwardProbe {
+    /// Whether the hash is currently tracked as forwarded.
+    pub forwarded: bool,
+    /// Whether the hash is untracked or its mark is due for resend/release.
+    pub due: bool,
+}
+
+/// A capability handle scoping mark writes to the forwarding role, returned by
+/// `InFlightTracker::arm_forwarding` so a caller cannot mark hashes without first arming.
+#[derive(Debug, Clone)]
+pub struct ForwardMarks {
+    tracker: InFlightTracker,
+    policy: DuePolicy,
+}
+
+impl ForwardMarks {
+    /// Wraps a tracker already armed for forwarding, under the given expiry policy.
+    pub fn new(tracker: InFlightTracker, policy: DuePolicy) -> Self {
+        Self { tracker, policy }
+    }
+
+    /// Returns whether the given hash is untracked or due under this round's policy.
+    pub fn is_due(&self, hash: &TxHash, now: Instant, anchor: u64) -> bool {
+        self.tracker.is_due(hash, now, anchor, &self.policy)
+    }
+
+    /// Returns whether the given hash is currently tracked as forwarded.
+    pub fn is_forwarded(&self, hash: &TxHash) -> bool {
+        self.tracker.is_in_flight(hash)
+    }
+
+    /// Reads presence and due-ness for the given hash under one lock acquisition, so the two
+    /// facts reflect the same instant instead of two independently-locked reads racing a
+    /// concurrent writer.
+    pub fn probe(&self, hash: &TxHash, now: Instant, anchor: u64) -> ForwardProbe {
+        let guard = self.tracker.inner.read();
+        let mark = guard.marks.get(hash);
+        ForwardProbe {
+            forwarded: mark.is_some(),
+            due: mark.is_none_or(|m| m.is_due(now, anchor, &self.policy)),
+        }
+    }
+
+    /// Records a forward attempt for the given hashes: resends an existing mark (bumping its
+    /// backoff) or inserts a fresh one, so a first forward and a retry share one code path.
+    pub fn mark_forwarded(
+        &self,
+        hashes: impl IntoIterator<Item = TxHash>,
+        now: Instant,
+        anchor: u64,
+    ) {
+        let mut hashes = hashes.into_iter().peekable();
+        if hashes.peek().is_none() {
+            return;
+        }
+
+        let mut guard = self.tracker.inner.write();
+        let previous_marks_len = guard.marks.len();
+        for hash in hashes {
+            guard
+                .marks
+                .entry(hash)
+                .and_modify(|mark| mark.resend(now, anchor))
+                .or_insert(Mark::Sent { at: now, anchor, attempts: 0 });
+        }
+        let current_marks_len = guard.marks.len();
+        drop(guard);
+        self.tracker.on_marked(previous_marks_len, current_marks_len);
+        self.tracker.on_forwarded(previous_marks_len, current_marks_len);
+    }
+
+    /// Marks the given hashes acknowledged-stale: forwarded once, confirmed no longer live, and
+    /// exempt from further resend or TTL release until explicitly reconciled or cleared.
+    pub fn mark_acked_stale(&self, hashes: impl IntoIterator<Item = TxHash>) {
+        self.tracker.track_all(hashes, Mark::AckedStale);
+    }
+}
+
+/// Schema version of `MarkBackup`, bumped whenever its serialized shape changes so a backup
+/// written by a prior version is rejected instead of misread.
+pub const MARK_BACKUP_VERSION: u32 = 1;
+
+/// A serializable snapshot of the marks tracked for one role, persisted across a restart and
+/// restored via `InFlightTracker::stash_restore` once re-armed for the matching role.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MarkBackup {
+    /// Schema version this backup was written under; see `MARK_BACKUP_VERSION`.
+    pub version: u32,
+    /// The role the marks were captured under; a restore for a different role is discarded.
+    pub role: MarkRole,
+    /// The captured marks, sorted by hash for deterministic serialization.
+    pub marks: Vec<SavedMark>,
+}
+
+/// The role a captured `MarkBackup` belongs to, mirroring `Armed` in a serializable form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MarkRole {
+    /// Marks owned by the block builder.
+    Sealing,
+    /// Marks owned by the gossip forwarder.
+    Forwarding,
+}
+
+/// One tracked hash's mark, in the serializable form used by `MarkBackup`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SavedMark {
+    /// The tracked transaction hash.
+    pub hash: TxHash,
+    /// The mark state to restore for this hash.
+    pub kind: SavedMarkKind,
+}
+
+/// The serializable form of `Mark`, carrying only the state needed to resume tracking after a
+/// restart (the wall-clock `at`/`anchor` fields are re-stamped fresh on restore instead).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SavedMarkKind {
+    /// A `Mark::Sent` reduced to its resend count; the clock and anchor are re-stamped on restore.
+    Sent { attempts: u32 },
+    /// A `Mark::AckedStale`.
+    AckedStale,
+}

--- a/crates/execution/evm/src/in_flight/metrics.rs
+++ b/crates/execution/evm/src/in_flight/metrics.rs
@@ -1,0 +1,113 @@
+use prometheus::{default_registry, IntCounter, IntGauge, Registry};
+use std::sync::LazyLock;
+
+const IN_FLIGHT_GAUGE: &str = "rayls_txpool_in_flight";
+const MARKED_COUNTER: &str = "rayls_txpool_in_flight_marked_total";
+const RELEASED_RECONCILE_COUNTER: &str = "rayls_txpool_in_flight_released_reconcile";
+const RELEASED_TTL_COUNTER: &str = "rayls_txpool_in_flight_released_ttl";
+const RELEASED_CLEAR_COUNTER: &str = "rayls_txpool_in_flight_released_clear";
+const RELEASED_DROPPED_COUNTER: &str = "rayls_txpool_in_flight_released_dropped";
+const MARKED_FORWARD_COUNTER: &str = "rayls_txpool_in_flight_marked_forward";
+const RESTORED_COUNTER: &str = "rayls_txpool_in_flight_restored_total";
+
+/// Prometheus counters and gauge backing one `InFlightTracker`; each registration description is
+/// that metric's HELP text.
+#[derive(Clone, Debug)]
+pub(super) struct InFlightMetrics {
+    pub gauge: IntGauge,
+    pub marked: IntCounter,
+    pub marked_forward: IntCounter,
+    pub released_reconcile: IntCounter,
+    pub released_dropped: IntCounter,
+    pub released_ttl: IntCounter,
+    pub released_clear: IntCounter,
+    pub restored: IntCounter,
+}
+
+impl InFlightMetrics {
+    /// Registers every counter/gauge against the given registry; fails if any metric name is
+    /// already registered there.
+    pub(crate) fn register(registry: &Registry) -> Result<Self, prometheus::Error> {
+        Ok(Self {
+            gauge: prometheus::register_int_gauge_with_registry!(
+                IN_FLIGHT_GAUGE,
+                "Transactions currently marked in-flight (sealed or forwarded, not yet executed)",
+                registry
+            )?,
+            marked: prometheus::register_int_counter_with_registry!(
+                MARKED_COUNTER,
+                "Total hashes marked in-flight",
+                registry
+            )?,
+            marked_forward: prometheus::register_int_counter_with_registry!(
+                MARKED_FORWARD_COUNTER,
+                "Hashes marked in-flight by the forwarder (the rest of `marked` is the sealer's)",
+                registry
+            )?,
+            released_reconcile: prometheus::register_int_counter_with_registry!(
+                RELEASED_RECONCILE_COUNTER,
+                "Marks released because the transaction left the PENDING sub-pool (executed, superseded, evicted, or downgraded to queued)",
+                registry
+            )?,
+            released_dropped: prometheus::register_int_counter_with_registry!(
+                RELEASED_DROPPED_COUNTER,
+                "Marks released because the batch executed but dropped the transaction (nonce too high); the tx stays pooled and re-sealable",
+                registry
+            )?,
+            released_ttl: prometheus::register_int_counter_with_registry!(
+                RELEASED_TTL_COUNTER,
+                "Marks released by the TTL sweep (the sealed batch never executed)",
+                registry
+            )?,
+            released_clear: prometheus::register_int_counter_with_registry!(
+                RELEASED_CLEAR_COUNTER,
+                "Marks released by the epoch-transition clear",
+                registry
+            )?,
+            restored: prometheus::register_int_counter_with_registry!(
+                RESTORED_COUNTER,
+                "Marks reinstated from the shutdown mark backup at the first arming",
+                registry
+            )?,
+        })
+    }
+}
+
+/// The process-wide metrics instance shared by every `InFlightTracker::new()`. Falls back to a
+/// fresh, unregistered registry if `default_registry()` already has these names registered (e.g.
+/// a second tracker in the same process during tests), so construction never panics in that case.
+pub(crate) static IN_FLIGHT_METRICS: LazyLock<InFlightMetrics> = LazyLock::new(|| {
+    InFlightMetrics::register(default_registry())
+        .unwrap_or_else(|_| InFlightMetrics::register(&Registry::new()).expect("fresh registry"))
+});
+
+#[cfg(test)]
+impl InFlightMetrics {
+    /// Registers a fresh, isolated instance for a test so its counters cannot collide with the
+    /// process-wide `IN_FLIGHT_METRICS` or another test's.
+    pub(crate) fn register_fresh() -> Self {
+        Self::register(&Registry::new()).expect("a fresh registry should always succeed")
+    }
+
+    /// Returns `(marked, released_reconcile, released_ttl, released_clear)` for assertions.
+    pub(crate) fn counts(&self) -> (u64, u64, u64, u64) {
+        (
+            self.marked.get(),
+            self.released_reconcile.get(),
+            self.released_ttl.get(),
+            self.released_clear.get(),
+        )
+    }
+
+    /// Derives the outstanding mark count from the counters rather than reading the gauge
+    /// directly, so a test can cross-check the gauge against an independent computation.
+    pub(crate) fn outstanding(&self) -> i64 {
+        let (marked, reconcile, ttl, clear) = self.counts();
+        marked as i64 - reconcile as i64 - ttl as i64 - clear as i64
+    }
+
+    /// Returns the current gauge reading.
+    pub(crate) fn gauge(&self) -> i64 {
+        self.gauge.get()
+    }
+}

--- a/crates/execution/evm/src/in_flight/mod.rs
+++ b/crates/execution/evm/src/in_flight/mod.rs
@@ -1,0 +1,410 @@
+// allow: long-doc module overview of the in-flight tracker feature (roles, marks, release, restart)
+//! Tracking of transactions sent to the mempool but not yet observed mined, so a sealing or
+//! forwarding round can skip the hashes it already has outstanding instead of resending them.
+//!
+//! # Why it exists
+//!
+//! Both the block builder and the transaction forwarder repeatedly scan the pending sub-pool and
+//! push its transactions onward: the builder seals them into batches, the forwarder gossips them
+//! to the current leader. With no memory of what is already outstanding, every scan re-sends the
+//! same hashes, so a transaction stuck behind a deep inclusion backlog is sealed into batch after
+//! batch (wasted bytes) or re-gossiped every round (network amplification). [`InFlightTracker`] is
+//! that memory: a hash is marked when sent and released when the pool proves it is no longer
+//! pending, and each round consults the tracker to skip what is still in flight.
+//!
+//! # Roles
+//!
+//! The two consumers have different release semantics, so the tracker is armed for exactly one
+//! [`MarkRole`] at a time and hands back a capability handle that scopes the writes it allows:
+//!
+//! - **Sealing** ([`SealMarks`]) is the block builder. Arming installs a policy-driven sweep
+//!   ([`InFlightTracker::sweep_due`]) that releases marks once their batch is old enough to be
+//!   presumed lost, and each arm starts from an empty set because a new sealing round has no
+//!   relation to the prior one.
+//! - **Forwarding** ([`ForwardMarks`]) is the gossip forwarder. It installs no sweep: the forwarder
+//!   re-drives its own resends through a due check with exponential backoff, so a flat sweep would
+//!   erase that backoff and reintroduce the amplification it exists to stop. Forwarding marks
+//!   survive an epoch boundary ([`InFlightTracker::clear`] keeps them) because validator pools
+//!   persist across it, and re-publishing the whole pool with the backoff erased would flood the
+//!   leader.
+//!
+//! # Marks and due-ness
+//!
+//! A tracked hash holds one `Mark`: `Sent`, carrying the send time, the execution anchor at send,
+//! and a resend-attempt count; or `AckedStale`, the terminal state the forwarder mints once it has
+//! confirmed a forwarded transaction is no longer live but still wants further resends suppressed.
+//! A `Sent` mark comes due under a [`DuePolicy`] combining a base wait, a per-attempt exponential
+//! backoff (capped), and a minimum anchor advance, so a mark cannot release on wall-clock time
+//! alone before the node has seen at least one new block. An `AckedStale` mark is never due; only
+//! an explicit reconcile or clear releases it.
+//!
+//! # Release paths and the release watch
+//!
+//! A mark leaves the set through one of several paths, each counted under its own cause so TTL
+//! churn stays distinguishable from healthy execution-driven release: reconcile against the live
+//! pending set ([`InFlightTracker::release_mined`]), an explicit drop of pool-rejected hashes
+//! ([`InFlightTracker::release_dropped`]), the sealing TTL sweep, and the epoch-transition clear.
+//! Every release that frees at least one mark ticks the release watch
+//! ([`InFlightTracker::release_events`]) exactly once - once per release *call*, not per hash -
+//! which is the builder's only wake-up signal that transactions are re-selectable again; a no-op
+//! release must not tick it, or the builder spins on wakes that select nothing.
+//!
+//! # Restart survival
+//!
+//! Marks are captured to a versioned, serializable [`MarkBackup`] ([`InFlightTracker::snapshot`])
+//! and staged for the next boot ([`InFlightTracker::stash_restore`]). The stash is applied lazily
+//! at the next arm, and only when its role matches: a restore for the wrong role is discarded
+//! rather than corrupt the freshly armed state. Wall-clock fields are re-stamped fresh on restore,
+//! so only the resend and backoff state carries across, never a stale clock.
+//!
+//! # Concurrency
+//!
+//! The tracker is a cheaply cloned handle over one shared `parking_lot::RwLock`, and up to four
+//! writers can race it: the builder marks, the canonical-chain task releases mined hashes, a sweep
+//! expires, and the epoch transition clears. Correctness does not depend on their interleaving.
+//! Every mutation reads the set size before and after its change under the one write lock and
+//! derives its metric delta from that pair, so the deltas telescope and the conservation identity
+//! `marked - reconcile - ttl - clear = live set size` (and the gauge) holds under any
+//! linearization.
+
+use crate::in_flight::metrics::{InFlightMetrics, IN_FLIGHT_METRICS};
+use alloy::primitives::{
+    map::{B256Map, B256Set},
+    TxHash,
+};
+use parking_lot::RwLock;
+#[cfg(test)]
+use std::time::Duration;
+use std::{sync::Arc, time::Instant};
+use tracing::info;
+
+mod marks;
+mod metrics;
+
+pub use marks::*;
+
+#[derive(Default, Debug)]
+struct Inner {
+    marks: B256Map<Mark>,
+    armed: Option<Armed>,
+    // Staged by `stash_restore` ahead of the arm that will use it, since the caller
+    // (e.g. crash recovery) knows the saved role before the tracker is re-armed. Applied
+    // lazily in `consume_stash` so a restore for the wrong role is dropped instead of
+    // corrupting the freshly armed state.
+    pending_restore: Option<MarkBackup>,
+}
+
+/// Shared, cheaply cloned handle over the in-flight mark set; see the module header for the
+/// roles, release paths, and restart behavior.
+#[derive(Clone, Debug)]
+pub struct InFlightTracker {
+    inner: Arc<RwLock<Inner>>,
+    metrics: InFlightMetrics,
+    release_epoch: tokio::sync::watch::Sender<u64>,
+}
+
+impl Default for InFlightTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InFlightTracker {
+    /// Creates a tracker backed by the process-wide in-flight metrics.
+    pub fn new() -> Self {
+        Self::with_metrics(IN_FLIGHT_METRICS.clone())
+    }
+
+    fn with_metrics(metrics: InFlightMetrics) -> Self {
+        Self { inner: Arc::default(), metrics, release_epoch: tokio::sync::watch::Sender::new(0) }
+    }
+
+    /// Arms the tracker for a sealing round under the given expiry policy, discarding any
+    /// marks left from the prior round.
+    pub fn arm_sealing(&self, policy: DuePolicy) -> SealMarks {
+        let mut guard = self.inner.write();
+        let previous_marks_len = guard.marks.len();
+        // Wipe unconditionally: a new sealing round has no relation to whatever the prior
+        // arm tracked. Only `pending_restore`, staged separately, survives into the new round.
+        guard.marks.clear();
+        guard.armed = Some(Armed::Sealing(policy));
+        let restored = Self::consume_stash(&mut guard, MarkRole::Sealing);
+        drop(guard);
+        self.on_released(previous_marks_len, 0, &self.metrics.released_clear);
+        self.on_restored(restored, MarkRole::Sealing);
+        SealMarks::new(self.clone())
+    }
+
+    /// Arms the tracker for a forwarding round under the given expiry policy, restoring any
+    /// marks stashed for the forwarding role.
+    pub fn arm_forwarding(&self, policy: DuePolicy) -> ForwardMarks {
+        let mut guard = self.inner.write();
+        guard.armed = Some(Armed::Forwarding);
+        let restored = Self::consume_stash(&mut guard, MarkRole::Forwarding);
+        drop(guard);
+        self.on_restored(restored, MarkRole::Forwarding);
+        ForwardMarks::new(self.clone(), policy)
+    }
+}
+
+impl InFlightTracker {
+    /// Returns whether no hashes are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().marks.is_empty()
+    }
+
+    /// Returns the tracked hash count.
+    pub fn len(&self) -> usize {
+        self.inner.read().marks.len()
+    }
+
+    /// Returns whether the given hash is tracked; true for an `AckedStale` hash too, which no
+    /// sweep releases on its own.
+    pub fn is_in_flight(&self, hash: &TxHash) -> bool {
+        self.inner.read().marks.contains_key(hash)
+    }
+
+    fn is_due(&self, hash: &TxHash, now: Instant, anchor: u64, policy: &DuePolicy) -> bool {
+        self.inner.read().marks.get(hash).is_none_or(|mark| mark.is_due(now, anchor, policy))
+    }
+
+    /// Subscribes to the release epoch, which ticks each time one or more marks are released.
+    pub fn release_events(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.release_epoch.subscribe()
+    }
+}
+
+impl InFlightTracker {
+    fn track_all(&self, hashes: impl IntoIterator<Item = TxHash>, mark: Mark) {
+        let mut hashes = hashes.into_iter().peekable();
+        if hashes.peek().is_none() {
+            return;
+        }
+
+        let mut guard = self.inner.write();
+        let previous_marks_len = guard.marks.len();
+        for hash in hashes {
+            guard.marks.insert(hash, mark);
+        }
+        let current_marks_len = guard.marks.len();
+        drop(guard);
+        self.on_marked(previous_marks_len, current_marks_len)
+    }
+
+    /// Releases marks due under the active sealing policy at the given execution anchor;
+    /// a no-op unless the tracker is armed for sealing.
+    pub fn sweep_due(&self, anchor: u64) -> usize {
+        let Some(Armed::Sealing(policy)) = self.inner.read().armed else {
+            return 0;
+        };
+        self.release_due(anchor, &policy)
+    }
+
+    fn release_due(&self, anchor: u64, policy: &DuePolicy) -> usize {
+        let mut guard = self.inner.write();
+        let previous_marks_len = guard.marks.len();
+        guard.marks.retain(|_, mark| !mark.is_due(Instant::now(), anchor, policy));
+        let current_marks_len = guard.marks.len();
+        drop(guard);
+        self.on_released(previous_marks_len, current_marks_len, &self.metrics.released_ttl);
+        previous_marks_len - current_marks_len
+    }
+
+    /// Releases the given hashes, e.g. transactions the pool dropped before mining.
+    pub fn release_dropped(&self, hashes: impl IntoIterator<Item = TxHash>) {
+        let mut hashes = hashes.into_iter().peekable();
+        if hashes.peek().is_none() {
+            return;
+        }
+
+        let mut guard = self.inner.write();
+        let previous_marks_len = guard.marks.len();
+        for hash in hashes {
+            guard.marks.remove(&hash);
+        }
+        let current_marks_len = guard.marks.len();
+        drop(guard);
+        self.on_released(previous_marks_len, current_marks_len, &self.metrics.released_dropped);
+    }
+
+    /// Reconciles against the given live set, releasing every tracked hash absent from it.
+    pub fn release_mined(&self, live: &B256Set) -> usize {
+        let mut guard = self.inner.write();
+        let previous_marks_len = guard.marks.len();
+        guard.marks.retain(|hash, _| live.contains(hash));
+        let current_marks_len = guard.marks.len();
+        drop(guard);
+        self.on_released(previous_marks_len, current_marks_len, &self.metrics.released_reconcile)
+    }
+
+    /// Disarms the tracker, releasing all tracked marks except forwarding marks (which persist
+    /// for the next arm to inherit or explicitly release).
+    pub fn clear(&self) {
+        let released = {
+            let mut guard = self.inner.write();
+            let released = match guard.armed {
+                Some(Armed::Sealing(_)) => {
+                    let previous_marks_len = guard.marks.len();
+                    guard.marks.clear();
+                    previous_marks_len
+                }
+                // Forwarding marks (including AckedStale) outlive an epoch boundary by
+                // design: the forwarder tracks acknowledgement across restarts via
+                // stash/restore, so `clear` only disarms and leaves the marks for the
+                // next arm to inherit or explicitly release.
+                Some(Armed::Forwarding) => 0,
+                None => {
+                    let previous_marks_len = guard.marks.len();
+                    guard.marks.clear();
+                    previous_marks_len
+                }
+            };
+
+            guard.armed = None;
+            released
+        };
+
+        if released > 0 {
+            self.on_released(released, 0, &self.metrics.released_clear);
+        }
+    }
+}
+
+impl InFlightTracker {
+    fn on_marked(&self, previous_marks_len: usize, current_marks_len: usize) {
+        let delta = current_marks_len.saturating_sub(previous_marks_len);
+        self.metrics.marked.inc_by(delta as u64);
+        self.metrics.gauge.add(delta as i64);
+    }
+
+    fn on_forwarded(&self, previous_marks_len: usize, current_marks_len: usize) {
+        let delta = current_marks_len.saturating_sub(previous_marks_len);
+        self.metrics.marked_forward.inc_by(delta as u64);
+    }
+
+    fn on_released(
+        &self,
+        previous_marks_len: usize,
+        current_marks_len: usize,
+        counter: &prometheus::IntCounter,
+    ) -> usize {
+        let delta = previous_marks_len.saturating_sub(current_marks_len);
+        if delta > 0 {
+            counter.inc_by(delta as u64);
+            self.release_epoch.send_modify(|epoch| *epoch += 1);
+        }
+        self.metrics.gauge.sub(delta as i64);
+        delta
+    }
+}
+
+impl InFlightTracker {
+    /// Captures the current marks for the armed role, sorted for deterministic serialization.
+    /// Returns `None` if the tracker is unarmed.
+    pub fn snapshot(&self) -> Option<MarkBackup> {
+        let guard = self.inner.read();
+        let role = match guard.armed? {
+            Armed::Sealing(_) => MarkRole::Sealing,
+            Armed::Forwarding => MarkRole::Forwarding,
+        };
+        let mut marks: Vec<SavedMark> = guard
+            .marks
+            .iter()
+            .map(|(hash, mark)| SavedMark {
+                hash: *hash,
+                kind: match *mark {
+                    Mark::Sent { attempts, .. } => SavedMarkKind::Sent { attempts },
+                    Mark::AckedStale => SavedMarkKind::AckedStale,
+                },
+            })
+            .collect();
+        drop(guard);
+        marks.sort_unstable_by_key(|mark| mark.hash);
+        Some(MarkBackup { version: MARK_BACKUP_VERSION, role, marks })
+    }
+
+    /// Stages a previously captured snapshot to be restored on the next matching-role arm.
+    pub fn stash_restore(&self, backup: MarkBackup) {
+        self.inner.write().pending_restore = Some(backup);
+    }
+
+    fn consume_stash(guard: &mut Inner, role: MarkRole) -> usize {
+        let Some(backup) = guard.pending_restore.take() else { return 0 };
+        if backup.role != role {
+            info!(
+                target: "rayls::txpool",
+                discarded = backup.marks.len(),
+                saved_role = ?backup.role,
+                armed_role = ?role,
+                "discarded restored in-flight marks on role change"
+            );
+            return 0;
+        }
+        let now = Instant::now();
+        let before = guard.marks.len();
+        for mark in backup.marks {
+            let restored = match mark.kind {
+                SavedMarkKind::Sent { attempts } => Mark::Sent { at: now, anchor: 0, attempts },
+                // only the forwarder mints acked-stale marks; under a sealing arm one would
+                // strand its tx past the TTL (the sweep never releases acked-stale)
+                SavedMarkKind::AckedStale if role == MarkRole::Sealing => continue,
+                SavedMarkKind::AckedStale => Mark::AckedStale,
+            };
+            guard.marks.insert(mark.hash, restored);
+        }
+        guard.marks.len() - before
+    }
+
+    fn on_restored(&self, n: usize, role: MarkRole) {
+        if n > 0 {
+            self.metrics.marked.inc_by(n as u64);
+            self.metrics.restored.inc_by(n as u64);
+            info!(target: "rayls::txpool", restored = n, ?role, "restored in-flight marks");
+        }
+        // Add the restored count directly rather than re-reading `self.len()`, which would take
+        // the read lock a second time and could observe a length a concurrent writer already moved.
+        self.metrics.gauge.add(n as i64);
+    }
+}
+
+#[cfg(test)]
+impl InFlightTracker {
+    fn with_fresh_metrics() -> Self {
+        Self::with_metrics(InFlightMetrics::register_fresh())
+    }
+
+    fn metrics(&self) -> &InFlightMetrics {
+        &self.metrics
+    }
+
+    /// Marks the given hashes in-flight directly, bypassing the sealing/forwarding arm flow.
+    pub fn mark_in_flight(&self, hashes: impl IntoIterator<Item = TxHash>) {
+        self.track_all(hashes, Mark::Sent { at: Instant::now(), anchor: 0, attempts: 0 });
+    }
+
+    /// Returns every tracked hash, `AckedStale` included.
+    pub fn tracked_hashes(&self) -> Vec<TxHash> {
+        let guard = self.inner.read();
+        guard.marks.keys().cloned().collect()
+    }
+
+    /// Releases the given hashes directly, bypassing the sealing/forwarding arm flow.
+    pub fn release_in_flight(&self, hashes: impl IntoIterator<Item = TxHash>) {
+        let mut guard = self.inner.write();
+        let before = guard.marks.len();
+        for hash in hashes {
+            guard.marks.remove(&hash);
+        }
+        let len = guard.marks.len();
+        drop(guard);
+        self.on_released(before, len, &self.metrics.released_reconcile);
+    }
+
+    /// Releases marks older than the given TTL, independent of any armed policy.
+    pub fn sweep_expired(&self, ttl: Duration) -> usize {
+        self.release_due(0, &DuePolicy::ttl(ttl))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/execution/evm/src/in_flight/tests.rs
+++ b/crates/execution/evm/src/in_flight/tests.rs
@@ -1,0 +1,611 @@
+use super::*;
+use proptest::prelude::*;
+
+fn hash(n: u64) -> TxHash {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&n.to_be_bytes());
+    TxHash::from(bytes)
+}
+
+/// A stale ack is terminal: never due again however far time and the anchor advance, not
+/// revived by a racing forward mark, released only by the membership reconcile. Fails
+/// against release-on-ack semantics, where the hash reads unmarked and due.
+#[test]
+fn acked_stale_suppresses_resends_until_released_by_membership() {
+    let tracker = InFlightTracker::with_fresh_metrics();
+    let marks = tracker.arm_forwarding(DuePolicy {
+        after: Duration::from_secs(10),
+        backoff_shift_cap: 4,
+        min_anchor_advance: 20,
+    });
+    let now = Instant::now();
+    marks.mark_forwarded([hash(1)], now, 0);
+    marks.mark_acked_stale([hash(1)]);
+
+    let late = now + Duration::from_secs(3600);
+    assert!(marks.is_forwarded(&hash(1)));
+    assert!(!marks.is_due(&hash(1), late, u64::MAX));
+    // a racing forward mark does not downgrade the ack
+    marks.mark_forwarded([hash(1)], late, u64::MAX);
+    assert!(!marks.is_due(&hash(1), late + Duration::from_secs(3600), u64::MAX));
+    // execution pruning the transaction from the pool is the release path
+    tracker.release_in_flight([hash(1)]);
+    assert!(marks.is_due(&hash(1), late, 0));
+}
+
+#[test]
+fn mark_and_query_roundtrip() {
+    let tracker = InFlightTracker::new();
+    tracker.mark_in_flight([hash(1), hash(2)]);
+    assert!(tracker.is_in_flight(&hash(1)) && tracker.is_in_flight(&hash(2)));
+    assert!(!tracker.is_in_flight(&hash(3)));
+    let tracked = tracker.tracked_hashes();
+    assert_eq!(tracked.len(), 2);
+    // the copy is point-in-time: later mutations do not affect it
+    tracker.release_in_flight([hash(1)]);
+    assert!(tracked.contains(&hash(1)));
+    assert!(!tracker.is_in_flight(&hash(1)));
+    assert_eq!(tracker.len(), 1);
+}
+
+#[test]
+fn release_ignores_unknown_hashes() {
+    let tracker = InFlightTracker::new();
+    tracker.mark_in_flight([hash(1)]);
+    tracker.release_in_flight([hash(1), hash(99)]);
+    assert!(tracker.is_empty());
+}
+
+#[test]
+fn clones_share_one_set() {
+    let tracker = InFlightTracker::new();
+    let clone = tracker.clone();
+    tracker.mark_in_flight([hash(7)]);
+    assert!(clone.is_in_flight(&hash(7)));
+    clone.clear();
+    assert!(tracker.is_empty());
+}
+
+#[test]
+fn sweep_respects_ttl() {
+    let tracker = InFlightTracker::new();
+    tracker.mark_in_flight([hash(1), hash(2)]);
+    // a generous TTL keeps fresh entries
+    assert_eq!(tracker.sweep_expired(Duration::from_secs(60)), 0);
+    assert_eq!(tracker.len(), 2);
+    // a zero TTL expires everything
+    assert_eq!(tracker.sweep_expired(Duration::ZERO), 2);
+    assert!(tracker.is_empty());
+}
+
+#[test]
+fn clear_empties_the_set() {
+    let tracker = InFlightTracker::new();
+    tracker.mark_in_flight((0..10).map(hash));
+    tracker.clear();
+    assert!(tracker.is_empty());
+    assert!(tracker.tracked_hashes().is_empty());
+}
+
+/// The sweep is a strict age-vs-TTL comparison: an entry younger than the TTL survives the
+/// sweep, an entry older is dropped. The TTL is a floor, never a target - shrinking it only
+/// trades batch bytes (duplicates skip deterministically at execution), but a sweep that
+/// fires early would release txs whose batch is still in flight.
+#[test]
+fn sweep_drops_only_entries_older_than_ttl() {
+    let tracker = InFlightTracker::new();
+    tracker.mark_in_flight([hash(1)]);
+    std::thread::sleep(Duration::from_millis(120));
+    tracker.mark_in_flight([hash(2)]);
+
+    // hash(1) is ~120ms old, hash(2) fresh: a 80ms TTL sweeps exactly the aged entry
+    assert_eq!(tracker.sweep_expired(Duration::from_millis(80)), 1);
+    assert!(!tracker.is_in_flight(&hash(1)));
+    assert!(tracker.is_in_flight(&hash(2)));
+
+    // a TTL larger than every entry's age sweeps nothing
+    assert_eq!(tracker.sweep_expired(Duration::from_secs(60)), 0);
+    assert!(tracker.is_in_flight(&hash(2)));
+}
+
+/// Every release path (targeted release, TTL sweep, epoch clear) must bump the release
+/// watch: it is the builder's only wake-up signal for re-selectable txs. No-op releases
+/// must not bump it, or the builder spins on wakes that select nothing.
+#[test]
+fn release_paths_bump_the_release_watch() {
+    let tracker = InFlightTracker::new();
+    let events = tracker.release_events();
+    let epoch = || *events.borrow();
+    assert_eq!(epoch(), 0);
+
+    // marking is not a release
+    tracker.mark_in_flight([hash(1), hash(2), hash(3)]);
+    assert_eq!(epoch(), 0);
+
+    tracker.release_in_flight([hash(1)]);
+    assert_eq!(epoch(), 1);
+
+    // releasing only unknown hashes is a no-op
+    tracker.release_in_flight([hash(99)]);
+    assert_eq!(epoch(), 1);
+
+    assert_eq!(tracker.sweep_expired(Duration::ZERO), 2);
+    assert_eq!(epoch(), 2);
+
+    // sweeping an empty set is a no-op
+    assert_eq!(tracker.sweep_expired(Duration::ZERO), 0);
+    assert_eq!(epoch(), 2);
+
+    tracker.mark_in_flight([hash(4)]);
+    tracker.clear();
+    assert_eq!(epoch(), 3);
+
+    // clearing an empty set is a no-op
+    tracker.clear();
+    assert_eq!(epoch(), 3);
+}
+
+/// The counters are deltas of the set, not of the caller's input, so marked minus the three
+/// release counters always equals the live set size - and the gauge. A re-mark of a tracked
+/// hash and a release of an untracked one must both count as nothing, or the identity drifts
+/// and TTL churn can no longer be separated from healthy execution-driven releases.
+#[test]
+fn counter_deltas_reconcile_with_the_gauge() {
+    let tracker = InFlightTracker::with_fresh_metrics();
+    tracker.mark_in_flight((0..5).map(hash));
+    // hash(0) and hash(1) are already tracked: only hash(5) is a new mark
+    tracker.mark_in_flight([hash(0), hash(1), hash(5)]);
+    // hash(99) was never marked: only hash(0) is a real release
+    tracker.release_in_flight([hash(0), hash(99)]);
+
+    std::thread::sleep(Duration::from_millis(80));
+    tracker.mark_in_flight([hash(6)]);
+    // everything but the fresh hash(6) is older than the TTL
+    assert_eq!(tracker.sweep_expired(Duration::from_millis(40)), 5);
+
+    tracker.mark_in_flight([hash(7), hash(8)]);
+    tracker.clear();
+    tracker.mark_in_flight([hash(9)]);
+
+    assert_eq!(tracker.metrics().counts(), (10, 1, 5, 3));
+    assert_eq!(tracker.len(), 1);
+    assert_eq!(tracker.metrics().outstanding(), 1);
+    assert_eq!(tracker.metrics().gauge(), 1);
+}
+
+/// An unarmed tracker must not sweep: between roles (CvvInactive epochs, pre-first-epoch)
+/// no policy is installed, and a sweep with no owner would release marks on a schedule
+/// nobody chose.
+#[test]
+fn sweep_due_is_a_no_op_unarmed() {
+    let tracker = InFlightTracker::new();
+    tracker.mark_in_flight([hash(1), hash(2)]);
+    assert_eq!(tracker.sweep_due(u64::MAX), 0);
+    assert_eq!(tracker.len(), 2);
+}
+
+/// Arming for sealing installs the flat sweep; `clear` disarms it again, so a policy can
+/// never outlive the epoch-scoped owner that chose it.
+#[test]
+fn arm_sealing_installs_the_sweep_and_clear_disarms_it() {
+    let tracker = InFlightTracker::new();
+    let marks = tracker.arm_sealing(DuePolicy::ttl(Duration::ZERO));
+    marks.mark([hash(1)]);
+    assert_eq!(tracker.sweep_due(0), 1);
+    assert!(tracker.is_empty());
+
+    tracker.clear();
+    tracker.mark_in_flight([hash(2)]);
+    assert_eq!(tracker.sweep_due(u64::MAX), 0, "clear must disarm the sweep");
+    assert!(tracker.is_in_flight(&hash(2)));
+}
+
+/// Arming for forwarding installs NO sweep: forward marks are re-driven by the forwarder's
+/// own due check, and a flat sweep releasing them would erase the backoff state and bring
+/// back the re-gossip amplification the backoff exists to stop.
+#[test]
+fn arm_forwarding_never_installs_a_sweep() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(DuePolicy {
+        after: Duration::ZERO,
+        backoff_shift_cap: 4,
+        min_anchor_advance: 0,
+    });
+    forward.mark_forwarded([hash(1)], Instant::now(), 0);
+    assert_eq!(tracker.sweep_due(u64::MAX), 0);
+    assert!(tracker.is_in_flight(&hash(1)));
+}
+
+/// The forward policy the due tests exercise: 10s base, x16 backoff cap, 20-block anchor
+/// margin (the production shape).
+fn forward_policy() -> DuePolicy {
+    DuePolicy { after: Duration::from_secs(10), backoff_shift_cap: 4, min_anchor_advance: 20 }
+}
+
+/// A forwarded hash is not due again inside the base window, while an unmarked hash is
+/// always due.
+#[test]
+fn published_hash_is_not_due_within_the_window() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    let now = Instant::now();
+
+    assert!(forward.is_due(&hash(1), now, 0), "an unmarked hash is always due");
+    forward.mark_forwarded([hash(1)], now, 0);
+    assert!(!forward.is_due(&hash(1), now + Duration::from_secs(1), u64::MAX));
+}
+
+/// Wall clock alone is not loss: past the window with a stalled anchor nothing is due,
+/// because the node cannot yet know whether the transaction landed. The margin must be
+/// fully cleared, not merely started.
+#[test]
+fn stalled_anchor_holds_a_due_hash_back() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    let now = Instant::now();
+    forward.mark_forwarded([hash(1)], now, 100);
+
+    let late = now + Duration::from_secs(100);
+    assert!(!forward.is_due(&hash(1), late, 100), "a stalled anchor must hold the hash");
+    assert!(!forward.is_due(&hash(1), late, 119), "the margin must be fully cleared");
+    assert!(forward.is_due(&hash(1), late, 120));
+}
+
+/// Each resend doubles the wait before the next one, so a transaction stuck behind a deep
+/// inclusion backlog is not re-gossiped every base window.
+#[test]
+fn restamp_backs_off_exponentially() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    let now = Instant::now();
+    forward.mark_forwarded([hash(1)], now, 0);
+
+    let t1 = now + Duration::from_secs(10);
+    assert!(forward.is_due(&hash(1), t1, 20));
+    forward.mark_forwarded([hash(1)], t1, 20);
+
+    // the base window is no longer enough; the second re-send needs double
+    assert!(
+        !forward.is_due(&hash(1), t1 + Duration::from_secs(10), 40),
+        "second re-send fired at the base window instead of backing off"
+    );
+    assert!(forward.is_due(&hash(1), t1 + Duration::from_secs(20), 40));
+}
+
+/// A release (the tx left the pool) erases the mark entirely: re-entering the pool is a
+/// fresh mark with fresh backoff, so the tracker follows pool membership.
+#[test]
+fn release_resets_forward_state() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    let now = Instant::now();
+    forward.mark_forwarded([hash(1)], now, 0);
+
+    tracker.release_in_flight([hash(1)]);
+    assert!(forward.is_due(&hash(1), now, 0), "a released hash is a fresh claim");
+}
+
+/// An epoch exit under a forwarding arm keeps the marks: a forwarded transaction's
+/// delivery is not invalidated by an epoch boundary (validator pools persist across it),
+/// and clearing would schedule a full-pool re-publish with the backoff state erased. The
+/// arm itself still drops, so the next epoch re-arms cleanly.
+#[test]
+fn clear_keeps_forward_marks_and_disarms() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    forward.mark_forwarded([hash(1), hash(2)], Instant::now(), 0);
+
+    tracker.clear();
+    assert_eq!(tracker.len(), 2, "forward marks must survive the epoch exit");
+    assert!(!forward.is_due(&hash(1), Instant::now(), 0), "the backoff state must survive too");
+
+    // a sealing clear is unchanged: marks go, sweep disarms
+    let marks = tracker.arm_sealing(DuePolicy::ttl(Duration::ZERO));
+    marks.mark([hash(3)]);
+    tracker.clear();
+    assert!(tracker.is_empty(), "a sealing-armed clear drops everything");
+    assert_eq!(tracker.sweep_due(u64::MAX), 0, "and disarms the sweep");
+}
+
+/// A promotion carries an Observer epoch's forward marks across the boundary (clear() keeps
+/// them under Armed::Forwarding), but arm_sealing must start the sealing set empty: a leftover
+/// mark - especially AckedStale, which the TTL sweep never releases - would make the newly
+/// promoted validator's builder skip a transaction it now solely owns. Fails against an
+/// arm_sealing that only sets the sweep policy.
+#[test]
+fn arm_sealing_clears_forward_marks_left_by_a_promotion() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    forward.mark_forwarded([hash(1)], Instant::now(), 0);
+    forward.mark_acked_stale([hash(2)]);
+    tracker.clear(); // epoch boundary: Armed::Forwarding keeps the forward marks
+    assert_eq!(tracker.len(), 2, "clear keeps forward marks across the boundary");
+
+    // Observer -> CvvActive promotion: the builder arms for sealing the next epoch
+    let _seal = tracker.arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+    assert!(!tracker.is_in_flight(&hash(1)), "a Sent mark must not survive into sealing");
+    assert!(!tracker.is_in_flight(&hash(2)), "an AckedStale mark must not survive into sealing");
+}
+
+/// `is_forwarded` distinguishes a first send from a re-send: the catch-up gate blocks only
+/// re-sends, so new transactions flow even while the node is behind.
+#[test]
+fn is_forwarded_tracks_first_sends() {
+    let tracker = InFlightTracker::new();
+    let forward = tracker.arm_forwarding(forward_policy());
+    assert!(!forward.is_forwarded(&hash(1)));
+    forward.mark_forwarded([hash(1)], Instant::now(), 0);
+    assert!(forward.is_forwarded(&hash(1)));
+    tracker.release_in_flight([hash(1)]);
+    assert!(!forward.is_forwarded(&hash(1)), "a released hash is a fresh first send");
+}
+
+/// The batched membership release keeps only the live set, counts as a reconcile release,
+/// and bumps the release watch exactly once; releasing nothing bumps nothing.
+#[test]
+fn release_mined_retains_only_the_live_set() {
+    let tracker = InFlightTracker::new();
+    let events = tracker.release_events();
+    tracker.mark_in_flight([hash(1), hash(2), hash(3)]);
+
+    let live = [hash(2)].into_iter().collect();
+    assert_eq!(tracker.release_mined(&live), 2);
+    assert!(tracker.is_in_flight(&hash(2)));
+    assert_eq!(tracker.len(), 1);
+    assert_eq!(*events.borrow(), 1);
+
+    // everything tracked is live: a no-op, and no spurious wake
+    assert_eq!(tracker.release_mined(&live), 0);
+    assert_eq!(*events.borrow(), 1);
+}
+
+/// `mark_forwarded` participates in the conservation law: a fresh mark counts as marked,
+/// a resend counts as nothing, so `marked - releases = len` holds across both roles.
+#[test]
+fn mark_forwarded_counts_set_deltas_only() {
+    let tracker = InFlightTracker::with_fresh_metrics();
+    let forward = tracker.arm_forwarding(forward_policy());
+    let now = Instant::now();
+
+    forward.mark_forwarded([hash(1), hash(2)], now, 0);
+    // hash(1) is a resend: only hash(3) is a new mark
+    forward.mark_forwarded([hash(1), hash(3)], now, 0);
+
+    let (marked, _, _, _) = tracker.metrics().counts();
+    assert_eq!(marked, 3);
+    assert_eq!(tracker.metrics().outstanding(), 3);
+    assert_eq!(tracker.metrics().gauge(), 3);
+}
+
+/// Hashes the concurrent property draws from; small enough that the threads collide.
+const UNIVERSE: u8 = 12;
+
+#[derive(Clone, Debug)]
+enum Op {
+    Mark(Vec<u8>),
+    Release(Vec<u8>),
+    /// `sweep_expired(ZERO)`: expires everything currently tracked.
+    SweepAll,
+    /// `sweep_expired(1h)`: expires nothing, so it must be a pure no-op.
+    SweepNone,
+    Clear,
+}
+
+impl Op {
+    fn apply(&self, tracker: &InFlightTracker) {
+        match self {
+            Op::Mark(ids) => tracker.mark_in_flight(ids.iter().map(|id| hash(*id as u64))),
+            Op::Release(ids) => tracker.release_in_flight(ids.iter().map(|id| hash(*id as u64))),
+            Op::SweepAll => drop(tracker.sweep_expired(Duration::ZERO)),
+            Op::SweepNone => drop(tracker.sweep_expired(Duration::from_secs(3600))),
+            Op::Clear => tracker.clear(),
+        }
+    }
+}
+
+fn any_op() -> impl Strategy<Value = Op> {
+    let ids = || prop::collection::vec(0..UNIVERSE, 0..4);
+    prop_oneof![
+        4 => ids().prop_map(Op::Mark),
+        3 => ids().prop_map(Op::Release),
+        1 => Just(Op::SweepAll),
+        1 => Just(Op::SweepNone),
+        1 => Just(Op::Clear),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 96, ..ProptestConfig::default() })]
+
+    /// Up to four writers race one tracker (builder marks, canonical task releases, sweep
+    /// expires, epoch transition clears); the per-method tests never interleave them.
+    ///
+    /// The final membership is not interleaving-independent, so the oracle is the one thing
+    /// that is: every mutation derives its counter delta from set sizes read under the one
+    /// write lock, so the deltas telescope and `marked - reconcile - ttl - clear` equals the
+    /// live set size under *every* linearization. That is the shadow model, checked exactly,
+    /// alongside the interleaving-free structural invariants (membership agrees with
+    /// `is_in_flight`, the set never exceeds the universe, the release watch never goes
+    /// backwards, and a final `clear` is absorbing and leaves a working tracker).
+    #[test]
+    fn concurrent_writers_preserve_the_release_conservation_law(
+        per_thread in prop::collection::vec(
+            prop::collection::vec(any_op(), 0..12),
+            2..=3usize,
+        ),
+    ) {
+        let tracker = InFlightTracker::with_fresh_metrics();
+        std::thread::scope(|scope| {
+            for ops in &per_thread {
+                let tracker = tracker.clone();
+                scope.spawn(move || {
+                    let events = tracker.release_events();
+                    let mut last = *events.borrow();
+                    for op in ops {
+                        op.apply(&tracker);
+                        let seen = *events.borrow();
+                        assert!(seen >= last, "release watch fell {last} -> {seen}");
+                        last = seen;
+                    }
+                });
+            }
+        });
+
+        let len = tracker.len();
+        prop_assert!(len <= UNIVERSE as usize);
+        prop_assert_eq!(tracker.metrics().outstanding(), len as i64);
+        // the gauge telescopes from the same per-op deltas as the counters, so it tracks the
+        // live length exactly even after concurrent churn
+        prop_assert_eq!(tracker.metrics().gauge(), len as i64);
+
+        let tracked = tracker.tracked_hashes();
+        prop_assert_eq!(tracked.len(), len);
+        for id in 0..UNIVERSE {
+            let hash = hash(id as u64);
+            prop_assert_eq!(tracker.is_in_flight(&hash), tracked.contains(&hash));
+        }
+        // a final clear empties the set and stays empty under re-reads
+        tracker.clear();
+        prop_assert!(tracker.is_empty());
+        prop_assert!(tracker.tracked_hashes().is_empty());
+        prop_assert_eq!(tracker.len(), 0);
+        prop_assert_eq!(tracker.metrics().outstanding(), 0);
+        prop_assert_eq!(tracker.metrics().gauge(), 0);
+
+        // the tracker still behaves after the churn, and the release watch is one bump per
+        // release *call*, not per released hash: it wakes the builder, it does not count txs
+        tracker.mark_in_flight([hash(0), hash(1), hash(2)]);
+        let before = *tracker.release_events().borrow();
+        tracker.release_in_flight([hash(0), hash(1)]);
+        prop_assert_eq!(*tracker.release_events().borrow(), before + 1);
+        prop_assert_eq!(tracker.len(), 1);
+        prop_assert!(tracker.is_in_flight(&hash(2)));
+        prop_assert!(!tracker.is_in_flight(&hash(0)));
+        prop_assert_eq!(tracker.metrics().outstanding(), 1);
+        prop_assert_eq!(tracker.metrics().gauge(), 1);
+    }
+}
+
+/// `release_dropped` frees exactly the given hashes and counts them under its own release
+/// cause, leaving unrelated marks in place.
+#[test]
+fn release_dropped_frees_only_the_given_hashes() {
+    let tracker = InFlightTracker::new();
+    let kept = TxHash::random();
+    let dropped = TxHash::random();
+    tracker.mark_in_flight([kept, dropped]);
+    tracker.release_dropped([dropped]);
+    assert_eq!(tracker.len(), 1, "only the dropped hash is released");
+    tracker.release_dropped([dropped]);
+    assert_eq!(tracker.len(), 1, "an already-released hash is a no-op");
+}
+
+/// A sealing snapshot round-trips through the next boot's matching arm: marks reinstalled
+/// with rebased clocks, sorted persisted output, and nothing live until the arm.
+#[test]
+fn snapshot_round_trips_through_a_matching_sealing_arm() {
+    let source = InFlightTracker::with_fresh_metrics();
+    let seal = source.arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+    seal.mark([hash(2), hash(1)]);
+    let backup = source.snapshot().expect("an armed tracker snapshots");
+    assert_eq!(backup.role, MarkRole::Sealing);
+    assert_eq!(backup.marks.len(), 2);
+    assert!(backup.marks.windows(2).all(|w| w[0].hash < w[1].hash), "sorted by hash");
+
+    let restored = InFlightTracker::with_fresh_metrics();
+    restored.stash_restore(backup);
+    assert!(restored.is_empty(), "the stash must not touch the live set");
+    let _seal = restored.arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+    assert_eq!(restored.len(), 2, "the matching arm installs the stash");
+    assert!(restored.is_in_flight(&hash(1)) && restored.is_in_flight(&hash(2)));
+}
+
+/// An arming of the other role discards the stash: it cannot honor marks whose semantics
+/// belong to a role the node no longer runs.
+#[test]
+fn restored_marks_are_discarded_on_a_role_change() {
+    let source = InFlightTracker::with_fresh_metrics();
+    let seal = source.arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+    seal.mark([hash(1)]);
+    let backup = source.snapshot().expect("armed");
+
+    let restored = InFlightTracker::with_fresh_metrics();
+    restored.stash_restore(backup);
+    let _fwd = restored.arm_forwarding(DuePolicy::ttl(Duration::from_secs(10)));
+    assert!(restored.is_empty(), "a sealing stash must not survive a forwarding arm");
+}
+
+/// The promotion-safety clear still wipes cross-role residue while the matching stash
+/// installs: an Observer -> CvvActive boot keeps only what the sealing role owns.
+#[test]
+fn arm_sealing_clears_residue_and_installs_the_matching_stash() {
+    let tracker = InFlightTracker::with_fresh_metrics();
+    tracker.mark_in_flight([hash(9)]);
+    tracker.stash_restore(MarkBackup {
+        version: MARK_BACKUP_VERSION,
+        role: MarkRole::Sealing,
+        marks: vec![SavedMark { hash: hash(1), kind: SavedMarkKind::Sent { attempts: 0 } }],
+    });
+    let _seal = tracker.arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+    assert!(!tracker.is_in_flight(&hash(9)), "cross-role residue is cleared");
+    assert!(tracker.is_in_flight(&hash(1)), "the matching stash installs");
+}
+
+/// Forward backoff survives the round trip: a restored mark reads as forwarded (no
+/// first-send flood), its attempts keep the backoff window, and acked-stale stays
+/// never-due; an acked-stale mark also snapshots back out.
+#[test]
+fn forward_backoff_survives_the_round_trip() {
+    let policy =
+        DuePolicy { after: Duration::from_secs(10), backoff_shift_cap: 4, min_anchor_advance: 0 };
+    let tracker = InFlightTracker::with_fresh_metrics();
+    tracker.stash_restore(MarkBackup {
+        version: MARK_BACKUP_VERSION,
+        role: MarkRole::Forwarding,
+        marks: vec![
+            SavedMark { hash: hash(1), kind: SavedMarkKind::Sent { attempts: 3 } },
+            SavedMark { hash: hash(2), kind: SavedMarkKind::AckedStale },
+        ],
+    });
+    let fwd = tracker.arm_forwarding(policy);
+    assert!(fwd.is_forwarded(&hash(1)), "a restored mark is a re-send, not a first send");
+    assert!(
+        !fwd.is_due(&hash(1), Instant::now(), u64::MAX),
+        "the restored backoff window holds at the rebased stamp"
+    );
+    assert!(
+        !fwd.is_due(&hash(2), Instant::now() + Duration::from_secs(3600), u64::MAX),
+        "acked-stale is never due"
+    );
+    let backup = tracker.snapshot().expect("armed");
+    assert_eq!(backup.role, MarkRole::Forwarding);
+    assert!(backup.marks.iter().any(|m| m.kind == SavedMarkKind::AckedStale));
+}
+
+/// An unarmed tracker has no role whose marks mean anything: no snapshot.
+#[test]
+fn snapshot_is_none_when_unarmed() {
+    let tracker = InFlightTracker::with_fresh_metrics();
+    tracker.mark_in_flight([hash(1)]);
+    assert!(tracker.snapshot().is_none());
+}
+
+/// A clear with nothing armed keeps the stash: the epoch that ended had no role armed, so the
+/// marks belong to the next role to arm. A validator boots CvvInactive and promotes to
+/// CvvActive through exactly this clear before its builder ever arms - dropping the stash
+/// there silently discards every restored seal mark.
+#[test]
+fn clear_with_nothing_armed_keeps_the_stash() {
+    let tracker = InFlightTracker::with_fresh_metrics();
+    tracker.stash_restore(MarkBackup {
+        version: MARK_BACKUP_VERSION,
+        role: MarkRole::Sealing,
+        marks: vec![SavedMark { hash: hash(1), kind: SavedMarkKind::Sent { attempts: 0 } }],
+    });
+    tracker.clear();
+    let _seal = tracker.arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
+    assert!(
+        tracker.is_in_flight(&hash(1)),
+        "an actor-less clear must not eat the next actor's stash"
+    );
+}

--- a/crates/execution/evm/src/lib.rs
+++ b/crates/execution/evm/src/lib.rs
@@ -37,6 +37,7 @@ pub mod txn_pool;
 pub use txn_pool::*;
 pub mod error;
 mod evm;
+pub mod in_flight;
 pub mod native_erc20;
 pub(crate) mod persistence;
 pub mod reth_env;

--- a/crates/execution/evm/src/txn_pool.rs
+++ b/crates/execution/evm/src/txn_pool.rs
@@ -31,8 +31,10 @@ use tracing::{debug, info, trace, warn};
 use crate::{
     bypass_validator::{BypassHandle, BypassableValidator},
     error::RaylsRethResult,
+    in_flight::InFlightTracker,
     traits::RaylsNode,
 };
+use alloy::primitives::map::B256Set;
 
 /// Owned version of CanonicalStateUpdate for use in blocking tasks.
 ///
@@ -102,6 +104,8 @@ pub trait TxPool {
     fn get_pending_base_fee(&self) -> u64;
     /// Remove EIP-4844 blob transactions from the pool and delete the sidecars from blob store.
     fn remove_eip4844_txs(&mut self, blobs: Vec<TxHash>);
+    /// Return whether the hash is sealed into a batch still in flight, so the sealer skips it.
+    fn is_in_flight(&self, tx_hash: &TxHash) -> bool;
 }
 
 /// The reth EthTransactionValidator type used by this pool.
@@ -125,6 +129,10 @@ pub struct WorkerTxPool {
     task_spawner: TaskSpawner,
     bypass_handle: BypassHandle,
     blockchain_provider: BlockchainProvider<RaylsNode>,
+    /// Hashes sealed into a batch but not yet observed mined, so the sealer skips re-sealing
+    /// them while their batch is in flight; created here and shared with the batch builder via
+    /// [`WorkerTxPool::in_flight`].
+    in_flight_tracker: InFlightTracker,
 }
 
 impl From<WorkerTxPool> for RaylsTransactionPool {
@@ -170,6 +178,7 @@ impl WorkerTxPool {
             task_spawner: task_spawner.clone(),
             bypass_handle,
             blockchain_provider: blockchain_provider.clone(),
+            in_flight_tracker: InFlightTracker::new(),
         };
         let txn_pool_clone = this.clone();
         // Update the txn pool as the canonical tip changes.
@@ -289,9 +298,7 @@ impl WorkerTxPool {
         self.pool.queued_transactions()
     }
 
-    /// This method is called when a canonical state update is received.
-    ///
-    /// Trigger the maintenance task to update pool before building the next block.
+    /// Applies a canonical state update to the pool so the next build sees the new tip.
     fn process_canon_state_update(&self, update: Arc<Chain>) {
         trace!(target: "worker::block-builder", ?update, "canon state update from engine");
 
@@ -327,6 +334,34 @@ impl WorkerTxPool {
             mined_transactions,
             changed_accounts,
         );
+
+        self.reconcile_in_flight();
+    }
+
+    /// The in-flight tracker shared with this pool's batch builder.
+    ///
+    /// The builder marks a batch's hashes here on quorum so the next sealing round skips them
+    /// while the batch is in flight; the pool releases them again via [`Self::reconcile_in_flight`]
+    /// once execution removes them from the pending sub-pool.
+    pub fn in_flight(&self) -> InFlightTracker {
+        self.in_flight_tracker.clone()
+    }
+
+    /// Releases in-flight marks for hashes no longer in the pending sub-pool.
+    ///
+    /// A sealed transaction stays pending (and RPC-visible) until it executes; once execution
+    /// drops it from pending, its mark is stale and released so a later resubmission of the same
+    /// nonce is not skipped.
+    pub fn reconcile_in_flight(&self) {
+        if self.in_flight_tracker.is_empty() {
+            return;
+        }
+        let pending: B256Set =
+            self.pool.pending_transactions().iter().map(|tx| *tx.hash()).collect();
+        let released = self.in_flight_tracker.release_mined(&pending);
+        if released > 0 {
+            debug!(target: "rayls::txpool", released, "released in-flight marks against pending sub-pool");
+        }
     }
 
     /// Return the current status of the pool.
@@ -509,6 +544,10 @@ impl TxPool for WorkerTxPool {
         self.pool.remove_transactions_and_descendants(blobs.clone());
         self.pool.delete_blobs(blobs);
     }
+
+    fn is_in_flight(&self, tx_hash: &TxHash) -> bool {
+        self.in_flight_tracker.is_in_flight(tx_hash)
+    }
 }
 
 /// An iterator that produces the best transactions from a pool.
@@ -534,7 +573,7 @@ impl BestTxns {
     ///
     /// Without this, the iterator receives new pending transactions via a broadcast
     /// channel while iterating. If a transaction arrives whose predecessor is not in the
-    /// snapshot, it becomes a new independent chain — creating intra-sender nonce gaps
+    /// snapshot, it becomes a new independent chain, creating intra-sender nonce gaps
     /// that cause `nonce_too_high` at execution time.
     pub fn no_updates(&mut self) {
         self.inner.no_updates();

--- a/crates/infrastructure/types/src/batch_tracker.rs
+++ b/crates/infrastructure/types/src/batch_tracker.rs
@@ -219,7 +219,7 @@ impl BatchTracker {
                 ?sender,
                 nonce_min = range.min,
                 nonce_max = range.max,
-                nonce_span = range.max - range.min + 1,
+                nonce_span = range.span(),
                 "batch_sealed_sender_range"
             );
         }
@@ -371,7 +371,7 @@ impl BatchTracker {
                     ?sender,
                     nonce_min = range.min,
                     nonce_max = range.max,
-                    nonce_span = range.max - range.min + 1,
+                    nonce_span = range.span(),
                     "nonce_range_for_sender"
                 );
             }

--- a/crates/infrastructure/types/src/worker/mod.rs
+++ b/crates/infrastructure/types/src/worker/mod.rs
@@ -14,8 +14,21 @@ pub use pending_batch::*;
 /// Min and max nonce for a single sender within a batch.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct NonceRange {
+    /// Lowest nonce observed for the sender.
     pub min: u64,
+    /// Highest nonce observed for the sender; never below `min`.
     pub max: u64,
+}
+
+impl NonceRange {
+    /// Returns the number of nonces the range covers, both ends inclusive.
+    ///
+    /// Saturates at `u64::MAX` for a range ending at the maximum nonce: the value is diagnostic
+    /// only, and with overflow checks on and `panic = abort` an overflow here would let one
+    /// crafted batch abort every node that logs the range.
+    pub fn span(&self) -> u64 {
+        (self.max - self.min).saturating_add(1)
+    }
 }
 
 /// Per-sender nonce ranges observed during batch construction.
@@ -32,6 +45,7 @@ pub type SenderNonceRanges = HashMap<crate::Address, NonceRange>;
 /// The receiving half (CL) broadcasts to peers and tries to reach quorum.
 pub type BatchSender =
     Sender<(SealedBatch, SenderNonceRanges, oneshot::Sender<Result<(), BlockSealError>>)>;
+/// The receiving half of [`BatchSender`].
 pub type BatchReceiver =
     Receiver<(SealedBatch, SenderNonceRanges, oneshot::Sender<Result<(), BlockSealError>>)>;
 
@@ -42,3 +56,22 @@ pub const DEFAULT_WORKER_PORT: u16 = 44895;
 ///
 /// Workers communicate with peers of the same `WorkerId`.
 pub type WorkerId = u16;
+
+#[cfg(test)]
+mod tests {
+    use super::NonceRange;
+
+    #[test]
+    fn nonce_span_saturates_at_the_max_nonce() {
+        // nonce 0 paired with u64::MAX from one sender: the true count is u64::MAX + 1
+        assert_eq!(NonceRange { min: 0, max: u64::MAX }.span(), u64::MAX);
+        // any non-zero min leaves headroom for the +1, so no saturation
+        assert_eq!(NonceRange { min: 5, max: u64::MAX }.span(), u64::MAX - 4);
+    }
+
+    #[test]
+    fn nonce_span_counts_both_ends() {
+        assert_eq!(NonceRange { min: 3, max: 3 }.span(), 1);
+        assert_eq!(NonceRange { min: 3, max: 7 }.span(), 5);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `InFlightTracker`: the txpool records hashes sealed into a batch but not yet observed mined, so the next sealing round skips them instead of re-sealing a stuck backlog batch after batch. Marks are armed per role behind a capability handle (`SealMarks` / `ForwardMarks`), released by a reconcile against the pending sub-pool plus a backoff-gated sweep, and snapshot/restored across restarts through a versioned `MarkBackup`.
- On quorum the sealer now marks the batch in flight instead of evicting it from the pool, so sealed transactions stay pending and RPC-visible until execution drains them.
- Defuse two latent traps ahead of the rework: the diagnostic nonce span overflowed at `u64::MAX` (overflow-checks + panic=abort turned one crafted batch into a whole-network halt), and the workspace `metrics` facade is pinned to 0.24 so a crate adopting 0.23 cannot bind a second global whose macros silently no-op.

Stack 1/9 of the txpool in-flight tracker and observer-forwarder series. The builder pipeline and the forwarder that also consume the tracker land in later PRs; this one scopes to the pool and sealer.

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No wire or storage format changes; the mark backup file is new and only read when present.

## Test plan

- [x] `nonce_span_saturates_at_the_max_nonce` fails on the pre-fix span arithmetic.
- [x] Failing-first regression that a sealed batch is not re-proposed while in flight; four builder tests retargeted from drain-on-quorum to stay-pending-and-marked.
- [x] Proptest drives concurrent tracker writers and checks `marked - reconcile - ttl - clear` equals the live set and the gauge.
- [x] `make check` on the stack tip; CI (`fmt`, `clippy`, workspace tests) on this branch.

