### PR TITLE
feat: drive the batch builder through a typestate seal-ahead pipeline

### DIFF
--- a/crates/consensus/worker/src/batch-builder/src/batch.rs
+++ b/crates/consensus/worker/src/batch-builder/src/batch.rs
@@ -13,25 +13,40 @@ use rayls_infrastructure_types::{
 };
 use tracing::debug;
 
-/// The output from building the next block.
+/// The transactions selected into a sealed batch, to be marked in flight on quorum.
 ///
-/// Contains information needed to update the transaction pool.
+/// `#[must_use]` so a build's selection cannot be silently dropped: the caller either marks it in
+/// flight on quorum or explicitly discards it.
+#[must_use = "mark the selection in flight on quorum, or explicitly drop it"]
+#[derive(Debug)]
+pub struct SelectedForSeal(Vec<TxHash>);
+
+impl SelectedForSeal {
+    /// Returns whether the batch selected no transactions.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consumes the selection into the hashes to mark in flight.
+    pub(crate) fn into_marks(self) -> Vec<TxHash> {
+        self.0
+    }
+}
+
+/// The output from building the next batch.
 #[derive(Debug)]
 pub struct BatchBuilderOutput {
-    /// The batch info for the worker to propose.
+    /// The batch for the worker to propose.
     pub(crate) batch: Batch,
-    /// The transaction hashes mined in this worker's batch.
+    /// The transactions sealed into the batch, to mark in flight on quorum.
     ///
-    /// NOTE: canonical changes update `ChangedAccount` and changed senders.
-    /// Only the mined transactions are removed from the pool. Account nonce and state
-    /// should only be updated on canonical changes so workers can validate
-    /// each other's blocks off the canonical tip.
-    ///
-    /// This is less efficient when accounts have lots of transactions in the pending
-    /// pool, but this approach is easier to implement in the short term.
-    pub(crate) mined_transactions: Vec<TxHash>,
+    /// The pool itself is left untouched: account nonce and state move only on canonical changes,
+    /// so workers validate each other's batches off the same canonical tip.
+    pub(crate) selected: SelectedForSeal,
     /// Per-sender nonce ranges for all transactions in this batch.
     pub sender_nonce_ranges: SenderNonceRanges,
+    /// Whether the batch filled to capacity (gas or bytes), so more candidates certainly remain.
+    pub(crate) at_capacity: bool,
 }
 
 /// Construct an Rayls batch using the best transactions from the pool.
