### PR TITLE
refactor: extract the engine-update loop with an injectable interval

### DIFF
--- a/crates/middleware/orchestrator/src/epoch_manager/engine.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/engine.rs
@@ -1,4 +1,5 @@
 use crate::{engine::ExecutionNode, epoch_manager::types::EpochManager};
+use rayls_consensus_primary::ConsensusBus;
 use rayls_execution_evm::{reth_env::RethEnv, CanonStateNotificationStream};
 use rayls_infrastructure_config::RaylsDirs;
 use rayls_infrastructure_types::{
@@ -13,7 +14,7 @@ where
     P: RaylsDirs + Clone + 'static,
     DB: ReDatabase,
 {
-    /// Builds the execution node for this epoch manager.
+    /// Create the reth environment and the [`ExecutionNode`] that wraps it.
     pub(super) async fn create_engine(
         &self,
         engine_task_manager: &TaskManager,
@@ -34,50 +35,76 @@ where
         Ok(engine)
     }
 
-    /// Spawns the node-scoped task that records each executed block on
-    /// `ConsensusBus::recently_executed_blocks` and runs the periodic gap check and in-flight
-    /// mark sweep. Node-scoped because the engine keeps executing queued outputs after an epoch
-    /// shuts down.
+    /// Spawn the node-scoped [`engine_update_loop`] with the production gap-check cadence.
+    ///
+    /// The task is node-scoped rather than epoch-scoped because the engine keeps executing queued
+    /// outputs after an epoch shuts down, and those blocks must still reach
+    /// `ConsensusBus::recently_executed_blocks`.
     pub(super) fn spawn_engine_update_task(
         &self,
         shutdown_rx: Noticer,
-        mut engine_state: CanonStateNotificationStream,
+        engine_state: CanonStateNotificationStream,
         engine: ExecutionNode,
         task_manager: &TaskManager,
     ) {
         let consensus_bus = self.consensus_bus.clone();
-        task_manager.spawn_critical_task("latest execution block", async move {
-            let mut gap_check_interval = tokio::time::interval(Duration::from_secs(30));
-            gap_check_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tokio::select!(
-                    _ = &shutdown_rx => {
-                        info!(target: "engine", "received node shutdown, stopping recently-executed blocks updater");
-                        break;
-                    }
-                    latest = engine_state.next() => {
-                        if let Some(latest) = latest {
-                            consensus_bus.recently_executed_blocks().send_modify(|blocks| blocks.push_latest(latest.tip().clone_sealed_header()));
-                        } else {
-                            error!(target: "engine", "engine state stream ended, node will exit");
-                            break;
-                        }
-                    }
-                    _ = gap_check_interval.tick() => {
-                        consensus_bus.batch_tracker().check_gaps();
-                        // Pools are fetched per tick: workers are created during the first epoch,
-                        // after this node-scoped task starts.
-                        let anchor = consensus_bus.executed_anchor().borrow().number;
-                        for pool in engine.get_all_worker_transaction_pools().await {
-                            // Seal marks age out via the TTL sweep. Forward marks have no sweep,
-                            // so the O(pending) membership reconcile runs here too: its only other
-                            // driver is the canonical-stream task, which a burst can starve.
-                            pool.in_flight().sweep_due(anchor);
-                            pool.reconcile_in_flight();
-                        }
-                    }
-                )
+        task_manager.spawn_critical_task(
+            "latest execution block",
+            engine_update_loop(
+                shutdown_rx,
+                engine_state,
+                consensus_bus,
+                engine,
+                Duration::from_secs(30),
+            ),
+        );
+    }
+}
+
+/// Run the engine-update loop until node shutdown or the end of the canonical-state stream.
+///
+/// Each canonical tip is pushed into `ConsensusBus::recently_executed_blocks`; each
+/// `gap_check_interval` tick checks batch-tracker gaps and sweeps every worker pool's in-flight
+/// marks. The interval is a parameter so a test can drive one maintenance tick without the
+/// production cadence. The sweep policy is not: each tracker applies the policy of the role the
+/// current epoch armed it for, so this node-scoped loop cannot apply a stale or wrong-role policy
+/// (unarmed and forwarding-armed trackers sweep nothing).
+pub(crate) async fn engine_update_loop(
+    shutdown_rx: Noticer,
+    mut engine_state: CanonStateNotificationStream,
+    consensus_bus: ConsensusBus,
+    engine: ExecutionNode,
+    gap_check_interval: Duration,
+) {
+    let mut gap_check_interval = tokio::time::interval(gap_check_interval);
+    gap_check_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select!(
+            _ = &shutdown_rx => {
+                info!(target: "engine", "received node shutdown, stopping recently-executed blocks updater");
+                break;
             }
-        });
+            latest = engine_state.next() => {
+                if let Some(latest) = latest {
+                    consensus_bus.recently_executed_blocks().send_modify(|blocks| blocks.push_latest(latest.tip().clone_sealed_header()));
+                } else {
+                    error!(target: "engine", "engine state stream ended, node will exit");
+                    break;
+                }
+            }
+            _ = gap_check_interval.tick() => {
+                consensus_bus.batch_tracker().check_gaps();
+                // pools are fetched per tick, not captured at spawn: worker components are
+                // created during the first epoch, after this node-scoped task starts
+                let anchor = consensus_bus.executed_anchor().borrow().number;
+                for pool in engine.get_all_worker_transaction_pools().await {
+                    // sealing marks age out via the sweep; forwarding marks have no sweep, so drive
+                    // the O(pending) membership reconcile here too: its only other trigger is
+                    // the canonical-stream task, which a burst can starve. both are idempotent
+                    pool.in_flight().sweep_due(anchor);
+                    pool.reconcile_in_flight();
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Move the node-scoped engine-update task body into `engine_update_loop`, leaving `spawn_engine_update_task` a thin spawner, and take the gap-check interval as a parameter (still 30s in production) so a node harness can drive one maintenance tick without the cadence.

Pure extraction: the recently-executed push, gap check, and per-pool sweep/reconcile are unchanged. Stack 7/9 of the txpool in-flight tracker and observer-forwarder series.

## Surface areas touched

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [x] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None.

## Test plan

- [x] Behavior-preserving refactor; `make check` on the stack tip and CI on this branch.