@@ -73,6 +88,7 @@ pub fn build_batch<P: TxPool>(
     // let mut sum_blob_gas_used = 0;
     let mut total_bytes_size = 0;
     let mut total_possible_gas = 0;
+    let mut at_capacity = false;
     let mut transactions = Vec::new();
     let mut mined_transactions = Vec::new();
     let mut blob_transactions = Vec::new();
@@ -98,6 +114,9 @@ pub fn build_batch<P: TxPool>(
             // before continuing loop
             best_txs.exceeds_gas_limit(&pool_tx, gas_limit);
             debug!(target: "worker::batch_builder", ?pool_tx, "marking tx invalid due to gas constraint");
+            // Only a non-empty batch is "at capacity": a tx whose own gas exceeds the whole cap can
+            // never fit any batch, so treating it as backlog would spin the builder on it forever.
+            at_capacity |= total_possible_gas > 0;
             continue;
         }
 
@@ -122,6 +141,8 @@ pub fn build_batch<P: TxPool>(
             // before continuing loop
             best_txs.max_batch_size(&pool_tx, tx.size(), max_size);
             debug!(target: "worker::batch_builder", ?pool_tx, "marking tx invalid due to bytes constraint");
+            // As with the gas branch: a tx larger than the whole batch is unbatchable, not backlog.
+            at_capacity |= total_bytes_size > 0;
             continue;
         }
 
@@ -160,5 +181,10 @@ pub fn build_batch<P: TxPool>(
     pool.remove_eip4844_txs(blob_transactions);
 
     // return output
-    BatchBuilderOutput { batch, mined_transactions, sender_nonce_ranges }
+    BatchBuilderOutput {
+        batch,
+        selected: SelectedForSeal(mined_transactions),
+        sender_nonce_ranges,
+        at_capacity,
+    }
 }

--- a/crates/consensus/worker/src/batch-builder/src/error.rs
+++ b/crates/consensus/worker/src/batch-builder/src/error.rs
@@ -1,14 +1,14 @@
-//! Error types for Rayls Network Block Builder.
+//! Error types for the batch builder.
 
 use std::any::Any;
 
 use rayls_execution_evm::{PoolTransactionError, ProviderError, RethError};
 use tokio::sync::{mpsc, oneshot};
 
-/// Result alias for [`RLEngineError`].
+/// Result alias for [`BatchBuilderError`].
 pub(crate) type BatchBuilderResult<T> = Result<T, BatchBuilderError>;
 
-/// Core error variants when executing the output from consensus and extending the canonical block.
+/// Errors raised while building a batch or handing it to the worker.
 #[derive(Debug, thiserror::Error)]
 pub enum BatchBuilderError {
     /// Error from Reth
@@ -41,6 +41,16 @@ pub enum BatchBuilderError {
     /// An operation that requires canonical state did not have it.
     #[error("Missing canonical state.")]
     MissingCanonical,
+    /// The blocking pool failed to complete batch construction.
+    #[error("batch build task failed: {0}")]
+    BuildTaskFailed(#[from] tokio::task::JoinError),
+}
+
+impl BatchBuilderError {
+    /// Returns whether the worker seal loop is gone, so the builder should end gracefully.
+    pub(crate) fn is_worker_gone(&self) -> bool {
+        matches!(self, Self::AckChannelClosed | Self::WorkerChannelClosed)
+    }
 }
 
 impl From<oneshot::error::RecvError> for BatchBuilderError {

--- a/crates/consensus/worker/src/batch-builder/src/lib.rs
+++ b/crates/consensus/worker/src/batch-builder/src/lib.rs
@@ -1,956 +1,454 @@
 // SPDX-License-Identifier: BUSL-1.1
-//! The block builder maintains the transaction pool and builds the next block.
+//! The batch builder, which seals pending-pool transactions into batches for the worker to propose.
 //!
-//! Only the engine's canonical updates move transactions between sub-pools, and only the pending
-//! sub-pool feeds the next batch. A built batch goes to the worker, which publishes it to peers
-//! and seals it (quorum within a time limit, then a report to the primary). A failed seal leaves
-//! the transactions untouched for the next round; a successful seal marks them in flight so the
-//! next round skips them, and they stay pending until the engine's canonical update mines them
-//! and releases the marks.
+//! Only transactions in the pending sub-pool are candidates; the engine's canonical updates alone
+//! move the pool's tracked tip, basefee, and blob fees, so every worker validates a peer's batch
+//! off the same canonical state. A sealed batch goes to the worker, which publishes it and seeks
+//! quorum within a time limit. On quorum failure the candidates are left untouched for the next
+//! attempt. On quorum the sealed transactions are marked in flight so the next build skips them;
+//! they stay in the pending pool until execution mines them, which releases the marks.
 
 // it tests
 #![allow(unused_crate_dependencies)]
 
-pub use batch::{build_batch, BatchBuilderOutput};
+pub use batch::{build_batch, BatchBuilderOutput, SelectedForSeal};
+pub use watermark::OwnWatermarkReceiver;
+
 use error::{BatchBuilderError, BatchBuilderResult};
 use futures_util::{FutureExt, StreamExt};
+use pipeline::{BatchPipeline, PipelineState, TaskOutcome};
 use rayls_execution_evm::{
     in_flight::{DuePolicy, SealMarks},
     reth_env::RethEnv,
-    CanonStateNotificationStream, TxPool as _, WorkerTxPool,
+    CanonStateNotificationStream, WorkerTxPool,
 };
 use rayls_infrastructure_types::{
-    error::BlockSealError, gas_accumulator::BaseFeeContainer, Address, BatchBuilderArgs,
-    BatchSender, Epoch, SealedBlock, TaskSpawner, TxHash, WorkerId,
+    batch_ordering::MAX_PARKED_PER_AUTHORITY, error::BlockSealError,
+    gas_accumulator::BaseFeeContainer, Address, BatchBuilderArgs, BatchSender, Epoch, SealedBatch,
+    SenderNonceRanges, TaskSpawner, TxHash, WorkerId,
 };
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
+use std::time::Duration;
+use tokio::{
+    sync::{mpsc, oneshot, watch},
+    time::{Interval, MissedTickBehavior},
 };
-use tokio::{sync::oneshot, time::Interval};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 mod batch;
 mod error;
+pub mod pipeline;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
+pub mod watermark;
 
-/// Result from a batch build attempt: mined tx hashes and the seq number used.
-type BuildResult = oneshot::Receiver<BatchBuilderResult<(Vec<TxHash>, u64)>>;
-
-/// How long a sealed transaction stays marked in flight before [`InFlightTracker::sweep_due`] may
-/// presume its batch lost and release it for resealing. Reconcile against the pending sub-pool
-/// releases marks on execution well before this, so the sweep is the backstop, not the norm.
+/// How long a sealed transaction stays marked in flight before a sweep may presume its batch lost
+/// and release it for resealing. Inert unless a sweep runs; reconcile releases marks on execution
+/// well before this.
 const IN_FLIGHT_TTL: Duration = Duration::from_secs(60);
 
-/// The type that builds blocks for workers to propose.
+/// The most batches the builder may seal ahead of its own execution watermark while the epoch is
+/// active. Keeps the in-flight prefix within the per-authority parking budget, so a lagging batch
+/// cannot strand its successors.
+pub const MAX_SEAL_AHEAD: u64 = 4;
+const _: () = assert!(MAX_SEAL_AHEAD * 4 <= MAX_PARKED_PER_AUTHORITY as u64);
+
+/// Seconds before the epoch boundary within which the seal-ahead budget collapses to one batch, so
+/// a batch sealed near the cut has no unexecuted predecessor of its own to cascade skips from once
+/// the epoch severs per-authority sequence ordering.
+pub const BOUNDARY_QUIESCE_WINDOW_SECS: u64 = 5;
+
+/// Builds batches for a worker to propose, sealing ahead of its own execution watermark.
 ///
-/// This is a future that:
-/// - listens for canonical state changes and updates the tx pool
-/// - polls the transaction pool for pending transactions
-///     - tries to build the next batch when there transactions are available
+/// Driven by [`BatchBuilder::run`], a `select!` loop that reacts to canonical updates, candidate
+/// transaction ingress, in-flight mark releases, its own execution watermark, and a batching-window
+/// tick. A [`pipeline::BatchPipeline`] typestate tracks whether a build may start and the next
+/// phase after each seal, so the seal-ahead budget and epoch-boundary cutoff live in the types
+/// rather than in ad hoc flags.
 #[derive(Debug)]
 pub struct BatchBuilder {
-    /// Single active future that executes consensus output on a blocking thread and then returns
-    /// the result through a oneshot channel.
-    pending_task: Option<BuildResult>,
+    /// Static per-epoch configuration.
+    config: BatchBuilderConfig,
     /// The transaction pool with pending transactions.
     pool: WorkerTxPool,
     /// Sealing capability over the pool's in-flight tracker: marks a batch's hashes on quorum so
-    /// the next round skips them until execution releases them. Armed once per (epoch-scoped)
-    /// builder.
+    /// the next round skips them until execution releases them. Armed once for this builder's
+    /// (epoch-scoped) life.
     in_flight: SealMarks,
-    /// The sending side to the worker's batch maker.
-    ///
-    /// Sending the new block through this channel publishes it to all peers.
-    ///
-    /// The worker's block maker sends an ack once the block has been stored in db
-    /// which guarantees the worker will keep publishing the new block until
-    /// quorum is reached.
+    /// The sending side to the worker's batch maker; a send has the worker publish the batch to
+    /// all peers.
     to_worker: BatchSender,
-    /// The address for batch's beneficiary.
-    address: Address,
-    /// Maximum amount of time to wait before querying block builds.
-    ///
-    /// This interval wakes the task periodically to check on the progress of the latest built
-    /// block and the pending transaction pool.
-    max_delay_interval: Interval,
-
-    /// This channel will receive a header on canonical update.  We use it to wakeup the future and
-    /// save the canonical update.
-    state_changed: CanonStateNotificationStream,
-    /// The last canonical update, saved when state_changed sends a new update.
-    last_canonical_update: SealedBlock,
     /// The type to spawn tasks.
     task_spawner: TaskSpawner,
-    /// Worker id this batch builder belongs too.
-    worker_id: WorkerId,
     /// The current base fee for this worker.
     base_fee: BaseFeeContainer,
-    /// The epoch we are building batches for.
-    epoch: Epoch,
-    /// Monotonically increasing sequence number for batches produced by this builder.
-    next_batch_seq: u64,
-    /// Epoch boundary timestamp (seconds) for this epoch; once the canonical tip's block reaches
-    /// it, the epoch is closing and we stop sealing new batches. Fixed for the life of this
-    /// (epoch-scoped) builder, so it's held by value.
-    epoch_boundary: u64,
+    /// This authority's highest executed batch sequence, bounding how far ahead the builder seals.
+    own_executed_watermark: OwnWatermarkReceiver,
+    /// Canonical updates from the engine; the tip timestamp gates the epoch boundary and quiesce.
+    state_changed: CanonStateNotificationStream,
+    /// Wakes the builder when a new candidate enters the pending sub-pool.
+    pending_tx_events: mpsc::Receiver<TxHash>,
+    /// Wakes the builder when in-flight marks release, reopening candidates for the next seal.
+    release_events: watch::Receiver<u64>,
+    /// The last canonical tip timestamp seen, seeded from the tip at construction.
+    last_canonical_timestamp: u64,
+    /// The highest sequence already sealed and durable before this builder started, if any.
+    persisted_highest_sealed_seq: Option<u64>,
+}
+
+/// Static configuration for a [`BatchBuilder`], fixed for its (epoch-scoped) life.
+#[derive(Debug, Clone, Copy)]
+pub struct BatchBuilderConfig {
+    /// The beneficiary address for this worker's batches.
+    pub address: Address,
+    /// The worker id this builder belongs to.
+    pub worker_id: WorkerId,
+    /// The epoch this builder seals batches for.
+    pub epoch: Epoch,
+    /// Epoch boundary timestamp (seconds); once the canonical tip reaches it the builder stops.
+    pub epoch_boundary: u64,
+    /// Maximum time to wait before the batching-window tick attempts a build.
+    pub max_delay: Duration,
+    /// The sequence number the first batch uses, before the execution watermark resumes it.
+    pub next_batch_seq: u64,
     /// Block gas limit for batches.
-    gas_limit: u64,
+    pub gas_limit: u64,
+}
+
+/// The result of a single build attempt on the blocking pool, before quorum.
+enum Built {
+    /// Every candidate was already in flight, so nothing was sealed.
+    NothingToSeal,
+    /// A batch was sealed and is ready to send to the worker.
+    Sealed {
+        /// The sealed batch to send.
+        sealed_batch: SealedBatch,
+        /// The transactions to mark in flight once quorum is reached.
+        selected: SelectedForSeal,
+        /// Per-sender nonce ranges carried to the worker.
+        sender_nonce_ranges: SenderNonceRanges,
+        /// Whether the batch filled to capacity, implying more candidates remain.
+        at_capacity: bool,
+    },
 }
 
 impl BatchBuilder {
-    /// Create a new instance of [Self].
-    #[allow(clippy::too_many_arguments)]
+    /// Creates a batch builder for one epoch, resuming its sequence from the execution watermark.
     pub fn new(
         reth_env: &RethEnv,
         pool: WorkerTxPool,
         to_worker: BatchSender,
-        address: Address,
-        max_delay: Duration,
         task_spawner: TaskSpawner,
-        worker_id: WorkerId,
         base_fee: BaseFeeContainer,
-        epoch: Epoch,
-        next_batch_seq: u64,
-        epoch_boundary: u64,
-        gas_limit: u64,
+        own_executed_watermark: OwnWatermarkReceiver,
+        config: BatchBuilderConfig,
     ) -> Self {
-        let max_delay_interval = tokio::time::interval(max_delay);
-        let state_changed = reth_env.canonical_block_stream();
-        let last_canonical_update = Self::latest_canon_block(reth_env);
-        let in_flight = pool.in_flight().arm_sealing(DuePolicy::ttl(IN_FLIGHT_TTL));
+        let tracker = pool.in_flight();
+        let release_events = tracker.release_events();
+        let in_flight = tracker.arm_sealing(DuePolicy::ttl(IN_FLIGHT_TTL));
+        let last_canonical_timestamp = Self::latest_canon_timestamp(reth_env);
+
+        let start_seq = own_executed_watermark.resume_seq(config.next_batch_seq);
+        let persisted_highest_sealed_seq = start_seq.checked_sub(1);
+
         Self {
-            pending_task: None,
-            pool,
+            config: BatchBuilderConfig { next_batch_seq: start_seq, ..config },
+            pool: pool.clone(),
             in_flight,
             to_worker,
-            address,
-            max_delay_interval,
-            state_changed,
-            last_canonical_update,
             task_spawner,
-            worker_id,
             base_fee,
-            epoch,
-            next_batch_seq,
-            epoch_boundary,
-            gas_limit,
+            own_executed_watermark,
+            state_changed: reth_env.canonical_block_stream(),
+            pending_tx_events: pool.pending_transactions_listener(),
+            release_events,
+            last_canonical_timestamp,
+            persisted_highest_sealed_seq,
         }
     }
 
-    /// Spawns a blocking task that builds the batch, sends it to the worker's batch proposer, and
-    /// waits for the quorum ack, so the builder yields to the runtime meanwhile.
-    ///
-    /// Workers only propose one batch at a time.
-    fn spawn_execution_task(&mut self) -> BuildResult {
-        let pool = self.pool.clone();
-        let to_worker = self.to_worker.clone();
+    /// Runs the builder until the epoch boundary is reached or the worker seal loop disconnects.
+    pub async fn run(mut self) -> BatchBuilderResult<()> {
+        let mut interval = tokio::time::interval(self.config.max_delay);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        interval.reset();
 
-        // configure params for next building the next batch
-        let build_args = BatchBuilderArgs::new(pool.clone(), self.address, self.epoch);
+        let initial_clean = BatchPipeline::new(
+            self.persisted_highest_sealed_seq,
+            self.config.next_batch_seq,
+            self.last_canonical_timestamp,
+        );
+        let mut pipeline = PipelineState::Clean(initial_clean);
+        pipeline = self.try_start_build(pipeline.on_event(), &mut interval);
 
-        let (result, done) = oneshot::channel();
-        let worker_id = self.worker_id;
-        let base_fee = self.base_fee.base_fee();
-        // Use the current seq but do NOT increment yet: only advance on quorum success.
-        let seq = self.next_batch_seq;
-        let gas_limit = self.gas_limit;
+        loop {
+            pipeline = match pipeline.check_boundary(self.config.epoch_boundary) {
+                Ok(p) => p,
+                Err(_closed) => {
+                    debug!(
+                        target: "worker::batch_builder",
+                        epoch = %self.config.epoch,
+                        "epoch boundary reached; terminating batch builder"
+                    );
+                    return Ok(());
+                }
+            };
 
-        // spawn block building task and forward to worker
-        self.task_spawner.spawn_task("next-batch", async move {
-            // ack once worker reaches quorum
-            let (ack, rx) = oneshot::channel();
-
-            // this is safe to call without a semaphore bc it's held as a single `Option`
-            let BatchBuilderOutput { batch, mined_transactions, sender_nonce_ranges } = build_batch(build_args, worker_id, base_fee, seq, gas_limit);
-
-            // forward to worker and wait for ack that quorum was reached
-            if let Err(e) = to_worker.send((batch.seal_slow(), sender_nonce_ranges, ack)).await {
-                error!(target: "worker::batch_builder", ?e, "failed to send next batch to worker");
-                // try to return error if worker channel closed
-                let _ = result.send(Err(e.into()));
-                return;
+            // Drain backlog while the budget allows before parking on select!, so a full batch does
+            // not wait for the next tick.
+            if matches!(
+                pipeline,
+                PipelineState::BacklogDraining(_) | PipelineState::Accumulating(_)
+            ) {
+                pipeline = self.try_start_build(pipeline, &mut interval);
             }
 
-            // wait for worker to ack quorum reached then update pool with mined transactions
-            match rx.await {
-                Ok(res) => {
-                    match res {
-                        Ok(_) => {
-                            debug!(target: "block-builder", ?res, "received ack");
-                            // signal to Self that this task is complete, include seq for counter advancement
-                            if let Err(e) = result.send(Ok((mined_transactions, seq))) {
-                                error!(target: "worker::batch_builder", ?e, "failed to send block builder result to block builder task");
-                            }
-                        }
-                        Err(error) => {
-                            error!(target: "worker::batch_builder", ?error, "error while sealing batch");
-                            let converted = match error {
-                                BlockSealError::FatalDBFailure => {
-                                    // fatal - return error
-                                    Err(BatchBuilderError::FatalDBFailure)
-                                }
-                                BlockSealError::QuorumRejected
-                                | BlockSealError::AntiQuorum
-                                | BlockSealError::Timeout
-                                | BlockSealError::NotValidator
-                                | BlockSealError::FailedQuorum => {
-                                    // potentially non-fatal error
-                                    //
-                                    // return empty vec to indicate no transactions mined
-                                    // NOTE: this will apply no changes to transaction pool
-                                    Ok((vec![], seq))
-                                }
-                            };
+            let is_awaiting = pipeline.is_awaiting_quorum();
 
-                            if let Err(e) = result.send(converted) {
-                                error!(target: "worker::batch_builder", ?e, "failed to send block builder result to block builder task");
-                            }
-                        }
+            tokio::select! {
+                // Shutdown and boundary detection must win, so keep the branch order semantic.
+                biased;
+
+                // Canonical tip updates: burst-drain to the latest tip.
+                Some(latest) = self.state_changed.next() => {
+                    let tip_ts = latest.tip().sealed_block().timestamp;
+                    pipeline.on_canonical_update(tip_ts);
+                    while let Some(Some(more)) = self.state_changed.next().now_or_never() {
+                        pipeline.on_canonical_update(more.tip().sealed_block().timestamp);
+                    }
+
+                    if !is_awaiting && tip_ts >= self.config.epoch_boundary {
+                        debug!(
+                            target: "worker::batch_builder",
+                            epoch = %self.config.epoch,
+                            "epoch boundary crossed by canonical tip; terminating builder"
+                        );
+                        return Ok(());
+                    }
+
+                    if !is_awaiting {
+                        pipeline = self.try_start_build(pipeline.on_event(), &mut interval);
                     }
                 }
-                Err(e) => {
-                    error!(target: "worker::batch_builder", ?e, "quorum waiter failed ack failed");
-                    if let Err(e) = result.send(Err(e.into())) {
-                        error!(target: "worker::batch_builder", ?e, "failed to send block builder result to block builder task");
+
+                // Quorum resolution: unblock the next sequence promptly.
+                rx_res = pipeline.await_quorum(), if is_awaiting => {
+                    match self.handle_quorum_resolution(rx_res, pipeline, &mut interval)? {
+                        Some(next) => pipeline = next,
+                        // The worker seal loop is gone; end the builder rather than spin resealing.
+                        None => return Ok(()),
+                    }
+                }
+
+                // Own watermark advance: wake as soon as one of this authority's batches executes.
+                Ok(()) = self.own_executed_watermark.inner_mut().changed(), if !is_awaiting => {
+                    let _ = self.own_executed_watermark.inner_mut().borrow_and_update();
+                    pipeline = self.try_start_build(pipeline, &mut interval);
+                }
+
+                // Candidate transaction ingress: burst-drain.
+                Some(_) = self.pending_tx_events.recv() => {
+                    pipeline = pipeline.on_event();
+                    while self.pending_tx_events.try_recv().is_ok() {}
+
+                    if !is_awaiting {
+                        pipeline = self.try_start_build(pipeline, &mut interval);
+                    }
+                }
+
+                // In-flight mark releases reopen candidates for the next seal.
+                Ok(()) = self.release_events.changed() => {
+                    let _ = self.release_events.borrow_and_update();
+                    pipeline = pipeline.on_event();
+
+                    if !is_awaiting {
+                        pipeline = self.try_start_build(pipeline, &mut interval);
+                    }
+                }
+
+                // Batching window tick.
+                _ = interval.tick(), if !is_awaiting => {
+                    pipeline = self.try_start_build(pipeline, &mut interval);
+                }
+            }
+        }
+    }
+
+    /// Starts a build when the active phase allows it, transitioning to `AwaitingQuorum` on spawn.
+    fn try_start_build(
+        &mut self,
+        pipeline: PipelineState,
+        interval: &mut Interval,
+    ) -> PipelineState {
+        let executed_seq = self.own_executed_watermark.get();
+        let seq = pipeline.current_seq();
+
+        match pipeline {
+            PipelineState::Clean(clean) => PipelineState::Clean(clean),
+            PipelineState::Accumulating(acc) => {
+                if acc.can_start_build(executed_seq, self.config.epoch_boundary).is_err() {
+                    return PipelineState::Accumulating(acc);
+                }
+                interval.reset();
+                let rx = self.spawn_build_task(seq);
+                PipelineState::AwaitingQuorum(acc.start_building(rx))
+            }
+            PipelineState::BacklogDraining(backlog) => {
+                if backlog.can_start_build(executed_seq, self.config.epoch_boundary).is_err() {
+                    return PipelineState::BacklogDraining(backlog);
+                }
+                interval.reset();
+                let rx = self.spawn_build_task(seq);
+                PipelineState::AwaitingQuorum(backlog.start_building(rx))
+            }
+            PipelineState::AwaitingQuorum(p) => PipelineState::AwaitingQuorum(p),
+        }
+    }
+
+    /// Folds a quorum resolution into the next pipeline phase, advancing the sequence on success.
+    ///
+    /// Returns `None` when the worker seal loop has disconnected, signalling [`Self::run`] to end.
+    fn handle_quorum_resolution(
+        &mut self,
+        res: Result<BatchBuilderResult<TaskOutcome>, oneshot::error::RecvError>,
+        pipeline: PipelineState,
+        interval: &mut Interval,
+    ) -> BatchBuilderResult<Option<PipelineState>> {
+        let awaiting = match pipeline {
+            PipelineState::AwaitingQuorum(a) => a,
+            other => return Ok(Some(other)),
+        };
+
+        let current_seq = awaiting.current_seq();
+        let start_time = std::time::Instant::now();
+
+        let outcome = match res.map_err(BatchBuilderError::from).and_then(|r| r) {
+            Ok(out) => out,
+            Err(e) if e.is_worker_gone() => {
+                warn!(target: "worker::batch_builder", %e, "worker seal loop disconnected; ending builder");
+                return Ok(None);
+            }
+            Err(e) => return Err(e),
+        };
+
+        interval.reset();
+
+        match outcome {
+            TaskOutcome::NothingToSeal => {
+                debug!(target: "worker::batch_builder", "all candidate txs in-flight; nothing to seal");
+                Ok(Some(PipelineState::Clean(awaiting.into_clean())))
+            }
+            TaskOutcome::QuorumFailed => {
+                warn!(
+                    target: "worker::batch_builder",
+                    elapsed_ms = start_time.elapsed().as_millis(),
+                    "batch quorum failed; re-armed retry for next window"
+                );
+                Ok(Some(PipelineState::Accumulating(awaiting.into_accumulating())))
+            }
+            TaskOutcome::QuorumSucceeded { selected, at_capacity } => {
+                debug!(
+                    target: "worker::batch_builder",
+                    seq = current_seq,
+                    elapsed_ms = start_time.elapsed().as_millis(),
+                    "batch reached quorum and sealed successfully"
+                );
+
+                let transition =
+                    awaiting.mark_in_flight_and_advance(selected, at_capacity, &self.in_flight);
+                Ok(Some(transition.into()))
+            }
+        }
+    }
+
+    /// Spawns the blocking build, sends the batch to the worker, and reports the quorum outcome.
+    fn spawn_build_task(&mut self, seq: u64) -> oneshot::Receiver<BatchBuilderResult<TaskOutcome>> {
+        let pool = self.pool.clone();
+        let to_worker = self.to_worker.clone();
+        let address = self.config.address;
+        let epoch = self.config.epoch;
+        let worker_id = self.config.worker_id;
+        let base_fee = self.base_fee.base_fee();
+        let gas_limit = self.config.gas_limit;
+
+        let (outcome_tx, outcome_rx) = oneshot::channel();
+        self.task_spawner.spawn_task("build-seal-and-submit-batch", async move {
+            let built = match tokio::task::spawn_blocking(move || {
+                let build_args = BatchBuilderArgs::new(pool, address, epoch);
+                let BatchBuilderOutput { batch, selected, sender_nonce_ranges, at_capacity } =
+                    build_batch(build_args, worker_id, base_fee, seq, gas_limit);
+
+                if selected.is_empty() {
+                    Built::NothingToSeal
+                } else {
+                    Built::Sealed {
+                        sealed_batch: batch.seal_slow(),
+                        selected,
+                        sender_nonce_ranges,
+                        at_capacity,
+                    }
+                }
+            })
+            .await
+            {
+                Ok(built) => built,
+                Err(err) => {
+                    let _ = outcome_tx.send(Err(BatchBuilderError::from(err)));
+                    return;
+                }
+            };
+
+            match built {
+                Built::NothingToSeal => {
+                    let _ = outcome_tx.send(Ok(TaskOutcome::NothingToSeal));
+                }
+                Built::Sealed { sealed_batch, selected, sender_nonce_ranges, at_capacity } => {
+                    if outcome_tx.is_closed() {
+                        debug!(target: "worker::batch_builder", "builder cancelled task prior to broadcast");
+                        return;
+                    }
+
+                    let (ack, ack_rx) = oneshot::channel();
+
+                    if let Err(send_err) =
+                        to_worker.send((sealed_batch, sender_nonce_ranges, ack)).await
+                    {
+                        let err = BatchBuilderError::from(send_err);
+                        if !err.is_worker_gone() {
+                            error!(target: "worker::batch_builder", ?err, "failed to send next batch to worker");
+                        }
+                        let _ = outcome_tx.send(Err(err));
+                        return;
+                    }
+
+                    match ack_rx.await {
+                        Ok(Ok(_)) => {
+                            let _ = outcome_tx
+                                .send(Ok(TaskOutcome::QuorumSucceeded { selected, at_capacity }));
+                        }
+                        Ok(Err(BlockSealError::FatalDBFailure)) => {
+                            let _ = outcome_tx.send(Err(BatchBuilderError::FatalDBFailure));
+                        }
+                        Ok(Err(_)) => {
+                            let _ = outcome_tx.send(Ok(TaskOutcome::QuorumFailed));
+                        }
+                        Err(recv_err) => {
+                            let _ = outcome_tx.send(Err(BatchBuilderError::from(recv_err)));
+                        }
                     }
                 }
             }
         });
 
-        // return oneshot channel for receiving completion status
-        done
+        outcome_rx
     }
 
-    fn latest_canon_block(reth_env: &RethEnv) -> SealedBlock {
+    /// Returns the timestamp of the latest canonical block, or genesis before any block.
+    fn latest_canon_timestamp(reth_env: &RethEnv) -> u64 {
         let num = reth_env.last_block_number().unwrap_or_default();
-        if let Ok(Some(header)) = reth_env.sealed_block_by_number(num) {
-            header
+        if let Ok(Some(block)) = reth_env.sealed_block_by_number(num) {
+            block.timestamp
         } else {
-            reth_env.chainspec().sealed_genesis_block()
+            reth_env.chainspec().sealed_genesis_block().timestamp
         }
-    }
-}
-
-/// The [BatchBuilder] is a future that loops through the following:
-/// - check/apply canonical state changes that affect the next build
-/// - poll any pending block building tasks
-/// - otherwise, build next block if pending transactions are available
-///
-/// If a task completes, the loop continues to poll for any new output from consensus then begins
-/// executing the next task.
-///
-/// If the broadcast stream is closed, the engine will attempt to execute all remaining tasks and
-/// any output that is queued.
-impl Future for BatchBuilder {
-    type Output = BatchBuilderResult<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-
-        // loop when a successful block is built
-        loop {
-            // This is used as a "wake up" when canonical state updates.
-            while let Poll::Ready(Some(latest)) = this.state_changed.poll_next_unpin(cx) {
-                this.last_canonical_update = latest.tip().sealed_block().clone()
-            }
-
-            // skip sealing new batches once the epoch is closing: the canonical tip has reached
-            // the epoch boundary (block timestamp == subdag commit_timestamp). Derived from
-            // executed state, so no shared flag is needed.
-            //
-            // This gates on the EXECUTED block timestamp, not the subdag commit_timestamp the
-            // subscriber enforces. If execution lags commit, our cutoff trails the subscriber's by
-            // that gap, so we may seal a few extra batches just past the boundary. That's benign:
-            // those batches don't make it into this epoch's blocks and are rescued next epoch by
-            // orphan_batches, so nothing is lost.
-            if this.pending_task.is_none()
-                && this.last_canonical_update.timestamp >= this.epoch_boundary
-            {
-                debug!(target: "worker::batch_builder", "epoch boundary reached, skipping batch seal");
-                this.max_delay_interval.reset();
-                let _ = this.max_delay_interval.poll_tick(cx);
-                break;
-            }
-
-            // only propose one block at a time
-            if this.pending_task.is_none() {
-                // Seal only when some pending transaction is not already in flight: sealed txs
-                // stay pending until execution releases them, so `best_transactions` keeps
-                // yielding them and gating on the bare iterator would spin sealing empty batches.
-                // The scan is O(pending) only when every pending tx is in flight, which the next
-                // canonical update (release + wake) clears.
-                let has_sealable =
-                    this.pool.best_transactions().any(|tx| !this.pool.is_in_flight(tx.hash()));
-                if !has_sealable {
-                    // reset interval to wake up after some time
-                    //
-                    // only need to reset here if there is no pending block being built
-                    this.max_delay_interval.reset();
-
-                    // tick interval to ensure it advances
-                    let _ = this.max_delay_interval.poll_tick(cx);
-
-                    // nothing to seal
-                    break;
-                }
-
-                // start building the next batch
-                this.pending_task = Some(this.spawn_execution_task());
-
-                // don't break so pending_task receiver gets polled
-            }
-
-            // poll receiver that returns mined transactions once the batch reaches quorum
-            if let Some(mut receiver) = this.pending_task.take() {
-                // poll here so waker is notified when ack received
-                match receiver.poll_unpin(cx) {
-                    Poll::Ready(res) => {
-                        debug!(target: "block-builder", ?res, "pending task complete");
-                        // ensure no fatal errors
-                        let (mined_transactions, seq) = res??;
-
-                        // NOTE: empty vec returned for non-fatal error during block proposal
-                        if mined_transactions.is_empty() {
-                            // Seal failed (no quorum, or the report went unacknowledged): do NOT
-                            // advance next_batch_seq so the same seq is reused for the next
-                            // attempt, avoiding gaps.
-                            // reset interval to prevent immediate re-wake from stale tick
-                            this.max_delay_interval.reset();
-                            let _ = this.max_delay_interval.poll_tick(cx);
-                            // return pending and wait for canonical update to wake up again
-                            break;
-                        }
-
-                        // Seal succeeded: advance the seq counter past the one we just used.
-                        this.next_batch_seq = seq + 1;
-
-                        debug!(target: "block-builder", "marking sealed transactions in flight");
-
-                        // Mark rather than evict: the txs stay pending (RPC-visible) until
-                        // execution, and `is_in_flight` keeps the next seal from re-proposing
-                        // them across the quorum-to-execution window.
-                        this.in_flight.mark(mined_transactions);
-
-                        // loop again to check for any other pending transactions
-                        // and possibly start building the next block
-                        //
-                        // NOTE: continuing here is important.
-                        // To prevent the following scenario, do not wait for task's waker:
-                        // - there were more transactions in the pool than could fit in the first
-                        //   block
-                        // - pending transaction notifications already drained
-                        // - have to wait for engine's next canonical update to wake up
-                        continue;
-                    }
-
-                    Poll::Pending => {
-                        this.pending_task = Some(receiver);
-
-                        // break loop and return Poll::Pending
-                        break;
-                    }
-                }
-            }
-        }
-
-        // all output executed, yield back to runtime
-        Poll::Pending
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use assert_matches::assert_matches;
-    use rayls_consensus_worker::{
-        metrics::WorkerMetrics, test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle,
-    };
-    use rayls_execution_evm::{
-        payload::BuildArguments,
-        recover_raw_transaction,
-        test_utils::{create_committee_from_state, TransactionFactory},
-        RethChainSpec,
-    };
-    use rayls_infrastructure_network_types::{local::LocalNetwork, MockWorkerToPrimaryHang};
-    use rayls_infrastructure_storage::{open_db, tables::Batches};
-    use rayls_infrastructure_types::{
-        gas_accumulator::GasAccumulator, test_genesis, Bytes, Certificate, CommittedSubDag,
-        ConsensusOutput, Database, DbTx, GenesisAccount, TaskManager,
-        ETHEREUM_BLOCK_GAS_LIMIT_56BITS, U160, U256,
-    };
-    use rayls_middleware_processor::{batch::BatchOrdering, execute_consensus_output};
-    use std::{path::Path, str::FromStr, sync::Arc, time::Duration};
-    use tempfile::TempDir;
-    use tokio::time::timeout;
-
-    #[tokio::test]
-    async fn test_make_block_no_ack_txs_in_pool_still() {
-        let genesis = test_genesis();
-        let mut tx_factory = TransactionFactory::new();
-        let factory_address = tx_factory.address();
-
-        // fund factory with 99mil RLS
-        let account = vec![(
-            factory_address,
-            GenesisAccount::default().with_balance(
-                U256::from_str("0x51E410C0F93FE543000000").expect("account balance is parsed"),
-            ),
-        )];
-
-        let genesis = genesis.extend_accounts(account);
-        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
-
-        // task manger
-        let task_manager = TaskManager::new("make_block_no_ack_txs_in_pool_still Task Manager");
-        let tmp_dir = TempDir::new().unwrap();
-        let reth_env =
-            RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
-                .await
-                .unwrap();
-        let txpool = reth_env.init_txn_pool().unwrap();
-        let address = Address::from(U160::from(33));
-        let client = LocalNetwork::new_with_empty_id();
-        let worker_to_primary = Arc::new(MockWorkerToPrimaryHang {});
-        client.set_worker_to_primary_local_handler(worker_to_primary);
-        let temp_dir = TempDir::new().unwrap();
-        let store = open_db(temp_dir.path());
-        let qw = TestMakeBlockQuorumWaiter::new_test();
-        let node_metrics = WorkerMetrics::default();
-        let timeout = Duration::from_secs(5);
-        let mut block_provider = Worker::new(
-            0,
-            Some(qw),
-            Arc::new(node_metrics),
-            client,
-            store.clone(),
-            timeout,
-            WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
-        );
-
-        block_provider.spawn_batch_builder("test batch builder", &task_manager);
-
-        // build execution block proposer
-        let batch_builder = BatchBuilder::new(
-            &reth_env,
-            txpool.clone(),
-            block_provider.batches_tx(),
-            address,
-            Duration::from_secs(1),
-            task_manager.get_spawner(),
-            0,
-            BaseFeeContainer::default(),
-            0,
-            0,
-            u64::MAX,
-            ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
-        );
-
-        let gas_price = reth_env.get_gas_price().unwrap();
-        let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
-
-        // create 3 transactions
-        let transaction1 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let transaction2 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let transaction3 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction1.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction1.hash());
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction2.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction2.hash());
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction3.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction3.hash());
-
-        // txpool size
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 3);
-
-        // spawn batch_builder once worker is ready
-        let _batch_builder = tokio::spawn(Box::pin(batch_builder));
-
-        // wait for new batch
-        let mut new_batch = None;
-        for _ in 0..5 {
-            let _ = tokio::time::sleep(Duration::from_secs(1)).await;
-            // Ensure the block is stored - use with_read_txn for proper transaction scoping
-            if let Ok(Some((_, wb))) = store.with_read_txn(|txn| Ok(txn.iter::<Batches>().next())) {
-                new_batch = Some(wb);
-                break;
-            }
-        }
-        let new_batch = new_batch.unwrap();
-
-        // number of transactions in the block
-        let block_txs = new_batch.transactions();
-
-        // check max tx for task matches num of transactions in block
-        let num_block_txs = block_txs.len();
-        assert_eq!(3, num_block_txs);
-
-        // ensure decoded block transaction is transaction1
-        let block_tx_bytes = block_txs.first().expect("one tx in block");
-        let block_tx =
-            recover_raw_transaction(block_tx_bytes).expect("recover raw tx for test").into_inner();
-
-        assert_eq!(block_tx, transaction1);
-
-        // yield to try and give pool a chance to update
-        tokio::task::yield_now().await;
-
-        // transactions should be in pool still since ack wasn't received
-        // IT test ensures these transactions are cleared
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 3);
-    }
-
-    /// Convenience struct for creating test assets.
-    struct TestTools {
-        /// Factory for creating and signing valid transactions.
-        tx_factory: TransactionFactory,
-        /// Execution components:
-        /// - BlockchainProvider (db)
-        /// - TransactionPool
-        /// - ChainSpec
-        /// - TaskManager (so executor tasks don't drop)
-        execution_components: TestExecutionComponents,
-        /// Own manager so executor's tasks don't drop.
-        task_manager: TaskManager,
-    }
-
-    /// Convenience type for holding execution components.
-    struct TestExecutionComponents {
-        /// The reth execution environment.
-        reth_env: RethEnv,
-        /// The transaction pool for the block builder.
-        txpool: WorkerTxPool,
-        /// The chainspec with seeded genesis.
-        chain: Arc<RethChainSpec>,
-    }
-
-    /// Helper function to create common testing infrastructure.
-    async fn get_test_tools(path: &Path) -> TestTools {
-        let tx_factory = TransactionFactory::new();
-        let factory_address = tx_factory.address();
-        let genesis = test_genesis().extend_accounts([(
-            factory_address,
-            GenesisAccount::default().with_balance(
-                U256::from_str("0x51E410C0F93FE543000000").expect("account balance is parsed"),
-            ),
-        )]);
-        let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
-
-        // task manger
-        let task_manager = TaskManager::new("Test Task Manager");
-        let reth_env =
-            RethEnv::new_for_temp_chain(chain.clone(), path, &task_manager, None).await.unwrap();
-        let txpool = reth_env.init_txn_pool().unwrap();
-
-        let execution_components = TestExecutionComponents { reth_env, txpool, chain };
-        TestTools { tx_factory, execution_components, task_manager }
-    }
-
-    /// Test all possible errors from the worker while trying to reach quorum from peers.
-    ///
-    /// Non-fatal errors return empty vecs of mined transactions.
-    /// Fatal error causes shutdown.
-    #[tokio::test]
-    async fn test_all_possible_error_outcomes() {
-        let tmp_dir = TempDir::new().unwrap();
-        let TestTools { mut tx_factory, execution_components, task_manager } =
-            get_test_tools(tmp_dir.path()).await;
-        let TestExecutionComponents { reth_env, txpool, chain, .. } = execution_components;
-        let address = Address::from(U160::from(33));
-        let temp_db_dir = TempDir::new().unwrap();
-        let ordering_store = open_db(temp_db_dir.path());
-        let batch_ordering = BatchOrdering::new_with_empty_state(ordering_store.clone());
-        let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
-
-        // build execution block proposer
-        let batch_builder = BatchBuilder::new(
-            &reth_env,
-            txpool.clone(),
-            to_worker,
-            address,
-            Duration::from_millis(1),
-            task_manager.get_spawner(),
-            0,
-            BaseFeeContainer::default(),
-            0,
-            0,
-            u64::MAX,
-            ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
-        );
-
-        // expected to be 7 wei for first block
-        let gas_price = reth_env.get_gas_price().unwrap();
-        let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
-
-        // create 3 transactions
-        let transaction1 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let transaction2 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let transaction3 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction1.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction1.hash());
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction2.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction2.hash());
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction3.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction3.hash());
-
-        // txpool size
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 3);
-
-        // spawn batch_builder once worker is ready
-        let batch_builder_task = tokio::spawn(Box::pin(batch_builder));
-
-        // plenty of time for block production
-        let duration = std::time::Duration::from_secs(5);
-
-        // simulate engine to create canonical blocks from empty rounds
-        let mut parent = chain.sealed_genesis_header();
-
-        let non_fatal_errors = vec![
-            BlockSealError::QuorumRejected,
-            BlockSealError::AntiQuorum,
-            BlockSealError::Timeout,
-            BlockSealError::FailedQuorum,
-        ];
-
-        let committee = create_committee_from_state(
-            reth_env.epoch_state_from_canonical_tip().expect("epoch state from canonical tip"),
-        )
-        .await
-        .expect("committee from state");
-        let gas_accumulator = GasAccumulator::new(1); // 1 worker
-        let leader = committee.authorities().first().expect("first authority").id();
-        gas_accumulator.rewards_counter().set_committee(committee);
-        // specify leader for consensus output
-        let mut leader_cert = Certificate::default();
-        leader_cert.header_mut_for_test().author = leader;
-        let mut subdag = CommittedSubDag::default();
-        subdag.leader = leader_cert;
-        let mut output = ConsensusOutput::default();
-        output.sub_dag = Arc::new(subdag);
-
-        // receive new blocks and return non-fatal errors
-        // non-fatal errors cause the loop to break and wait for txpool updates
-        // submitting a new pending transaction is one of the ways this task wakes up
-        for (subdag_index, error) in non_fatal_errors.into_iter().enumerate() {
-            let (sealed_batch, _sender_nonce_ranges, ack) =
-                timeout(duration, from_batch_builder.recv())
-                    .await
-                    .expect("block builder built another block after canonical update")
-                    .expect("batch was built");
-
-            // all 3 transactions present
-            assert_eq!(sealed_batch.batch().transactions().len(), 3 + subdag_index);
-
-            // submit another tx to pool BEFORE sending ack so it's in the pool
-            // by the time the BatchBuilder wakes up after receiving the ack
-            tx_factory
-                .create_and_submit_eip1559_pool_tx(
-                    chain.clone(),
-                    gas_price,
-                    Address::ZERO,
-                    value, // 1 RLS
-                    txpool.clone(),
-                )
-                .await;
-
-            // send non-fatal error - BatchBuilder won't poll pool until ack is received
-            let _ = ack.send(Err(error));
-
-            // canonical update to wake up task
-            // execute output to trigger canonical update
-            let args = BuildArguments::new(reth_env.clone(), output.clone(), parent);
-            let final_header = execute_consensus_output(
-                args,
-                gas_accumulator.clone(),
-                None,
-                Default::default(),
-                batch_ordering.clone(),
-                ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
-                rayls_execution_evm::in_flight::InFlightTracker::new(),
-            )
-            .expect("output executed");
-
-            // update values for next loop
-            parent = final_header;
-
-            // sleep to ensure canonical update received before ack
-            let _ = tokio::time::sleep(Duration::from_secs(5)).await;
-        }
-
-        // wait for next block
-        let (sealed_batch, _sender_nonce_ranges, ack) =
-            timeout(duration, from_batch_builder.recv())
-                .await
-                .expect("block builder's sender didn't drop")
-                .expect("batch was built");
-
-        // expect 7 transactions after loop added 4 more
-        assert_eq!(sealed_batch.batch().transactions().len(), 7);
-
-        // now send fatal error
-        let _ = ack.send(Err(BlockSealError::FatalDBFailure));
-
-        // ensure block builder shuts down from fatal error
-        let result = batch_builder_task.await.expect("ack channel delivered result");
-        assert!(result.is_err());
-
-        // yield to try and give pool a chance to update
-        tokio::task::yield_now().await;
-
-        // transactions should be in pool still since ack was error
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 7);
-    }
-
-    /// Test transactions are mined from the pool.
-    #[tokio::test]
-    async fn test_pool_updates_after_txs_mined() {
-        let tmp_dir = TempDir::new().unwrap();
-        let TestTools { mut tx_factory, execution_components, task_manager } =
-            get_test_tools(tmp_dir.path()).await;
-        let TestExecutionComponents { reth_env, txpool, chain, .. } = execution_components;
-        let address = Address::from(U160::from(33));
-        let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
-
-        // build execution block proposer
-        let batch_builder = BatchBuilder::new(
-            &reth_env,
-            txpool.clone(),
-            to_worker,
-            address,
-            Duration::from_secs(1),
-            task_manager.get_spawner(),
-            0,
-            BaseFeeContainer::default(),
-            0,
-            0,
-            u64::MAX,
-            ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
-        );
-
-        // expected to be 7 wei for first block
-        let gas_price = reth_env.get_gas_price().unwrap();
-        let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
-
-        // create 3 transactions
-        let transaction1 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let transaction2 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let transaction3 = tx_factory.create_eip1559(
-            chain.clone(),
-            None,
-            gas_price,
-            Some(Address::ZERO),
-            value, // 1 RLS
-            Bytes::new(),
-        );
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction1.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction1.hash());
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction2.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction2.hash());
-
-        let added_result = tx_factory.submit_tx_to_pool(transaction3.clone(), txpool.clone()).await;
-        assert_matches!(added_result, hash if &hash == transaction3.hash());
-
-        // txpool size
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 3);
-
-        // spawn batch_builder once worker is ready
-        let _batch_builder_task = tokio::spawn(Box::pin(batch_builder));
-
-        // plenty of time for block production
-        let duration = std::time::Duration::from_secs(5);
-
-        // receive proposed block with 3 transactions
-        let (sealed_batch, _sender_nonce_ranges, ack) =
-            timeout(duration, from_batch_builder.recv())
-                .await
-                .expect("block builder's sender didn't drop")
-                .expect("batch was built");
-
-        // submit new transaction before sending ack
-        let expected_tx_hash = tx_factory
-            .create_and_submit_eip1559_pool_tx(
-                chain.clone(),
-                gas_price,
-                Address::ZERO,
-                value, // 1 RLS
-                txpool.clone(),
-            )
-            .await;
-
-        // assert first 3 txs in block
-        assert_eq!(sealed_batch.batch().transactions().len(), 3);
-
-        // assert all 4 txs in pending pool
-        let pending_pool_len = txpool.pool_size().pending;
-        assert_eq!(pending_pool_len, 4);
-
-        // send ack to mine first 3 transactions
-        let _ = ack.send(Ok(()));
-
-        // receive next block
-        let (sealed_batch, _sender_nonce_ranges, ack) =
-            timeout(duration, from_batch_builder.recv())
-                .await
-                .expect("block builder's sender didn't drop")
-                .expect("batch was built");
-        // send ack to mine block
-        let _ = ack.send(Ok(()));
-
-        // assert only transaction in block
-        assert_eq!(sealed_batch.batch().transactions().len(), 1);
-
-        // confirm 4th transaction hash matches one submitted
-        let tx_bytes =
-            sealed_batch.batch().transactions().first().expect("block transactions length is one");
-        let tx = recover_raw_transaction(tx_bytes).expect("recover raw tx for test");
-        assert_eq!(tx.hash(), &expected_tx_hash);
-
-        // yield to try and give pool a chance to update
-        tokio::task::yield_now().await;
-
-        // Sealed transactions are marked in flight rather than evicted, so all four stay pending
-        // (RPC-visible) until execution; both batches reached quorum, so none is re-sealable.
-        let pending = txpool.pending_transactions();
-        assert_eq!(pending.len(), 4);
-        assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
-    }
-
-    /// A transaction sealed into a batch is marked in flight and skipped by the next seal, so the
-    /// same txs are not re-sealed across the quorum-to-execution window while they stay pending.
-    #[tokio::test]
-    async fn in_flight_txs_are_skipped_on_the_next_seal() {
-        let tmp_dir = TempDir::new().unwrap();
-        // keep task_manager alive: dropping it tears down the pool's validation service
-        let TestTools { mut tx_factory, execution_components, task_manager: _task_manager } =
-            get_test_tools(tmp_dir.path()).await;
-        let TestExecutionComponents { reth_env, txpool, chain } = execution_components;
-        let address = Address::from(U160::from(33));
-
-        let gas_price = reth_env.get_gas_price().unwrap();
-        let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 fits U256");
-
-        // three txs from one sender: sequential nonces, all land in the pending sub-pool
-        for _ in 0..3 {
-            tx_factory
-                .create_and_submit_eip1559_pool_tx(
-                    chain.clone(),
-                    gas_price,
-                    Address::ZERO,
-                    value,
-                    txpool.clone(),
-                )
-                .await;
-        }
-        assert_eq!(txpool.pool_size().pending, 3);
-
-        let base_fee = txpool.get_pending_base_fee();
-        let gas_limit = ETHEREUM_BLOCK_GAS_LIMIT_56BITS;
-
-        // first seal takes all three
-        let first = build_batch(
-            BatchBuilderArgs::new(txpool.clone(), address, 0),
-            0,
-            base_fee,
-            0,
-            gas_limit,
-        );
-        assert_eq!(first.mined_transactions.len(), 3);
-
-        // mark them in flight through the sealing capability, as quorum success does
-        let seal = txpool.in_flight().arm_sealing(DuePolicy::ttl(Duration::from_secs(60)));
-        seal.mark(first.mined_transactions.clone());
-
-        // the txs are still pending but now skipped, so the next seal is empty
-        assert_eq!(txpool.pool_size().pending, 3);
-        let second = build_batch(
-            BatchBuilderArgs::new(txpool.clone(), address, 0),
-            0,
-            base_fee,
-            1,
-            gas_limit,
-        );
-        assert!(second.mined_transactions.is_empty(), "in-flight txs must not be re-sealed");
-
-        // reconcile keeps the marks while the txs remain pending (not yet executed)
-        txpool.reconcile_in_flight();
-        assert!(txpool.is_in_flight(first.mined_transactions.first().unwrap()));
     }
 }

--- a/crates/consensus/worker/src/batch-builder/src/pipeline.rs
+++ b/crates/consensus/worker/src/batch-builder/src/pipeline.rs
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: BUSL-1.1
+//! Typestate machine for the batch builder, making an illegal build/seal ordering unrepresentable.
+//!
+//! Each phase is a distinct type, so a transition that does not exist (say, sealing without first
+//! accumulating candidate transactions) cannot be written. [`PipelineState`] wraps the active phase
+//! so the `select!` loop can hold it across iterations.
+
+use crate::{
+    batch::SelectedForSeal, error::BatchBuilderResult, BOUNDARY_QUIESCE_WINDOW_SECS, MAX_SEAL_AHEAD,
+};
+use rayls_execution_evm::in_flight::SealMarks;
+use std::fmt;
+use tokio::sync::oneshot;
+
+/// Phase with no candidate transactions pending a seal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Clean;
+
+/// Phase with candidates waiting for the next build attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Accumulating;
+
+/// Phase draining a batch that filled to capacity, so more candidates certainly remain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BacklogDraining;
+
+/// Terminal phase once the epoch boundary is reached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Closed;
+
+/// Phase with a build task in flight, awaiting the worker's quorum resolution.
+pub struct AwaitingQuorum {
+    /// The in-flight build task's outcome.
+    pub(crate) rx: oneshot::Receiver<BatchBuilderResult<TaskOutcome>>,
+    /// Whether a candidate event arrived mid-build, so the seal must re-accumulate rather than
+    /// return to clean and lose the wake.
+    pub(crate) event_arrived_while_waiting: bool,
+}
+
+impl fmt::Debug for AwaitingQuorum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AwaitingQuorum")
+            .field("rx", &"<oneshot::Receiver>")
+            .field("event_arrived_while_waiting", &self.event_arrived_while_waiting)
+            .finish()
+    }
+}
+
+/// How close the canonical tip is to the epoch boundary, which throttles the seal-ahead budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EpochPhase {
+    /// Well before the boundary: seal up to [`MAX_SEAL_AHEAD`] batches ahead of execution.
+    Active,
+    /// Within the quiesce window: allow at most one outstanding batch.
+    Quiescing,
+    /// At or past the boundary: seal nothing more this epoch.
+    Closed,
+}
+
+impl EpochPhase {
+    /// Classifies the phase from the boundary and the canonical tip timestamp.
+    pub fn evaluate(epoch_boundary: u64, canonical_tip: u64) -> Self {
+        if canonical_tip >= epoch_boundary {
+            Self::Closed
+        } else if epoch_boundary.saturating_sub(canonical_tip) <= BOUNDARY_QUIESCE_WINDOW_SECS {
+            Self::Quiescing
+        } else {
+            Self::Active
+        }
+    }
+
+    /// Returns the most batches that may be outstanding (sealed but unexecuted) in this phase.
+    #[inline]
+    pub fn max_allowed_ahead(&self) -> u64 {
+        match self {
+            Self::Active => MAX_SEAL_AHEAD,
+            Self::Quiescing => 1,
+            Self::Closed => 0,
+        }
+    }
+}
+
+/// Why the budget predicate refused to start a new build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GateRejectionReason {
+    /// The epoch boundary has been reached; no further batches seal this epoch.
+    EpochBoundaryReached,
+    /// The seal-ahead budget is already full; wait for execution to catch up.
+    BudgetExhausted,
+}
+
+/// The resolution of a spawned build-and-seal task.
+#[derive(Debug)]
+pub enum TaskOutcome {
+    /// Every candidate was already in flight, so nothing sealed.
+    NothingToSeal,
+    /// The worker failed to reach quorum; the same sequence retries next window.
+    QuorumFailed,
+    /// The batch reached quorum; `selected` must be marked in flight.
+    QuorumSucceeded {
+        /// The transactions sealed into the batch, to mark in flight.
+        selected: SelectedForSeal,
+        /// Whether the batch filled to capacity, implying more candidates remain.
+        at_capacity: bool,
+    },
+}
+
+/// Context carried unchanged across every phase transition.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PipelineData {
+    /// The sequence the builder resumed from; `start_seq - 1` stands in for the executed watermark
+    /// until execution reports one.
+    pub(crate) start_seq: u64,
+    /// The highest sequence sealed to quorum so far, if any; never moves backward.
+    pub(crate) highest_durable_sealed_seq: Option<u64>,
+    /// The sequence the next build uses; advances only on a successful seal.
+    pub(crate) current_seq: u64,
+    /// The latest canonical tip timestamp, which the boundary and quiesce checks read.
+    pub(crate) last_canonical_timestamp: u64,
+}
+
+/// The builder pipeline in a statically known phase `S`.
+///
+/// Legal transitions, each a consuming method on the matching `impl` block:
+/// - `Clean` -> `Accumulating` on a candidate event;
+/// - `Accumulating` | `BacklogDraining` -> `AwaitingQuorum` when a build spawns;
+/// - `AwaitingQuorum` -> `Clean` | `Accumulating` | `BacklogDraining` on the quorum outcome;
+/// - any phase -> `Closed` once the canonical tip reaches the epoch boundary; `Closed` has no
+///   outgoing transition.
+#[derive(Debug)]
+pub struct BatchPipeline<S> {
+    /// The phase marker, carrying per-phase payload where one exists.
+    pub(crate) state: S,
+    /// The phase-independent context.
+    pub(crate) data: PipelineData,
+}
+
+impl<S> BatchPipeline<S> {
+    /// Returns the sequence number the next build will use.
+    #[inline]
+    pub fn current_seq(&self) -> u64 {
+        self.data.current_seq
+    }
+
+    /// Returns the highest sequence sealed so far, if any.
+    #[inline]
+    pub fn highest_durable_sealed_seq(&self) -> Option<u64> {
+        self.data.highest_durable_sealed_seq
+    }
+
+    /// Records the latest canonical tip timestamp, which gates the boundary and quiesce checks.
+    #[inline]
+    pub fn on_canonical_update(&mut self, timestamp: u64) {
+        self.data.last_canonical_timestamp = timestamp;
+    }
+}
+
+impl BatchPipeline<Clean> {
+    /// Starts a fresh pipeline resuming from `start_seq` with the given durable seal high-water
+    /// mark.
+    pub fn new(
+        persisted_highest_sealed_seq: Option<u64>,
+        start_seq: u64,
+        canonical_timestamp: u64,
+    ) -> Self {
+        Self {
+            state: Clean,
+            data: PipelineData {
+                start_seq,
+                highest_durable_sealed_seq: persisted_highest_sealed_seq,
+                current_seq: start_seq,
+                last_canonical_timestamp: canonical_timestamp,
+            },
+        }
+    }
+
+    /// Moves to `Accumulating` once a candidate transaction event arrives.
+    pub fn on_event(self) -> BatchPipeline<Accumulating> {
+        BatchPipeline { state: Accumulating, data: self.data }
+    }
+
+    /// Closes the pipeline when the canonical tip has reached the epoch boundary.
+    pub fn check_boundary(self, epoch_boundary: u64) -> Result<Self, BatchPipeline<Closed>> {
+        if self.data.last_canonical_timestamp >= epoch_boundary {
+            Err(BatchPipeline { state: Closed, data: self.data })
+        } else {
+            Ok(self)
+        }
+    }
+}
+
+impl BatchPipeline<Accumulating> {
+    /// Returns whether a build may start now, given execution progress and the boundary.
+    pub fn can_start_build(
+        &self,
+        own_executed_seq: Option<u64>,
+        epoch_boundary: u64,
+    ) -> Result<(), GateRejectionReason> {
+        check_build_budget(&self.data, own_executed_seq, epoch_boundary)
+    }
+
+    /// Moves to `AwaitingQuorum` once the build task is spawned.
+    pub fn start_building(
+        self,
+        rx: oneshot::Receiver<BatchBuilderResult<TaskOutcome>>,
+    ) -> BatchPipeline<AwaitingQuorum> {
+        BatchPipeline {
+            state: AwaitingQuorum { rx, event_arrived_while_waiting: false },
+            data: self.data,
+        }
+    }
+
+    /// Closes the pipeline when the canonical tip has reached the epoch boundary.
+    pub fn check_boundary(self, epoch_boundary: u64) -> Result<Self, BatchPipeline<Closed>> {
+        if self.data.last_canonical_timestamp >= epoch_boundary {
+            Err(BatchPipeline { state: Closed, data: self.data })
+        } else {
+            Ok(self)
+        }
+    }
+}
+
+impl BatchPipeline<BacklogDraining> {
+    /// Returns whether a build may start now, given execution progress and the boundary.
+    pub fn can_start_build(
+        &self,
+        own_executed_seq: Option<u64>,
+        epoch_boundary: u64,
+    ) -> Result<(), GateRejectionReason> {
+        check_build_budget(&self.data, own_executed_seq, epoch_boundary)
+    }
+
+    /// Moves to `AwaitingQuorum` once the build task is spawned.
+    pub fn start_building(
+        self,
+        rx: oneshot::Receiver<BatchBuilderResult<TaskOutcome>>,
+    ) -> BatchPipeline<AwaitingQuorum> {
+        BatchPipeline {
+            state: AwaitingQuorum { rx, event_arrived_while_waiting: false },
+            data: self.data,
+        }
+    }
+
+    /// Closes the pipeline when the canonical tip has reached the epoch boundary.
+    pub fn check_boundary(self, epoch_boundary: u64) -> Result<Self, BatchPipeline<Closed>> {
+        if self.data.last_canonical_timestamp >= epoch_boundary {
+            Err(BatchPipeline { state: Closed, data: self.data })
+        } else {
+            Ok(self)
+        }
+    }
+}
+
+impl BatchPipeline<AwaitingQuorum> {
+    /// Records that a candidate event arrived while a build was already in flight.
+    #[inline]
+    pub fn on_event(&mut self) {
+        self.state.event_arrived_while_waiting = true;
+    }
+
+    /// Returns the receiver the loop awaits for the quorum resolution.
+    #[inline]
+    pub fn rx_mut(&mut self) -> &mut oneshot::Receiver<BatchBuilderResult<TaskOutcome>> {
+        &mut self.state.rx
+    }
+
+    /// Returns to `Clean` after a build that sealed nothing or found the worker gone.
+    pub fn into_clean(self) -> BatchPipeline<Clean> {
+        BatchPipeline { state: Clean, data: self.data }
+    }
+
+    /// Returns to `Accumulating` to retry after a failed quorum.
+    pub fn into_accumulating(self) -> BatchPipeline<Accumulating> {
+        BatchPipeline { state: Accumulating, data: self.data }
+    }
+
+    /// Marks the sealed batch in flight, advances the sequence, and picks the next phase.
+    ///
+    /// A full batch drains a backlog, a candidate that arrived mid-build re-accumulates, and
+    /// otherwise the pipeline returns to clean.
+    pub fn mark_in_flight_and_advance(
+        mut self,
+        selected: SelectedForSeal,
+        at_capacity: bool,
+        in_flight: &SealMarks,
+    ) -> SealedTransition {
+        in_flight.mark(selected.into_marks());
+
+        let sealed_seq = self.data.current_seq;
+        self.data.highest_durable_sealed_seq = Some(
+            self.data.highest_durable_sealed_seq.map_or(sealed_seq, |prev| prev.max(sealed_seq)),
+        );
+        self.data.current_seq += 1;
+
+        let event_arrived = self.state.event_arrived_while_waiting;
+
+        if at_capacity {
+            SealedTransition::BacklogDraining(BatchPipeline {
+                state: BacklogDraining,
+                data: self.data,
+            })
+        } else if event_arrived {
+            SealedTransition::Accumulating(BatchPipeline { state: Accumulating, data: self.data })
+        } else {
+            SealedTransition::Clean(BatchPipeline { state: Clean, data: self.data })
+        }
+    }
+
+    /// Closes the pipeline when the canonical tip has reached the epoch boundary.
+    pub fn check_boundary(self, epoch_boundary: u64) -> Result<Self, BatchPipeline<Closed>> {
+        if self.data.last_canonical_timestamp >= epoch_boundary {
+            Err(BatchPipeline { state: Closed, data: self.data })
+        } else {
+            Ok(self)
+        }
+    }
+}
+
+impl BatchPipeline<Closed> {
+    /// Returns true; the terminal phase has no outgoing transitions.
+    #[inline]
+    pub fn is_closed(&self) -> bool {
+        true
+    }
+}
+
+/// The non-terminal phase a completed seal transitions into.
+#[derive(Debug)]
+pub enum SealedTransition {
+    /// No further candidates; back to clean.
+    Clean(BatchPipeline<Clean>),
+    /// A candidate arrived mid-build; keep accumulating.
+    Accumulating(BatchPipeline<Accumulating>),
+    /// The batch filled to capacity; drain the remaining backlog.
+    BacklogDraining(BatchPipeline<BacklogDraining>),
+}
+
+/// The active pipeline phase, held by the `select!` loop across iterations.
+#[derive(Debug)]
+pub enum PipelineState {
+    /// No candidates pending.
+    Clean(BatchPipeline<Clean>),
+    /// Candidates pending a build.
+    Accumulating(BatchPipeline<Accumulating>),
+    /// Draining a capacity-filled batch's backlog.
+    BacklogDraining(BatchPipeline<BacklogDraining>),
+    /// A build is in flight awaiting quorum.
+    AwaitingQuorum(BatchPipeline<AwaitingQuorum>),
+}
+
+impl From<SealedTransition> for PipelineState {
+    fn from(transition: SealedTransition) -> Self {
+        match transition {
+            SealedTransition::Clean(p) => Self::Clean(p),
+            SealedTransition::Accumulating(p) => Self::Accumulating(p),
+            SealedTransition::BacklogDraining(p) => Self::BacklogDraining(p),
+        }
+    }
+}
+
+impl PipelineState {
+    /// Returns whether a build task is currently in flight.
+    #[inline]
+    pub fn is_awaiting_quorum(&self) -> bool {
+        matches!(self, Self::AwaitingQuorum(_))
+    }
+
+    /// Returns the sequence number the next build will use.
+    #[inline]
+    pub fn current_seq(&self) -> u64 {
+        match self {
+            Self::Clean(p) => p.current_seq(),
+            Self::Accumulating(p) => p.current_seq(),
+            Self::BacklogDraining(p) => p.current_seq(),
+            Self::AwaitingQuorum(p) => p.current_seq(),
+        }
+    }
+
+    /// Awaits the quorum resolution when a build is in flight, otherwise parks forever so the
+    /// `select!` branch is inert in every other phase.
+    pub async fn await_quorum(
+        &mut self,
+    ) -> Result<BatchBuilderResult<TaskOutcome>, oneshot::error::RecvError> {
+        match self {
+            Self::AwaitingQuorum(p) => p.rx_mut().await,
+            _ => std::future::pending().await,
+        }
+    }
+
+    /// Registers a candidate event, moving `Clean` to `Accumulating` and flagging an in-flight
+    /// build.
+    pub fn on_event(self) -> Self {
+        match self {
+            Self::Clean(p) => Self::Accumulating(p.on_event()),
+            Self::Accumulating(p) => Self::Accumulating(p),
+            Self::BacklogDraining(p) => Self::BacklogDraining(p),
+            Self::AwaitingQuorum(mut p) => {
+                p.on_event();
+                Self::AwaitingQuorum(p)
+            }
+        }
+    }
+
+    /// Records the latest canonical tip timestamp in whichever phase is active.
+    pub fn on_canonical_update(&mut self, timestamp: u64) {
+        match self {
+            Self::Clean(p) => p.on_canonical_update(timestamp),
+            Self::Accumulating(p) => p.on_canonical_update(timestamp),
+            Self::BacklogDraining(p) => p.on_canonical_update(timestamp),
+            Self::AwaitingQuorum(p) => p.on_canonical_update(timestamp),
+        }
+    }
+
+    /// Closes the pipeline when the canonical tip has reached the epoch boundary.
+    pub fn check_boundary(self, epoch_boundary: u64) -> Result<Self, BatchPipeline<Closed>> {
+        match self {
+            Self::Clean(p) => p.check_boundary(epoch_boundary).map(Self::Clean),
+            Self::Accumulating(p) => p.check_boundary(epoch_boundary).map(Self::Accumulating),
+            Self::BacklogDraining(p) => p.check_boundary(epoch_boundary).map(Self::BacklogDraining),
+            Self::AwaitingQuorum(p) => p.check_boundary(epoch_boundary).map(Self::AwaitingQuorum),
+        }
+    }
+}
+
+/// Refuses a build past the boundary or once the phase's seal-ahead budget is full.
+#[inline]
+fn check_build_budget(
+    data: &PipelineData,
+    own_executed_seq: Option<u64>,
+    epoch_boundary: u64,
+) -> Result<(), GateRejectionReason> {
+    let phase = EpochPhase::evaluate(epoch_boundary, data.last_canonical_timestamp);
+    if phase == EpochPhase::Closed {
+        return Err(GateRejectionReason::EpochBoundaryReached);
+    }
+
+    let in_flight = calculate_in_flight_depth(
+        data.highest_durable_sealed_seq,
+        data.start_seq,
+        own_executed_seq,
+    );
+
+    if in_flight >= phase.max_allowed_ahead() {
+        return Err(GateRejectionReason::BudgetExhausted);
+    }
+
+    Ok(())
+}
+
+/// Returns the number of sealed-but-unexecuted batches: the seal high-water mark minus the executed
+/// watermark, floored at the pre-resume sequence when execution has not reported yet.
+#[inline]
+pub fn calculate_in_flight_depth(
+    highest_sealed_seq: Option<u64>,
+    start_seq: u64,
+    own_executed_seq: Option<u64>,
+) -> u64 {
+    let sealed = match highest_sealed_seq {
+        Some(s) => s,
+        None => return 0,
+    };
+    let executed = own_executed_seq.unwrap_or_else(|| start_seq.saturating_sub(1));
+    sealed.saturating_sub(executed)
+}

--- a/crates/consensus/worker/src/batch-builder/src/watermark.rs
+++ b/crates/consensus/worker/src/batch-builder/src/watermark.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+//! This authority's executed batch-sequence watermark, as seen by the batch builder.
+
+use tokio::sync::watch;
+
+/// Receiver for the ordering layer's own-authority accepted-sequence watch.
+#[derive(Clone, Debug)]
+pub struct OwnWatermarkReceiver {
+    rx: watch::Receiver<Option<u64>>,
+}
+
+impl OwnWatermarkReceiver {
+    /// Wraps the ordering layer's own-executed-sequence watch for the builder.
+    pub fn new(rx: watch::Receiver<Option<u64>>) -> Self {
+        Self { rx }
+    }
+
+    /// Returns the current watermark without waiting for a change.
+    pub fn get(&self) -> Option<u64> {
+        *self.rx.borrow()
+    }
+
+    /// Returns the underlying watch receiver, for `changed()` wakeups in `select!`.
+    pub fn inner_mut(&mut self) -> &mut watch::Receiver<Option<u64>> {
+        &mut self.rx
+    }
+
+    /// Returns the sequence the builder resumes from: one past the executed watermark, or the
+    /// persisted next sequence when execution has not reported one.
+    pub fn resume_seq(&self, persisted_next: u64) -> u64 {
+        self.get().map_or(persisted_next, |executed| executed.saturating_add(1))
+    }
+}

--- a/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
@@ -4,7 +4,9 @@
 //! from peers.
 
 use assert_matches::assert_matches;
-use rayls_batch_builder::{test_utils::execute_test_batch, BatchBuilder};
+use rayls_batch_builder::{
+    test_utils::execute_test_batch, BatchBuilder, BatchBuilderConfig, OwnWatermarkReceiver,
+};
 use rayls_batch_validator::BatchValidator;
 use rayls_consensus_worker::{
     metrics::WorkerMetrics, test_utils::TestMakeBlockQuorumWaiter, Worker, WorkerNetworkHandle,
@@ -29,7 +31,7 @@ use rayls_infrastructure_types::{
 use rayls_middleware_processor::{batch::BatchOrdering, execute_consensus_output};
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 use tempfile::TempDir;
-use tokio::time::timeout;
+use tokio::{sync::watch, time::timeout};
 use tracing::debug;
 
 #[tokio::test]
@@ -75,19 +77,23 @@ async fn test_make_batch_el_to_cl() {
     let address = Address::from(U160::from(333));
 
     // build execution block proposer
+    let (_wm_tx, wm_rx) = watch::channel(None);
     let batch_builder = BatchBuilder::new(
         &reth_env,
         txpool.clone(),
         batch_provider.batches_tx(),
-        address,
-        Duration::from_secs(1),
         task_manager.get_spawner(),
-        0,
         BaseFeeContainer::default(),
-        0,
-        0,
-        u64::MAX,
-        ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address,
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: u64::MAX,
+            max_delay: Duration::from_secs(1),
+            next_batch_seq: 0,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        },
     );
 
     let gas_price = reth_env.get_gas_price().unwrap();
@@ -140,7 +146,7 @@ async fn test_make_batch_el_to_cl() {
     assert_eq!(pending_pool_len, 3);
 
     // spawn batch_builder once worker is ready
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     //
     //
@@ -251,19 +257,23 @@ async fn test_batch_builder_produces_valid_batches() {
     let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
 
     // build execution block proposer
+    let (_wm_tx, wm_rx) = watch::channel(None);
     let batch_builder = BatchBuilder::new(
         &reth_env,
         txpool.clone(),
         to_worker,
-        address,
-        Duration::from_secs(1),
         task_manager.get_spawner(),
-        0,
         BaseFeeContainer::default(),
-        0,
-        0,
-        u64::MAX,
-        ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address,
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: u64::MAX,
+            max_delay: Duration::from_secs(1),
+            next_batch_seq: 0,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        },
     );
 
     let gas_price = reth_env.get_gas_price().unwrap();
@@ -319,7 +329,7 @@ async fn test_batch_builder_produces_valid_batches() {
     assert_eq!(pool_size.blob, 0);
 
     // spawn batch_builder once worker is ready
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     //
     //
@@ -437,19 +447,23 @@ async fn test_canonical_notification_updates_pool() {
     let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
 
     // build execution block proposer
+    let (_wm_tx, wm_rx) = watch::channel(None);
     let batch_builder = BatchBuilder::new(
         &reth_env,
         txpool.clone(),
         to_worker,
-        address,
-        Duration::from_secs(1),
         task_manager.get_spawner(),
-        0,
         BaseFeeContainer::default(),
-        0,
-        0,
-        u64::MAX,
-        ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address,
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: u64::MAX,
+            max_delay: Duration::from_secs(1),
+            next_batch_seq: 0,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        },
     );
 
     let gas_price = reth_env.get_gas_price().unwrap();
@@ -490,7 +504,7 @@ async fn test_canonical_notification_updates_pool() {
     assert_eq!(pending_pool_len, 0);
 
     // spawn batch_builder once worker is ready
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     //
     //
@@ -559,19 +573,20 @@ async fn test_canonical_notification_updates_pool() {
     assert_eq!(pool_size.queued, 0);
     assert_eq!(pool_size.pending, 1);
 
-    // plenty of time for block production
-    let duration = std::time::Duration::from_secs(5);
+    // Wake the builder to seal the just-promoted tx. tx1-3 were mined from a foreign consensus
+    // output, not sealed by this builder, so no in-flight mark release wakes it for the promotion.
+    // A fresh candidate fires the pending-transaction wake, and the builder seals the promoted tx
+    // alongside it.
+    let _ = tx_factory
+        .create_and_submit_eip1559_pool_tx(
+            chain.clone(),
+            gas_price,
+            Address::ZERO,
+            value, // 1 RLS
+            txpool.clone(),
+        )
+        .await;
 
-    // receive next block
-    let (first_batch, _sender_nonce_ranges, ack) = timeout(duration, from_batch_builder.recv())
-        .await
-        .expect("block builder's sender didn't drop")
-        .expect("batch was built");
-
-    // send ack to mine transaction
-    let _ = ack.send(Ok(()));
-
-    // validate batch
     let batch_validator = BatchValidator::new(
         reth_env.clone(),
         Some(txpool.clone()),
@@ -581,19 +596,207 @@ async fn test_canonical_notification_updates_pool() {
         ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
     );
 
-    let valid_batch_result = batch_validator.validate_batch(first_batch.clone()).await;
-    assert!(valid_batch_result.is_ok());
+    // Drain and ack the batches the builder produces until both pending txs are sealed in flight.
+    let duration = std::time::Duration::from_secs(5);
+    while txpool.pending_transactions().iter().any(|tx| !txpool.is_in_flight(tx.hash())) {
+        let (batch, _sender_nonce_ranges, ack) = timeout(duration, from_batch_builder.recv())
+            .await
+            .expect("block builder's sender didn't drop")
+            .expect("batch was built");
+        assert!(batch_validator.validate_batch(batch).await.is_ok());
+        let _ = ack.send(Ok(()));
+        tokio::task::yield_now().await;
+    }
 
-    // yield to try and give pool a chance to update
-    tokio::task::yield_now().await;
-
-    // tx1-3 executed and drained; the 4th was sealed to quorum, so it is marked in flight and
-    // stays pending (RPC-visible) until it too executes.
+    // tx1-3 executed and drained; the promoted tx and the wake tx were sealed to quorum, so both
+    // are marked in flight and stay pending (RPC-visible) until they too execute.
     let pool_size = txpool.pool_size();
     assert_eq!(pool_size.queued, 0);
-    assert_eq!(pool_size.pending, 1);
+    assert_eq!(pool_size.pending, 2);
     let pending = txpool.pending_transactions();
     assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
+}
+
+/// The builder seals up to `MAX_SEAL_AHEAD` batches ahead of its own execution watermark, then
+/// stalls until execution advances, so a lagging proposer cannot outrun the parking budget.
+#[tokio::test]
+async fn builder_stalls_at_the_seal_ahead_budget_until_the_watermark_advances() {
+    let genesis = test_genesis();
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let tmp_dir = TempDir::new().unwrap();
+    let task_manager = TaskManager::default();
+    let reth_env = RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+        .await
+        .unwrap();
+    let txpool = reth_env.init_txn_pool().unwrap();
+    let address = Address::from(U160::from(333));
+    let gas_price = reth_env.get_gas_price().unwrap();
+    let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
+
+    // One transfer's worth of gas, so each batch caps at a single tx and every seal advances the
+    // sequence by exactly one, making the budget observable batch by batch.
+    let per_tx_gas = 30_000;
+    let mut tx_factory = TransactionFactory::new();
+    for _ in 0..5 {
+        let tx = tx_factory.create_eip1559(
+            chain.clone(),
+            Some(per_tx_gas),
+            gas_price,
+            Some(Address::ZERO),
+            value,
+            Bytes::new(),
+        );
+        let _ = tx_factory.submit_tx_to_pool(tx, txpool.clone()).await;
+    }
+    assert_eq!(txpool.pool_size().pending, 5);
+
+    let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
+    // Resume at seq 10 with execution reported through seq 9, so the seal-ahead budget starts
+    // empty.
+    let (wm_tx, wm_rx) = watch::channel(Some(9));
+    let batch_builder = BatchBuilder::new(
+        &reth_env,
+        txpool.clone(),
+        to_worker,
+        task_manager.get_spawner(),
+        BaseFeeContainer::default(),
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address,
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: u64::MAX,
+            max_delay: Duration::from_secs(60),
+            next_batch_seq: 10,
+            gas_limit: per_tx_gas,
+        },
+    );
+    let _builder = tokio::spawn(batch_builder.run());
+
+    // The builder seals exactly MAX_SEAL_AHEAD batches while execution stays at seq 9.
+    for _ in 0..rayls_batch_builder::MAX_SEAL_AHEAD {
+        let (_batch, _sender_nonce_ranges, ack) =
+            timeout(Duration::from_secs(5), from_batch_builder.recv())
+                .await
+                .expect("batch sealed ahead of execution")
+                .expect("batch channel open");
+        let _ = ack.send(Ok(()));
+    }
+
+    // With the budget full, no further batch seals until execution advances.
+    assert!(
+        timeout(Duration::from_millis(500), from_batch_builder.recv()).await.is_err(),
+        "builder must stall at the seal-ahead budget"
+    );
+
+    // Execution advances one sequence, reopening exactly one slot in the budget.
+    wm_tx.send(Some(10)).unwrap();
+    let (_batch, _sender_nonce_ranges, ack) =
+        timeout(Duration::from_secs(5), from_batch_builder.recv())
+            .await
+            .expect("watermark advance unblocks the next batch")
+            .expect("batch channel open");
+    let _ = ack.send(Ok(()));
+}
+
+/// The builder returns instead of sealing once the canonical tip has reached the epoch boundary.
+#[tokio::test]
+async fn builder_terminates_at_the_epoch_boundary() {
+    let genesis = test_genesis();
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let tmp_dir = TempDir::new().unwrap();
+    let task_manager = TaskManager::default();
+    let reth_env = RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+        .await
+        .unwrap();
+    let txpool = reth_env.init_txn_pool().unwrap();
+    let (to_worker, _from_batch_builder) = tokio::sync::mpsc::channel(2);
+    let (_wm_tx, wm_rx) = watch::channel(None);
+
+    // Boundary 0: the canonical tip is already at or past the boundary at construction, so the
+    // builder must terminate rather than seal.
+    let batch_builder = BatchBuilder::new(
+        &reth_env,
+        txpool.clone(),
+        to_worker,
+        task_manager.get_spawner(),
+        BaseFeeContainer::default(),
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address: Address::from(U160::from(333)),
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: 0,
+            max_delay: Duration::from_secs(60),
+            next_batch_seq: 0,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        },
+    );
+
+    let handle = tokio::spawn(batch_builder.run());
+    let joined = timeout(Duration::from_secs(3), handle)
+        .await
+        .expect("builder terminated at the epoch boundary")
+        .expect("builder task did not panic");
+    assert!(joined.is_ok(), "builder run() returned an error");
+}
+
+/// The builder terminates instead of spinning once the worker seal loop has disconnected.
+#[tokio::test]
+async fn builder_ends_when_the_worker_seal_loop_disconnects() {
+    let genesis = test_genesis();
+    let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
+    let tmp_dir = TempDir::new().unwrap();
+    let task_manager = TaskManager::default();
+    let reth_env = RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
+        .await
+        .unwrap();
+    let txpool = reth_env.init_txn_pool().unwrap();
+    let address = Address::from(U160::from(333));
+    let gas_price = reth_env.get_gas_price().unwrap();
+    let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
+
+    // A pending tx so the builder attempts a send to the (already gone) worker seal loop.
+    let mut tx_factory = TransactionFactory::new();
+    let tx = tx_factory.create_eip1559(
+        chain.clone(),
+        None,
+        gas_price,
+        Some(Address::ZERO),
+        value,
+        Bytes::new(),
+    );
+    let _ = tx_factory.submit_tx_to_pool(tx, txpool.clone()).await;
+
+    let (to_worker, from_batch_builder) = tokio::sync::mpsc::channel(2);
+    // The worker seal loop is gone before the builder starts, so its first send fails.
+    drop(from_batch_builder);
+
+    let (_wm_tx, wm_rx) = watch::channel(None);
+    let batch_builder = BatchBuilder::new(
+        &reth_env,
+        txpool.clone(),
+        to_worker,
+        task_manager.get_spawner(),
+        BaseFeeContainer::default(),
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address,
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: u64::MAX,
+            max_delay: Duration::from_secs(60),
+            next_batch_seq: 0,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        },
+    );
+
+    let handle = tokio::spawn(batch_builder.run());
+    let joined = timeout(Duration::from_secs(3), handle)
+        .await
+        .expect("builder terminated after the worker disconnected")
+        .expect("builder task did not panic");
+    assert!(joined.is_ok(), "builder run() returned an error");
 }
 
 /// A failed `report_own_batch` must not consume the batch seq or mark its txs in-flight.
@@ -637,19 +840,23 @@ async fn test_failed_report_leaves_txs_selectable_and_seq_unconsumed() {
     let txpool = reth_env.init_txn_pool().unwrap();
     let address = Address::from(U160::from(333));
 
+    let (_wm_tx, wm_rx) = watch::channel(None);
     let batch_builder = BatchBuilder::new(
         &reth_env,
         txpool.clone(),
         batch_provider.batches_tx(),
-        address,
-        Duration::from_secs(1),
         task_manager.get_spawner(),
-        0,
         BaseFeeContainer::default(),
-        0,
-        0,
-        u64::MAX,
-        ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        OwnWatermarkReceiver::new(wm_rx),
+        BatchBuilderConfig {
+            address,
+            worker_id: 0,
+            epoch: 0,
+            epoch_boundary: u64::MAX,
+            max_delay: Duration::from_secs(1),
+            next_batch_seq: 0,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        },
     );
 
     let gas_price = reth_env.get_gas_price().unwrap();
@@ -668,7 +875,7 @@ async fn test_failed_report_leaves_txs_selectable_and_seq_unconsumed() {
     }
     assert_eq!(txpool.pool_size().pending, 3);
 
-    let _batch_builder = tokio::spawn(Box::pin(batch_builder));
+    let _batch_builder = tokio::spawn(batch_builder.run());
 
     // wait until the worker has sealed a batch and attempted the report at least once, so the
     // assertions observe post-report state rather than a pre-seal race

--- a/crates/consensus/worker/src/batch-builder/tests/it/main.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/main.rs
@@ -1,8 +1,6 @@
-//! Batch maker EL -> CL integration test
+//! Batch builder integration tests.
 
-// prevent clippy unused dep warning
-
-// it test
 mod build_batches;
+mod pipeline_typestate;
 
 fn main() {}

--- a/crates/consensus/worker/src/batch-builder/tests/it/pipeline_typestate.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/pipeline_typestate.rs
@@ -1,0 +1,89 @@
+//! Typestate and seal-ahead-budget tests for the batch-build pipeline, run directly against the
+//! transition machine with no pool, worker, or async runtime.
+
+use rayls_batch_builder::{
+    pipeline::{calculate_in_flight_depth, BatchPipeline, Clean, EpochPhase, GateRejectionReason},
+    watermark::OwnWatermarkReceiver,
+    BOUNDARY_QUIESCE_WINDOW_SECS, MAX_SEAL_AHEAD,
+};
+
+#[test]
+fn epoch_phase_tracks_distance_to_the_boundary() {
+    let boundary = 1_000;
+    assert_eq!(
+        EpochPhase::evaluate(boundary, boundary - BOUNDARY_QUIESCE_WINDOW_SECS - 1),
+        EpochPhase::Active
+    );
+    assert_eq!(
+        EpochPhase::evaluate(boundary, boundary - BOUNDARY_QUIESCE_WINDOW_SECS),
+        EpochPhase::Quiescing
+    );
+    assert_eq!(EpochPhase::evaluate(boundary, boundary), EpochPhase::Closed);
+    assert_eq!(EpochPhase::evaluate(boundary, boundary + 1), EpochPhase::Closed);
+}
+
+#[test]
+fn max_allowed_ahead_collapses_toward_the_boundary() {
+    assert_eq!(EpochPhase::Active.max_allowed_ahead(), MAX_SEAL_AHEAD);
+    assert_eq!(EpochPhase::Quiescing.max_allowed_ahead(), 1);
+    assert_eq!(EpochPhase::Closed.max_allowed_ahead(), 0);
+}
+
+#[test]
+fn in_flight_depth_is_sealed_minus_executed() {
+    // nothing sealed yet leaves no depth, whatever the watermark reads
+    assert_eq!(calculate_in_flight_depth(None, 5, None), 0);
+    // ten sealed, six executed leaves four outstanding
+    assert_eq!(calculate_in_flight_depth(Some(10), 5, Some(6)), 4);
+    // with no watermark the executed floor falls back to start_seq - 1 (= 4)
+    assert_eq!(calculate_in_flight_depth(Some(10), 5, None), 6);
+    // execution running ahead of the seal cannot drive the depth negative
+    assert_eq!(calculate_in_flight_depth(Some(3), 1, Some(9)), 0);
+}
+
+#[test]
+fn can_start_build_enforces_the_seal_ahead_budget() {
+    let far_boundary = u64::MAX;
+    // highest sealed 10, resume seq 5, canonical tip far from the boundary (Active budget = 4)
+    let accumulating = BatchPipeline::<Clean>::new(Some(10), 5, 0).on_event();
+
+    // executed 6 leaves depth 4, at the budget, so a new build is refused
+    assert_eq!(
+        accumulating.can_start_build(Some(6), far_boundary),
+        Err(GateRejectionReason::BudgetExhausted)
+    );
+    // executed 9 leaves depth 1, under the budget, so a build may start
+    assert_eq!(accumulating.can_start_build(Some(9), far_boundary), Ok(()));
+}
+
+#[test]
+fn can_start_build_refuses_past_the_boundary() {
+    let boundary = 100;
+    // canonical tip at the boundary closes the epoch regardless of budget
+    let accumulating = BatchPipeline::<Clean>::new(None, 1, boundary).on_event();
+    assert_eq!(
+        accumulating.can_start_build(None, boundary),
+        Err(GateRejectionReason::EpochBoundaryReached)
+    );
+}
+
+#[test]
+fn clean_closes_when_the_tip_reaches_the_boundary() {
+    let boundary = 100;
+    let below = BatchPipeline::<Clean>::new(None, 1, boundary - 1);
+    assert!(below.check_boundary(boundary).is_ok(), "a tip below the boundary keeps building");
+
+    let at = BatchPipeline::<Clean>::new(None, 1, boundary);
+    assert!(at.check_boundary(boundary).is_err(), "a tip at the boundary closes the pipeline");
+}
+
+#[test]
+fn resume_seq_prefers_the_executed_watermark() {
+    let (_tx, rx) = tokio::sync::watch::channel(Some(5u64));
+    let reader = OwnWatermarkReceiver::new(rx);
+    assert_eq!(reader.resume_seq(9), 6, "an executed watermark resumes one past it");
+
+    let (_fresh_tx, fresh_rx) = tokio::sync::watch::channel(None);
+    let fresh = OwnWatermarkReceiver::new(fresh_rx);
+    assert_eq!(fresh.resume_seq(9), 9, "a fresh epoch trusts the persisted counter");
+}

--- a/crates/execution/evm/src/txn_pool.rs
+++ b/crates/execution/evm/src/txn_pool.rs
@@ -24,8 +24,8 @@ use reth_transaction_pool::{
     identifier::TransactionId,
     maintain::{maintain_transaction_pool_future, MaintainPoolConfig},
     AddedTransactionOutcome, BestTransactions, CoinbaseTipOrdering, EthPooledTransaction, Pool,
-    PoolSize, PoolTransaction, TransactionEvents, TransactionOrigin, TransactionPool as _,
-    TransactionPoolExt as _, ValidPoolTransaction,
+    PoolSize, PoolTransaction, TransactionEvents, TransactionListenerKind, TransactionOrigin,
+    TransactionPool as _, TransactionPoolExt as _, ValidPoolTransaction,
 };
 use std::{
     path::PathBuf,
@@ -202,6 +202,12 @@ impl WorkerTxPool {
     /// Returns the queued transactions (not yet executable).
     pub fn queued_transactions(&self) -> Vec<Arc<PoolTxn>> {
         self.pool.queued_transactions()
+    }
+
+    /// Subscribes to hashes as transactions enter the pending sub-pool, so the builder wakes
+    /// promptly on new candidates instead of waiting for the next batching-window tick.
+    pub fn pending_transactions_listener(&self) -> tokio::sync::mpsc::Receiver<TxHash> {
+        self.pool.pending_transactions_listener_for(TransactionListenerKind::All)
     }
 
     /// Returns the in-flight tracker shared with this pool's batch builder.

--- a/crates/middleware/orchestrator/src/engine/node.rs
+++ b/crates/middleware/orchestrator/src/engine/node.rs
@@ -46,7 +46,7 @@ impl ExecutionNode {
         engine_done_tx: oneshot::Sender<()>,
         executed_batch_registry: ExecutedBatchRegistry,
     ) -> eyre::Result<()> {
-        let guard = self.internal.read().await;
+        let mut guard = self.internal.write().await;
         guard
             .start_engine(
                 rx_output,

--- a/crates/middleware/orchestrator/src/engine/node_builder.rs
+++ b/crates/middleware/orchestrator/src/engine/node_builder.rs
@@ -42,6 +42,7 @@ impl ExecutionNodeBuilder {
             rayls_infrastructure_config: self.rayls_infrastructure_config,
             workers: Vec::default(),
             in_flight: rayls_execution_evm::in_flight::InFlightTracker::new(),
+            own_executed_sequence: None,
         })
     }
 }

--- a/crates/middleware/orchestrator/src/engine/node_inner.rs
+++ b/crates/middleware/orchestrator/src/engine/node_inner.rs
@@ -5,7 +5,7 @@
 use crate::types::ExecutionError;
 use eyre::OptionExt;
 use jsonrpsee::http_client::HttpClient;
-use rayls_batch_builder::BatchBuilder;
+use rayls_batch_builder::{BatchBuilder, BatchBuilderConfig, OwnWatermarkReceiver};
 use rayls_batch_validator::BatchValidator;
 use rayls_consensus_worker::WorkerNetworkHandle;
 use rayls_execution_evm::{
@@ -52,6 +52,9 @@ pub(super) struct ExecutionNodeInner {
     /// epoch's executor engine so execution-dropped txs are released for re-sealing from the
     /// first epoch after boot.
     pub(super) in_flight: InFlightTracker,
+    /// This authority's executed batch-sequence watch, captured when the engine starts and handed
+    /// to each batch builder so it resumes and paces sealing off its own execution progress.
+    pub(super) own_executed_sequence: Option<watch::Receiver<Option<u64>>>,
 }
 
 impl ExecutionNodeInner {
@@ -60,7 +63,7 @@ impl ExecutionNodeInner {
     /// The method is consumed by [PrimaryNodeInner::start].
     /// All tasks are spawned with the [ExecutionNodeInner]'s [TaskManager].
     pub(super) async fn start_engine<DB: Database>(
-        &self,
+        &mut self,
         rx_output: mpsc::Receiver<(CameFrom, ConsensusOutput)>,
         rx_shutdown: Noticer,
         gas_accumulator: GasAccumulator,
@@ -73,6 +76,10 @@ impl ExecutionNodeInner {
         executed_batch_registry: ExecutedBatchRegistry,
     ) -> eyre::Result<()> {
         let parent_header = self.reth_env.lookup_head()?;
+
+        // Capture this authority's executed-sequence watch before the ordering layer moves into the
+        // engine, so each batch builder started this epoch can resume and pace off execution.
+        self.own_executed_sequence = Some(batch_ordering.executed_own_watermark());
 
         // Keep a handle to the idle signal so we can flip it true when the engine task EXITS.
         // The engine's own poll() publishes idle only on the `Poll::Pending` path, not on
@@ -162,25 +169,34 @@ impl ExecutionNodeInner {
             .ok_or_eyre("worker components missing for {worker_id}")?
             .pool();
 
+        let own_executed_sequence = self
+            .own_executed_sequence
+            .clone()
+            .expect("own_executed_sequence must be initialized by start_engine before the builder");
+        let own_watermark_receiver = OwnWatermarkReceiver::new(own_executed_sequence);
+
         // create the batch builder for this epoch
         let batch_builder = BatchBuilder::new(
             &self.reth_env,
             transaction_pool.clone(),
             block_provider_sender,
-            self.address,
-            self.rayls_infrastructure_config.parameters.max_batch_delay,
             epoch_task_spawner.clone(),
-            worker_id,
             base_fee,
-            epoch,
-            initial_batch_seq,
-            epoch_boundary,
-            self.rayls_infrastructure_config.parameters.gas_limit,
+            own_watermark_receiver,
+            BatchBuilderConfig {
+                address: self.address,
+                worker_id,
+                epoch,
+                epoch_boundary,
+                max_delay: self.rayls_infrastructure_config.parameters.max_batch_delay,
+                next_batch_seq: initial_batch_seq,
+                gas_limit: self.rayls_infrastructure_config.parameters.gas_limit,
+            },
         );
 
         // spawn block builder task
         epoch_task_spawner.spawn_critical_task("batch builder", async move {
-            let res = batch_builder.await;
+            let res = batch_builder.run().await;
             info!(target: "rayls::execution", ?res, "batch builder task exited");
         });
 

--- a/crates/middleware/orchestrator/src/epoch_manager/core.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/core.rs
@@ -143,7 +143,9 @@ where
         let EpochState { epoch, .. } = engine.epoch_state_from_canonical_tip().await?;
 
         // load persisted BatchOrdering or reconstruct from chain history when missing
-        let batch_ordering = BatchOrdering::from_history(self.consensus_db.clone(), epoch);
+        let execution_address = self.builder.rayls_infrastructure_config.execution_address();
+        let batch_ordering =
+            BatchOrdering::from_history(self.consensus_db.clone(), epoch, execution_address);
 
         // The engine's dedup anchor MUST be the EL execution anchor (the consensus header the
         // highest executed EVM block commits to), NOT the consensus-chain tip. The anchor marks the

--- a/crates/middleware/processor/src/batch/ordering.rs
+++ b/crates/middleware/processor/src/batch/ordering.rs
@@ -21,6 +21,28 @@ use tracing::{debug, info, warn};
 struct BatchOrderingInner<DB: BatchOrderingStore> {
     batch_ordering_state: Mutex<BatchOrderingState>,
     batch_ordering_store: DB,
+    /// This node's execution address, the one authority whose sequence the watch tracks.
+    authority: Address,
+    /// The highest accepted sequence for `authority`; the batch builder paces on it.
+    executed_own_watermark: tokio::sync::watch::Sender<Option<u64>>,
+}
+
+impl<DB: BatchOrderingStore> BatchOrderingInner<DB> {
+    /// Advances the own-authority accepted-sequence watch, ignoring other authorities and
+    /// regressions.
+    fn update_executed_watermark(&self, authority: Address, watermark: Option<u64>) {
+        if authority != self.authority {
+            return;
+        }
+
+        self.executed_own_watermark.send_if_modified(|p| {
+            let updated = watermark > *p;
+            if updated {
+                *p = watermark
+            }
+            updated
+        });
+    }
 }
 
 /// Per-authority batch ordering with parking and epoch-reset.
@@ -30,19 +52,31 @@ pub struct BatchOrdering<DB: BatchOrderingStore> {
 }
 
 impl<DB: Database> BatchOrdering<DB> {
-    /// Create an ordering over `store` seeded with `batch_ordering_state`.
-    pub fn new(store: DB, batch_ordering_state: BatchOrderingState) -> Self {
+    /// Creates the ordering over `store`, seeding the own-authority watch for `address` from the
+    /// given state.
+    pub fn new(store: DB, batch_ordering_state: BatchOrderingState, address: &Address) -> Self {
+        let last_executed_watermark =
+            batch_ordering_state.authorities.get(address).and_then(|s| s.last_executed_seq);
+
         Self {
             inner: Arc::new(BatchOrderingInner {
                 batch_ordering_state: Mutex::new(batch_ordering_state),
                 batch_ordering_store: store,
+                authority: *address,
+                executed_own_watermark: tokio::sync::watch::Sender::new(last_executed_watermark),
             }),
         }
     }
 
-    /// Create an ordering over `store` with no recorded authorities.
+    /// Creates the ordering with no prior state and a zero authority address.
     pub fn new_with_empty_state(store: DB) -> Self {
-        Self::new(store, Default::default())
+        Self::new(store, Default::default(), &Default::default())
+    }
+
+    /// Subscribes to this authority's highest accepted batch sequence, the pacing signal the
+    /// builder uses to resume after a restart and to bound how far ahead of execution it seals.
+    pub fn executed_own_watermark(&self) -> tokio::sync::watch::Receiver<Option<u64>> {
+        self.inner.executed_own_watermark.subscribe()
     }
 
     /// Try to accept a batch for the given authority.
@@ -91,6 +125,7 @@ impl<DB: Database> BatchOrdering<DB> {
                         "parking limit reached, executing batch out of order"
                     );
                     auth.last_executed_seq = Some(batch_seq);
+                    self.inner.update_executed_watermark(authority, Some(batch_seq));
                     // Drop the parked entries the forced jump abandoned: drain_consecutive only
                     // looks at last_executed_seq + 1, so they can never drain, and leaving them
                     // pins parked.len() at the limit (every later gap force-executes forever).
@@ -120,6 +155,7 @@ impl<DB: Database> BatchOrdering<DB> {
         }
 
         auth.last_executed_seq = Some(batch_seq);
+        self.inner.update_executed_watermark(authority, Some(batch_seq));
         AcceptResult::InOrder(prepared)
     }
 
@@ -129,7 +165,7 @@ impl<DB: Database> BatchOrdering<DB> {
     /// and the next epoch's first output leaves the closing epoch's parked batches undrained (so
     /// `persisted.epoch` lags by one), and reseeding would drop them and fork the chain short.
     /// State further behind is stale and reseeded.
-    pub fn from_history(store: DB, current_epoch: Epoch) -> Self {
+    pub fn from_history(store: DB, current_epoch: Epoch, address: &Address) -> Self {
         let mut state = store
             .read_batch_ordering_state()
             .expect("BatchOrdering: initial DB read failed")
@@ -149,7 +185,7 @@ impl<DB: Database> BatchOrdering<DB> {
             state.authorities = recovered;
             state.epoch = current_epoch;
         }
-        Self::new(store, state)
+        Self::new(store, state, address)
     }
 
     /// Drains consecutive parked batches starting from the next expected seq into `collected`.
@@ -165,7 +201,7 @@ impl<DB: Database> BatchOrdering<DB> {
         check_dedup: bool,
     ) {
         loop {
-            let parked = {
+            let (next_seq, parked) = {
                 let mut state = self.inner.batch_ordering_state.lock();
                 let Some(auth) = state.authorities.get_mut(&authority) else {
                     break;
@@ -175,11 +211,15 @@ impl<DB: Database> BatchOrdering<DB> {
                 match auth.parked.remove(&next_seq) {
                     Some(parked) => {
                         auth.last_executed_seq = Some(next_seq);
-                        parked
+                        (next_seq, parked)
                     }
                     None => break,
                 }
             };
+
+            // Draining a parked own batch advances execution just as an in-order accept does, so
+            // the builder's pacing watch must track it too, or the seal-ahead budget never reopens.
+            self.inner.update_executed_watermark(authority, Some(next_seq));
 
             if check_dedup {
                 if !executed_batch_registry.try_register(parked.batch_digest, parked.output_digest)
@@ -442,7 +482,7 @@ mod tests {
         let auth = Address::from([7u8; 20]);
         write_consensus_block(&store, 1, 3, auth, 100);
 
-        let ord = BatchOrdering::from_history(store, 3);
+        let ord = BatchOrdering::from_history(store, 3, &auth);
         let state = ord.inner.batch_ordering_state.lock();
         assert_eq!(state.epoch, 3);
         assert_eq!(state.authorities.get(&auth).unwrap().last_executed_seq, Some(100));
@@ -463,7 +503,7 @@ mod tests {
 
         write_consensus_block(&store, 1, 3, auth, 999);
 
-        let ord = BatchOrdering::from_history(store, 3);
+        let ord = BatchOrdering::from_history(store, 3, &auth);
         let state = ord.inner.batch_ordering_state.lock();
         assert_eq!(state.authorities.get(&auth).unwrap().last_executed_seq, Some(50));
     }
@@ -510,7 +550,7 @@ mod tests {
         // A history reseed against the post-boundary epoch would rebuild empty parked.
         write_consensus_block(&store, 1, 88, auth, 1441);
 
-        let ord = BatchOrdering::from_history(store, 88);
+        let ord = BatchOrdering::from_history(store, 88, &auth);
 
         {
             let state = ord.inner.batch_ordering_state.lock();
@@ -522,6 +562,58 @@ mod tests {
         // the boundary drain on the first new-epoch output flushes them as their own blocks
         let drained = ord.drain_epoch(88);
         assert_eq!(drained.len(), 5, "parked batches drain into the new epoch");
+    }
+
+    #[test]
+    fn executed_own_watermark_tracks_own_authority_monotonically() {
+        // The builder resumes and paces sealing off this watch, so it must reflect only our own
+        // accepted sequence, never regress, and ignore other authorities' progress.
+        let store = MemDatabase::default();
+        let me = Address::from([1u8; 20]);
+        let other = Address::from([2u8; 20]);
+        let ord = BatchOrdering::new(store, BatchOrderingState::default(), &me);
+        let mut watermark = ord.executed_own_watermark();
+
+        assert_eq!(*watermark.borrow_and_update(), None, "no batch accepted yet");
+
+        assert!(matches!(ord.try_accept(me, 1, make_parked(me, 1), false), AcceptResult::InOrder(_)));
+        assert_eq!(*watermark.borrow_and_update(), Some(1), "own in-order accept advances it");
+
+        assert!(matches!(
+            ord.try_accept(other, 9, make_parked(other, 9), false),
+            AcceptResult::InOrder(_)
+        ));
+        assert_eq!(*watermark.borrow(), Some(1), "a foreign authority must not advance our mark");
+
+        assert!(matches!(ord.try_accept(me, 2, make_parked(me, 2), false), AcceptResult::InOrder(_)));
+        assert_eq!(*watermark.borrow_and_update(), Some(2), "next own seq advances it");
+
+        assert!(matches!(ord.try_accept(me, 1, make_parked(me, 1), false), AcceptResult::InOrder(_)));
+        assert_eq!(*watermark.borrow(), Some(2), "a stale re-accept must not regress the mark");
+    }
+
+    #[test]
+    fn executed_own_watermark_advances_when_parked_own_batches_drain() {
+        // The builder paces on this watch, so a parked-then-drained own batch must advance it just
+        // like an in-order accept, or the seal-ahead budget stays exhausted and the builder stalls.
+        let store = MemDatabase::default();
+        let me = Address::from([1u8; 20]);
+        let ord = BatchOrdering::new(store, BatchOrderingState::default(), &me);
+        let mut watermark = ord.executed_own_watermark();
+
+        assert!(matches!(ord.try_accept(me, 1, make_parked(me, 1), false), AcceptResult::InOrder(_)));
+        assert_eq!(*watermark.borrow_and_update(), Some(1));
+
+        // seq 3 arrives before seq 2, so it parks and the watch holds
+        assert!(matches!(ord.try_accept(me, 3, make_parked(me, 3), false), AcceptResult::Parked));
+        assert_eq!(*watermark.borrow(), Some(1));
+
+        // seq 2 closes the gap; draining then flushes the parked seq 3 for execution
+        assert!(matches!(ord.try_accept(me, 2, make_parked(me, 2), false), AcceptResult::InOrder(_)));
+        let mut collected = Vec::new();
+        ord.drain_consecutive(me, &mut collected, &ExecutedBatchRegistry::default(), None, false);
+        assert_eq!(collected.len(), 1, "the parked batch drains for execution");
+        assert_eq!(*watermark.borrow(), Some(3), "the watch tracks the drained own batch");
     }
 
     #[test]

--- a/crates/middleware/processor/src/batch/ordering.rs
+++ b/crates/middleware/processor/src/batch/ordering.rs
@@ -576,7 +576,10 @@ mod tests {
 
         assert_eq!(*watermark.borrow_and_update(), None, "no batch accepted yet");
 
-        assert!(matches!(ord.try_accept(me, 1, make_parked(me, 1), false), AcceptResult::InOrder(_)));
+        assert!(matches!(
+            ord.try_accept(me, 1, make_parked(me, 1), false),
+            AcceptResult::InOrder(_)
+        ));
         assert_eq!(*watermark.borrow_and_update(), Some(1), "own in-order accept advances it");
 
         assert!(matches!(
@@ -585,10 +588,16 @@ mod tests {
         ));
         assert_eq!(*watermark.borrow(), Some(1), "a foreign authority must not advance our mark");
 
-        assert!(matches!(ord.try_accept(me, 2, make_parked(me, 2), false), AcceptResult::InOrder(_)));
+        assert!(matches!(
+            ord.try_accept(me, 2, make_parked(me, 2), false),
+            AcceptResult::InOrder(_)
+        ));
         assert_eq!(*watermark.borrow_and_update(), Some(2), "next own seq advances it");
 
-        assert!(matches!(ord.try_accept(me, 1, make_parked(me, 1), false), AcceptResult::InOrder(_)));
+        assert!(matches!(
+            ord.try_accept(me, 1, make_parked(me, 1), false),
+            AcceptResult::InOrder(_)
+        ));
         assert_eq!(*watermark.borrow(), Some(2), "a stale re-accept must not regress the mark");
     }
 
@@ -601,7 +610,10 @@ mod tests {
         let ord = BatchOrdering::new(store, BatchOrderingState::default(), &me);
         let mut watermark = ord.executed_own_watermark();
 
-        assert!(matches!(ord.try_accept(me, 1, make_parked(me, 1), false), AcceptResult::InOrder(_)));
+        assert!(matches!(
+            ord.try_accept(me, 1, make_parked(me, 1), false),
+            AcceptResult::InOrder(_)
+        ));
         assert_eq!(*watermark.borrow_and_update(), Some(1));
 
         // seq 3 arrives before seq 2, so it parks and the watch holds
@@ -609,7 +621,10 @@ mod tests {
         assert_eq!(*watermark.borrow(), Some(1));
 
         // seq 2 closes the gap; draining then flushes the parked seq 3 for execution
-        assert!(matches!(ord.try_accept(me, 2, make_parked(me, 2), false), AcceptResult::InOrder(_)));
+        assert!(matches!(
+            ord.try_accept(me, 2, make_parked(me, 2), false),
+            AcceptResult::InOrder(_)
+        ));
         let mut collected = Vec::new();
         ord.drain_consecutive(me, &mut collected, &ExecutedBatchRegistry::default(), None, false);
         assert_eq!(collected.len(), 1, "the parked batch drains for execution");

--- a/crates/middleware/processor/tests/it/batch_ordering_restart.rs
+++ b/crates/middleware/processor/tests/it/batch_ordering_restart.rs
@@ -275,7 +275,7 @@ impl BatchOrderingHarness {
         let parent_header = self.parent_for_next_session(&reth_env);
 
         let store = self.ordering_store.as_ref().expect("ordering_store open").clone();
-        let batch_ordering = BatchOrdering::from_history(store, 0);
+        let batch_ordering = BatchOrdering::from_history(store, 0, &Default::default());
 
         let capacity = outputs.len().max(1);
         let (to_engine, from_consensus) = mpsc::channel(capacity);

--- a/crates/middleware/processor/tests/it/history_recovery.rs
+++ b/crates/middleware/processor/tests/it/history_recovery.rs
@@ -207,7 +207,7 @@ async fn recovery_seeds_state_and_enforces_ordering() {
     fixture.append_block(EPOCH, vec![(AUTH_A, vec![2])]);
     fixture.append_block(EPOCH, vec![(AUTH_A, vec![3]), (AUTH_B, vec![2])]);
 
-    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH);
+    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH, &AUTH_A);
 
     // in-order accept for AUTH_A at seq=4 (last=3 -> next=4)
     let r = ord.try_accept(AUTH_A, 4, make_prepared(AUTH_A, 4), false);
@@ -249,7 +249,7 @@ async fn recovery_filters_prior_epoch_blocks() {
     fixture.append_block(EPOCH - 1, vec![(AUTH_A, vec![99])]); // prior epoch - ignored
     fixture.append_block(EPOCH, vec![(AUTH_A, vec![10])]);
 
-    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH);
+    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH, &AUTH_A);
 
     // last for AUTH_A should be 10 (from current epoch), not 99 (prior)
     let r = ord.try_accept(AUTH_A, 11, make_prepared(AUTH_A, 11), false);
@@ -279,7 +279,7 @@ async fn recovery_filters_prior_epoch_blocks() {
 async fn recovery_empty_history_inaugural_first_batch() {
     let fixture = ConsensusHistoryFixture::new();
 
-    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH);
+    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH, &AUTH_A);
 
     // no prior state for AUTH_A; first batch at any seq is the inaugural one
     let r = ord.try_accept(AUTH_A, 5, make_prepared(AUTH_A, 5), false);
@@ -309,7 +309,7 @@ async fn recovery_parks_gap_batch_after_state_loss() {
     }
 
     // recovery seeds last_executed_seq[AUTH_A] = 5
-    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH);
+    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH, &AUTH_A);
 
     // inject the gap batch: seq jumps from None/5 to N+3=8
     let r = ord.try_accept(AUTH_A, 8, make_prepared(AUTH_A, 8), false);
@@ -353,7 +353,7 @@ async fn recovery_at_full_epoch_scale_86400_blocks() {
     }
 
     let recover_start = Instant::now();
-    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH);
+    let ord = BatchOrdering::from_history(fixture.db().clone(), EPOCH, &AUTH_A);
     let recover_elapsed = recover_start.elapsed();
     println!(
         "recovery: walked ~{} blocks in {:.3}s ({:.0} blocks/sec)",


### PR DESCRIPTION
## Summary

- `BatchOrdering` publishes this authority's accepted batch sequence as a watch, seeded from the persisted `last_executed_seq` and advanced on in-order accept, overflow-forced accept, and parked-batch drain. It marks acceptance into execution order, not block finalization.
- Replace the poll-based `BatchBuilder` future with an async run loop over a `BatchPipeline` typestate, so an illegal build/seal ordering cannot be represented. The builder seals up to `MAX_SEAL_AHEAD` batches ahead of its own watermark and then stalls until execution advances, keeping the in-flight prefix inside the per-authority parking budget; the budget collapses to one batch inside the boundary quiesce window and the builder ends once the canonical tip reaches the epoch boundary.
- On restart the sequence resumes from the execution watermark rather than from the persisted counter alone.

Stack 5/9 of the txpool in-flight tracker and observer-forwarder series.

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [x] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. Node-local pacing only; no wire, storage, or fork changes. A fast proposer now seals at most `MAX_SEAL_AHEAD` batches past its own executed sequence.

## Test plan

- [x] `tests/it/pipeline_typestate.rs` covers the phase transitions and the seal-ahead / quiesce / closed budget.
- [x] `tests/it/build_batches.rs` runs the builder through the new `run()` loop end to end.
- [x] `make check` on the stack tip; CI on this branch.

