### PR TITLE
perf: hot-path allocation, hashing, and backpressure optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7792,6 +7792,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "backoff",
+ "bcs",
  "consensus-metrics",
  "eyre",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7849,7 +7849,6 @@ version = "1.3.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "consensus-metrics",
  "eyre",
  "futures",
  "indexmap 2.13.0",

--- a/bin/rayls-replay/src/replay.rs
+++ b/bin/rayls-replay/src/replay.rs
@@ -6,7 +6,7 @@ use crate::{
     plan::PlanBlock,
 };
 use rayls_execution_evm::{reth_env::RethEnv, ExecutedBlock};
-use rayls_infrastructure_types::{payload::RLPayload, SealedHeader};
+use rayls_infrastructure_types::{payload::RLPayload, Bytes, SealedHeader};
 use std::collections::BTreeMap;
 use tracing::warn;
 
@@ -27,7 +27,7 @@ pub async fn execute_output_group(
     let mut diverged_count = 0u64;
 
     for plan in plans {
-        let (beneficiary, worker_id, transactions): (_, u16, &[Vec<u8>]) =
+        let (beneficiary, worker_id, transactions): (_, u16, &[Bytes]) =
             if let Some(batch) = plan.batch.as_ref() {
                 (batch.beneficiary, batch.worker_id, batch.transactions.as_slice())
             } else {

--- a/crates/consensus/network/src/consensus/constructor.rs
+++ b/crates/consensus/network/src/consensus/constructor.rs
@@ -179,6 +179,7 @@ where
             inbound_requests: Default::default(),
             kad_record_queries: Default::default(),
             kad_expecting_to_fail_query_ids: Default::default(),
+            kad_put_budget: Default::default(),
             config,
             connected_peers: VecDeque::new(),
             pending_px_disconnects,

--- a/crates/consensus/network/src/consensus/kad.rs
+++ b/crates/consensus/network/src/consensus/kad.rs
@@ -16,6 +16,17 @@ use libp2p::{
 use rayls_infrastructure_types::{encode, now, try_decode, BlsPublicKey, Database, RaylsSender};
 use tracing::{debug, error, info, trace, warn};
 
+/// Fixed-window length for the per-peer inbound PutRecord budget.
+const KAD_PUT_BUDGET_WINDOW_SECS: u64 = 60;
+/// Maximum inbound PutRecord requests accepted per peer per window.
+const KAD_PUT_BUDGET_MAX: u32 = 10;
+
+/// Returns the per-peer PutRecord budget so a test can exhaust it.
+#[cfg(test)]
+pub(crate) fn kad_put_budget_max() -> u32 {
+    KAD_PUT_BUDGET_MAX
+}
+
 impl<Req, Res, DB, Events> ConsensusNetwork<Req, Res, DB, Events>
 where
     Req: RLMessage,
@@ -253,9 +264,14 @@ where
             return;
         };
 
-        if let Err(reason) =
-            self.verify_kad_put_authenticity(&key, &source, &record, &decoded_record)
-        {
+        // Budget gate before any per-record work. Not a penalty: an honest node can burst
+        // republishes across an epoch change, so over-budget puts are dropped, never charged.
+        if !self.within_kad_put_budget(&source) {
+            trace!(target: "network-kad", ?source, "kad put budget exceeded - dropping put request");
+            return;
+        }
+
+        if let Err(reason) = self.check_kad_put_admissibility(&source, &record, &decoded_record) {
             if matches!(
                 reason,
                 RecordInvalidReason::PublisherBanned
@@ -271,16 +287,39 @@ where
             return;
         }
 
-        // OldRecord branch: record already lives in our store from a prior PUT,
-        // so refreshing the in-memory BLS mapping (wiped on restart) is safe.
+        // Dedup before the signature verify: a replayed or stale record costs a store lookup
+        // instead of a BLS verification on the swarm event loop (a validly signed replay earns
+        // no penalty, so verifying first is a free CPU-amplification vector).
+        //
+        // A duplicate already lives in our store from a prior put, so refreshing the in-memory
+        // BLS mapping (wiped on restart) is safe, but only from the stored record's info, which
+        // passed the signature check when it was admitted; the incoming duplicate is unverified.
         if !self.is_newer_record(&record.key, &decoded_record) {
             trace!(target: "network-kad", ?source, "duplicate record, refreshing known_peers");
-            self.swarm.behaviour_mut().peer_manager.add_known_peer(key, decoded_record.info);
+            let stored_info = self
+                .swarm
+                .behaviour_mut()
+                .kademlia
+                .store_mut()
+                .get(&record.key)
+                .and_then(|existing| try_decode::<NodeRecord>(&existing.value).ok())
+                .map(|stored| stored.info);
+            if let Some(info) = stored_info {
+                self.swarm.behaviour_mut().peer_manager.add_known_peer(key, info);
+            }
+            return;
+        }
+
+        // Signature verify only for fresh records that passed every cheap gate.
+        if let Err(e) = self.peer_record_valid_decoded(&key, record.publisher, &decoded_record) {
+            let reason = RecordInvalidReason::InvalidPeerRecord(e);
+            self.apply_invalid_kad_request_penalty(&source, record.publisher, &reason);
+            error!(target: "network-kad", ?source, ?reason, "failed to process kad put request");
             return;
         }
 
         // Fresh record: store it first. add_known_peer only on success so a full
-        // store cannot be used as a side-channel to populate known_peers (PR #280).
+        // store cannot be used as a side-channel to populate known_peers.
         let publisher = record.publisher;
         if let Err(err) = self.swarm.behaviour_mut().kademlia.store_mut().put(record) {
             self.handle_kad_store_error(&source, publisher, err);
@@ -308,9 +347,10 @@ where
         }
     }
 
-    fn verify_kad_put_authenticity(
+    /// Reject a put from or about a banned peer, without a publisher, or dated too far in the
+    /// future, all of which are decided without touching the signature.
+    fn check_kad_put_admissibility(
         &mut self,
-        key: &BlsPublicKey,
         source: &PeerId,
         record: &kad::Record,
         decoded_record: &NodeRecord,
@@ -329,14 +369,29 @@ where
             return Err(RecordInvalidReason::TimestampTooFarInFuture);
         }
 
-        // verify record signature and ensure publisher matches record's network
-        self.peer_record_valid_decoded(key, record.publisher, decoded_record)
-            .map_err(RecordInvalidReason::InvalidPeerRecord)
+        Ok(())
+    }
+
+    /// Count an inbound PutRecord against `source`'s fixed window; `false` when over budget.
+    fn within_kad_put_budget(&mut self, source: &PeerId) -> bool {
+        let now = now();
+        // Drop stale windows so the map tracks recent senders, not every peer ever seen.
+        if self.kad_put_budget.len() > 1024 {
+            self.kad_put_budget
+                .retain(|_, (start, _)| now.saturating_sub(*start) <= KAD_PUT_BUDGET_WINDOW_SECS);
+        }
+        let (window_start, count) = self.kad_put_budget.entry(*source).or_insert((now, 0));
+        if now.saturating_sub(*window_start) > KAD_PUT_BUDGET_WINDOW_SECS {
+            *window_start = now;
+            *count = 0;
+        }
+        *count += 1;
+        *count <= KAD_PUT_BUDGET_MAX
     }
 
     /// Handle a store error from `put()`, charging the peer at fault, if any.
     ///
-    /// Runs after `verify_kad_put_authenticity`, so `publisher` is authenticated: an oversize
+    /// Runs after the signature verify, so `publisher` is authenticated: an oversize
     /// value charges only its author, never an honest relayer, matching
     /// [`kad_record_fault_penalty`]. A full store is a local capacity condition, so the deliverer
     /// is charged only `Penalty::Mild`.

--- a/crates/consensus/network/src/consensus/mod.rs
+++ b/crates/consensus/network/src/consensus/mod.rs
@@ -30,7 +30,7 @@ mod command;
 mod constructor;
 mod debug;
 mod gossip;
-mod kad;
+pub(crate) mod kad;
 mod maintenance;
 mod peer_events;
 mod reqres;
@@ -91,18 +91,26 @@ where
     /// The collection of kademlia record requests.
     ///
     /// When the application layer makes a request, the swarm stores the kad::QueryId and the
-    /// the bls key associated with the desired authority's [NodeRecord]. The query runs until
+    /// bls key associated with the desired authority's [NodeRecord]. The query runs until
     /// the last step. During this time, results are tracked and compared to one another to
     /// ensure the latest valid record is used for the peer's info.
     kad_record_queries: HashMap<QueryId, KadQuery>,
-    /// Kad queries that are expected to fail because of having 0 peers
+    /// Kad queries that are expected to fail because of having 0 peers.
     kad_expecting_to_fail_query_ids: HashSet<QueryId>,
+    /// Fixed-window count of inbound kad PutRecord requests per peer, as `(window start in
+    /// seconds, puts seen)`.
+    ///
+    /// Every put reaching the verify path costs a BLS verification on the swarm event loop and a
+    /// validly signed replay earns no penalty, so without a budget one peer can convert puts into
+    /// event-loop CPU at will. Honest nodes republish their record on the order of minutes, so the
+    /// budget only bites floods.
+    pub(super) kad_put_budget: HashMap<PeerId, (u64, u32)>,
     /// The configurables for the libp2p consensus network implementation.
     config: LibP2pConfig,
     /// Track peers we have a connection with.
     ///
-    /// This explicitly tracked and is a VecDeque so we can use to round robin requests without an
-    /// explicit peer.
+    /// Tracked explicitly as a VecDeque so requests can round-robin over peers when the caller
+    /// names none.
     connected_peers: VecDeque<PeerId>,
     /// Key manager, provide the BLS public key and sign peer records published to kademlia.
     key_config: KeyConfig,
@@ -114,7 +122,7 @@ where
     node_record: NodeRecord,
     /// Last time cleanup was performed for time-based cleanup.
     last_cleanup: Instant,
-    ///Network metrics for the peer manager
+    /// Network metrics for the peer manager.
     network_metrics: Arc<NetworkMetrics>,
     /// A label for the network to use in metrics.
     network_label: &'static str,

--- a/crates/consensus/network/src/tests/network_tests.rs
+++ b/crates/consensus/network/src/tests/network_tests.rs
@@ -85,7 +85,7 @@ fn create_test_peers<Req: RLMessage, Res: RLMessage>(
     (target, peers, task_manager)
 }
 
-/// A peer on RL
+/// A peer on RL.
 struct TestPeer<Req, Res, DB = MemDatabase>
 where
     Req: RLMessage,
@@ -103,7 +103,7 @@ where
     /// Network metrics shared with the spawned task.
     network_metrics: Arc<NetworkMetrics>,
 }
-/// A peer on RL
+/// A peer on RL.
 struct NetworkPeer<Req, Res, DB = MemDatabase>
 where
     Req: RLMessage,
@@ -121,7 +121,7 @@ where
     network_metrics: Arc<NetworkMetrics>,
 }
 
-/// The type for holding testng components.
+/// The type for holding testing components.
 struct TestTypes<Req, Res, DB = MemDatabase>
 where
     Req: RLMessage,
@@ -1711,6 +1711,93 @@ async fn test_newer_kad_record_replaced() -> eyre::Result<()> {
     Ok(())
 }
 
+/// A replayed or stale record must be deduped before the signature verify: an invalid
+/// signature on a duplicate is never examined, so it must not earn a penalty. A verify-first
+/// ordering would trip the invalid-record penalty and ban an honest peer for a stale replay.
+#[tokio::test]
+async fn test_kad_put_stale_duplicate_deduped_before_signature_verify() -> eyre::Result<()> {
+    let TestTypes { peer1, mut peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+
+    // store peer2's valid record
+    let valid_record = peer2.network.get_peer_record();
+    network.swarm.behaviour_mut().kademlia.store_mut().put(valid_record.clone())?;
+
+    // craft a stale duplicate (older timestamp) with a garbage signature
+    let mut stale_info = peer2.network.node_record.info.clone();
+    stale_info.timestamp = now() - 10_000;
+    let garbage_signature = peer2.config.key_config().request_signature_direct(&encode(&"garbage"));
+    peer2.network.node_record = NodeRecord { info: stale_info, signature: garbage_signature };
+    let stale_record = peer2.network.get_peer_record();
+
+    let peer2_id = *peer2.network.swarm.local_peer_id();
+    network.process_kad_put_request(peer2_id, stale_record);
+
+    // the stored record is untouched and the sender is not penalized for a signature
+    // that was never checked
+    let store_record = network
+        .swarm
+        .behaviour_mut()
+        .kademlia
+        .store_mut()
+        .get(&valid_record.key)
+        .expect("peer2 record in local kad store");
+    assert_eq!(*store_record, valid_record);
+    assert!(
+        !network.swarm.behaviour().peer_manager.peer_banned(&peer2_id),
+        "stale duplicate must be dropped by the dedup, not verified and penalized"
+    );
+
+    Ok(())
+}
+
+/// Puts beyond the per-peer fixed-window budget are dropped before any per-record work,
+/// so a flood cannot push a fresh record into the store once the window is exhausted.
+#[tokio::test]
+async fn test_kad_put_budget_drops_flood() -> eyre::Result<()> {
+    let TestTypes { peer1, mut peer2, .. } =
+        create_test_types::<TestWorkerRequest, TestWorkerResponse>();
+    let mut network = peer1.network;
+    let peer2_id = *peer2.network.swarm.local_peer_id();
+
+    // store an old-but-valid record for peer2
+    let mut old_info = peer2.network.node_record.info.clone();
+    old_info.timestamp = now() - 10_000;
+    let signature = peer2.config.key_config().request_signature_direct(&encode(&old_info));
+    peer2.network.node_record = NodeRecord { info: old_info, signature };
+    let old_record = peer2.network.get_peer_record();
+    network.swarm.behaviour_mut().kademlia.store_mut().put(old_record.clone())?;
+
+    // exhaust the budget with duplicate puts (each is deduped but still counted)
+    for _ in 0..crate::consensus::kad::kad_put_budget_max() {
+        network.process_kad_put_request(peer2_id, old_record.clone());
+    }
+
+    // a genuinely newer, validly signed record now arrives - over budget, so it is dropped
+    let mut fresh_info = peer2.network.node_record.info.clone();
+    fresh_info.timestamp = now();
+    let signature = peer2.config.key_config().request_signature_direct(&encode(&fresh_info));
+    peer2.network.node_record = NodeRecord { info: fresh_info, signature };
+    let fresh_record = peer2.network.get_peer_record();
+    network.process_kad_put_request(peer2_id, fresh_record.clone());
+
+    let store_record = network
+        .swarm
+        .behaviour_mut()
+        .kademlia
+        .store_mut()
+        .get(&old_record.key)
+        .expect("peer2 record in local kad store");
+    assert_eq!(*store_record, old_record, "over-budget put must not reach the store");
+    assert!(
+        !network.swarm.behaviour().peer_manager.peer_banned(&peer2_id),
+        "over-budget puts are dropped, never penalized"
+    );
+
+    Ok(())
+}
+
 /// FIND-025 Path A: AddProvider store exhaustion must not propagate a fatal error.
 ///
 /// Pre-fill the provider table to capacity, then verify that an overflow AddProvider
@@ -1891,7 +1978,7 @@ async fn test_kad_record_store_exhaustion_does_not_propagate_error() -> eyre::Re
 
 /// `load_known_peers_from_kad_store` rehydrates the in-memory BLS map from persistent
 /// records at startup, so a restarted node does not need to wait for peer re-PUTs to
-/// route gossip. Pins the load-bearing fix for the observer-restart bug.
+/// route gossip.
 #[tokio::test]
 async fn test_load_known_peers_from_kad_store_rehydrates_after_restart() -> eyre::Result<()> {
     let TestTypes { peer1, peer2, .. } =
@@ -2040,7 +2127,7 @@ async fn test_connected_peers_count_double_decrement() -> eyre::Result<()> {
     let connected = peer1_handle.connected_peer_ids().await?;
     assert!(!connected.contains(&peer2_id), "peer2 should be disconnected after fatal penalty");
 
-    // The gauge should be 0 — exactly one peer disconnected.
+    // The gauge should be 0 - exactly one peer disconnected.
     assert_eq!(
         gauge.get(),
         0,

--- a/crates/consensus/primary/Cargo.toml
+++ b/crates/consensus/primary/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
+bcs = { workspace = true }
 eyre = { workspace = true }
 backoff = { workspace = true }
 futures = { workspace = true }

--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -100,9 +100,9 @@ pub(crate) struct CertificateFetcher<DB> {
     /// The max allowable RPC message size shared with peers (in bytes).
     /// This value should match the `request_response` codec's "max_rpc_message_size".
     max_rpc_message_size: usize,
-    /// Track consecutive fetch failures for exponential backoff
+    /// Track consecutive fetch failures for exponential backoff.
     consecutive_failures: u32,
-    /// Last fetch attempt time for rate limiting
+    /// Last fetch attempt time for rate limiting.
     last_fetch_attempt: Option<Instant>,
     /// Suppresses probes until this instant after an epoch-mismatch outcome.
     /// Prevents tight spin when all peers are on a future epoch.
@@ -786,7 +786,8 @@ async fn fetch_certificates_helper(
                     result
                 }));
             }
-            let mut interval = Box::pin(sleep(request_interval));
+            let interval = sleep(request_interval);
+            tokio::pin!(interval);
             tokio::select! {
                 res = fut.next() => match res {
                     Some(Ok(certificates)) => {

--- a/crates/consensus/primary/src/certifier.rs
+++ b/crates/consensus/primary/src/certifier.rs
@@ -1,4 +1,4 @@
-//! Certifier broadcasts headers and certificates for this primary.
+//! Certifier publishes headers and certificates for this primary.
 
 use crate::{
     aggregators::HeaderVotesAggregator,
@@ -37,8 +37,7 @@ enum VoteErrorAction {
     Continue,
 }
 
-/// This component is responisble for proposing headers to peers, collecting votes on headers,
-/// and certifying headers into certificates.
+/// Header proposer that collects peer votes and certifies headers into certificates.
 ///
 /// It receives headers to propose from Proposer via `rx_headers`, and publishes certificates to
 /// gossip network.
@@ -60,7 +59,7 @@ pub(crate) struct Certifier<DB> {
     consensus_bus: ConsensusBus,
     /// A network sender to send the batches to the other workers.
     network: PrimaryNetworkHandle,
-    /// Metrics handler
+    /// Metrics handler.
     metrics: Arc<PrimaryMetrics>,
     /// Spawn epoch-related tasks.
     task_spawner: TaskSpawner,
@@ -140,8 +139,8 @@ impl<DB: Database> Certifier<DB> {
     /// Rayls: Maximum vote request attempts before giving up.
     const MAX_VOTE_REQUEST_ATTEMPTS: u32 = 30;
 
-    /// Rayls: How long the committed round may stall — while we already hold the certs for a peer's
-    /// limit round — before a "too old" rejection counts toward demotion anyway. Below this, the
+    /// Rayls: How long the committed round may stall - while we already hold the certs for a peer's
+    /// limit round - before a "too old" rejection counts toward demotion anyway. Below this, the
     /// lag is treated as a transient proposer stall (certs arriving, not yet usable as parents)
     /// and the rejection is ignored; beyond it, the proposer is considered wedged and allowed
     /// to demote. Far above the normal sub-second commit interval, so transient gaps never trip
@@ -376,7 +375,7 @@ impl<DB: Database> Certifier<DB> {
     fn handle_vote_error(&self, error: &DagError, header: &Header) -> VoteErrorAction {
         match error {
             DagError::TooOldRejectedByPeers { peer_id, header_round, limit_round } => {
-                // A "too old" rejection means our PROPOSER is lagging in rounds — not that we lack
+                // A "too old" rejection means our PROPOSER is lagging in rounds - not that we lack
                 // data. If our cert store already covers the peer's limit round, we hold every cert
                 // CvvInactive would sync; the lag is transient (those certs are suspended on
                 // missing grandparents and not yet usable as parents, but they are
@@ -387,7 +386,7 @@ impl<DB: Database> Certifier<DB> {
                 // Mirrors `should_count_epoch_rejection`, which drops rejections carrying no
                 // liveness signal.
                 // `limit_round > 0` excludes the legacy string-based path (set to 0 at the
-                // request site), where we don't know the peer's real limit — those count normally
+                // request site), where we don't know the peer's real limit - those count normally
                 // toward demotion rather than always satisfying `cert_store_round >= 0`.
                 let cert_store_round = *self.consensus_bus.cert_store_round().borrow();
                 if *limit_round > 0 && cert_store_round >= *limit_round {
@@ -684,9 +683,9 @@ impl<DB: Database> Certifier<DB> {
                         }
 
                         // try to publish the certificate on gossip network.
-                        // Dev (single-node): no peers to gossip to — we already processed our
+                        // Dev (single-node): no peers to gossip to - we already processed our
                         // own certificate above, and publishing would only fail every round
-                        // with NoPeersSubscribedToTopic — so skip it entirely.
+                        // with NoPeersSubscribedToTopic - so skip it entirely.
                         #[cfg(not(feature = "dev-single-node-setup"))]
                         if let Err(e) = self.network.publish_certificate(certificate).await {
                             error!(target: "primary::certifier", ?e, "failed to gossip certificate");
@@ -718,9 +717,9 @@ impl<DB: Database> Certifier<DB> {
         }
     }
 
-    /// Execute the main certification task.  Will run until shutdown is signalled.
-    /// If this exits outside of shutdown it will log an error and this will trigger a node
-    /// shutdown.
+    /// Execute the main certification task until shutdown is signalled.
+    ///
+    /// Exiting outside of shutdown logs an error and triggers a node shutdown.
     async fn run(mut self) {
         info!(target: "primary::certifier", "Certifier on node {} has started successfully.", &self.authority_id);
         let mut rx_headers = self.consensus_bus.headers().subscribe();
@@ -729,6 +728,19 @@ impl<DB: Database> Certifier<DB> {
         let mut in_flight: Option<(HeaderDigest, tokio::task::AbortHandle)> = None;
         loop {
             tokio::select! {
+                // shutdown wins: certifying a further header during teardown wastes a vote
+                // round trip the epoch is about to discard
+                biased;
+
+                _ = shutdown => {
+                    debug!(target: "primary::certifier", "Certifier received shutdown signal");
+                    // cancel any outstanding proposals and vote requests
+                    self.new_proposal.notify();
+                    if let Some((_, h)) = in_flight.take() {
+                        h.abort();
+                    }
+                    break;
+                }
                 Some(header) = rx_headers.recv() => {
                     let digest = header.digest();
                     let round = header.round();
@@ -839,16 +851,6 @@ impl<DB: Database> Certifier<DB> {
                     in_flight = Some((digest, abort));
                 },
 
-                // listen for consensus shutdown
-                _ = shutdown => {
-                    debug!(target: "primary::certifier", "Certifier received shutdown signal");
-                    // cancel any outstanding proposals and vote requests
-                    self.new_proposal.notify();
-                    if let Some((_, h)) = in_flight.take() {
-                        h.abort();
-                    }
-                    break;
-                }
             }
         }
     }

--- a/crates/consensus/primary/src/consensus_bus.rs
+++ b/crates/consensus/primary/src/consensus_bus.rs
@@ -1,5 +1,5 @@
 //! Implement a container for channels used internally by consensus.
-//! This allows easier examination of message flow and avoids excessives channel passing as
+//! This allows easier examination of message flow and avoids excessive channel passing as
 //! arguments.
 
 use crate::{
@@ -76,7 +76,7 @@ impl<T> Drop for QueChanReceiver<T> {
 }
 
 /// Wrapper around an mpsc channel.  It allows a channel to exist for application lifetime
-/// even if used for epoch messages.  It tracks subscibers so that each epoch will be able to
+/// even if used for epoch messages.  It tracks subscribers so that each epoch will be able to
 /// "subscribe" to the channel (after the last epoch has dropped it's subscription).
 #[derive(Debug)]
 pub struct QueChannel<T> {
@@ -371,6 +371,11 @@ struct ConsensusBusEpochInner {
     /// Drain signal from manager to subscriber. Manager sends `Some(boundary_round)` to
     /// initiate drain with the deterministic epoch boundary round. `None` means no drain.
     drain_signal: watch::Sender<Option<Round>>,
+    /// Count of certificates currently suspended awaiting parents, owned by the certificate
+    /// manager. The proposer's backpressure gate reads this, never the mirrored metrics gauge:
+    /// control state lives in a component, a metric handle is write-only. Published on each
+    /// suspension, so a drained queue is reflected only at the next suspension.
+    suspended_cert_count: watch::Sender<usize>,
 
     /// Subscriber sends drain acknowledgment when all in-flight work is complete.
     /// Wrapped in Arc<Mutex<Option>> because oneshot::Sender is consumed on use and is not Clone.
@@ -432,6 +437,7 @@ impl ConsensusBusEpochInner {
         );
 
         let (drain_signal, _) = watch::channel(None);
+        let (suspended_cert_count, _) = watch::channel(0);
         let (drain_ack_tx, drain_ack_rx) = oneshot::channel();
 
         Self {
@@ -445,6 +451,7 @@ impl ConsensusBusEpochInner {
             sequence,
             certificate_manager,
             drain_signal,
+            suspended_cert_count,
             drain_ack_tx: Arc::new(Mutex::new(Some(drain_ack_tx))),
             drain_ack_rx: Arc::new(Mutex::new(Some(drain_ack_rx))),
         }
@@ -587,6 +594,11 @@ impl ConsensusBus {
     /// Send `Some(boundary_round)` to signal the subscriber with the deterministic cutoff round.
     pub fn drain_signal(&self) -> &watch::Sender<Option<Round>> {
         &self.inner_epoch.drain_signal
+    }
+
+    /// Count of certificates suspended awaiting parents (epoch-scoped, resets with the epoch).
+    pub fn suspended_cert_count(&self) -> &watch::Sender<usize> {
+        &self.inner_epoch.suspended_cert_count
     }
 
     /// Take the drain acknowledgment sender for the subscriber.

--- a/crates/consensus/primary/src/network/handler.rs
+++ b/crates/consensus/primary/src/network/handler.rs
@@ -22,13 +22,13 @@ use rayls_infrastructure_storage::{
 use rayls_infrastructure_types::{
     ensure,
     error::{CertificateError, HeaderError, HeaderResult},
-    now, to_intent_message, try_decode, AuthorityIdentifier, BlockHash, BlockNumHash, BlsPublicKey,
-    Certificate, CertificateDigest, ConsensusHeader, Database, Epoch, EpochCertificate,
-    EpochRecord, Hash as _, Header, ProtocolSignature, RaylsSender as _, Round,
+    now, to_intent_message, try_decode, AuthorityIdentifier, B256Map, BlockHash, BlockNumHash,
+    BlsPublicKey, Certificate, CertificateDigest, ConsensusHeader, Database, Epoch,
+    EpochCertificate, EpochRecord, Hash as _, Header, ProtocolSignature, RaylsSender as _, Round,
     SignatureVerificationState, Vote, VotesAggregator,
 };
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::Duration,
 };
@@ -37,24 +37,22 @@ use tracing::{debug, error, info, trace, warn};
 
 const MAX_AUTH_LAST_VOTE_ENTRIES: usize = 1000;
 const MAX_CONSENSUS_CERTS_ENTRIES: usize = 100;
-/// How long `committed_round` must stay flat while we keep looking behind before we demote to
-/// `CvvInactive`. Any commit advance resets the clock, so a node that's catching up (or mid
-/// epoch/mode transition) never trips it — only one genuinely stuck for the whole window does.
+/// How long `committed_round` must stay flat, while verdicts keep saying behind, before demoting
+/// to `CvvInactive`. Any commit advance resets the clock, so a node catching up or mid epoch/mode
+/// transition never trips it; only one stuck for the whole window does.
 ///
-/// We anchor the stall on wall-clock, NOT on a verdict/round count, on purpose. The verdicts come
-/// from incoming gossip and `primary_round` is bumped to the highest *received* round, so both are
-/// peer-arrival-driven — a burst of ahead-certs would jump them while commit legitimately lags,
-/// faking a stall. The clock is the only "how long" a burst can't accelerate. ~5s ≈ 5 rounds under
-/// load (the only regime where we're actually behind; idle means no traffic, so not behind), which
-/// is a sane "we produced rounds but committed nothing" threshold without depending on the (chain-
-/// varying, idle-ceiling) `max_header_delay`.
+/// Anchored on wall-clock, not on a verdict or round count, on purpose: verdicts come from
+/// incoming gossip and `primary_round` tracks the highest *received* round, so a burst of
+/// ahead-certs would jump both while commit legitimately lags, faking a stall. ~5s is ~5 rounds
+/// under load (the only regime where the node is actually behind), a sane "produced rounds but
+/// committed nothing" threshold that does not depend on the chain-varying `max_header_delay`.
 const BEHIND_STALL_WINDOW: Duration = Duration::from_secs(5);
 
 /// Tracks consensus-commit progress across `behind_consensus` "behind" verdicts, so we demote only
 /// when genuinely stuck (`committed_round` flat for a whole window) rather than merely mid-
 /// transition (commits still advancing). We track the DAG commit watermark, not the executed tip:
 /// execution lags commit, and a node that's committing fine but executing slowly is still
-/// participating — gating on the executed tip is exactly what produced the transition false
+/// participating - gating on the executed tip is exactly what produced the transition false
 /// positives. Shared across `RequestHandler` clones, hence behind a lock.
 #[derive(Debug)]
 struct BehindTracker {
@@ -108,7 +106,7 @@ pub(crate) struct RequestHandler<DB> {
     /// Per-authority vote state for equivocation detection and caching.
     auth_last_vote: Arc<Mutex<AuthEquivocationMap>>,
     /// Consensus result signers per digest.
-    consensus_certs: Arc<Mutex<HashMap<BlockHash, VotesAggregator<ConsensusResult>>>>,
+    consensus_certs: Arc<Mutex<B256Map<VotesAggregator<ConsensusResult>>>>,
     /// Commit-progress tracker gating demotion to `CvvInactive` (see [`behind_consensus`]).
     behind_tracker: Arc<Mutex<BehindTracker>>,
 }
@@ -142,11 +140,11 @@ where
 
     /// Return true and request CvvInactive if the peer's cert shows we are *stuck* behind.
     ///
-    /// "Behind" alone is not enough to demote: a node mid epoch/mode transition — or simply
-    /// syncing — is briefly behind by construction yet keeps committing and self-heals.
+    /// "Behind" alone is not enough to demote: a node mid epoch/mode transition - or simply
+    /// syncing - is briefly behind by construction yet keeps committing and self-heals.
     /// We demote only when behind AND not making progress: `committed_round` stays flat for the
     /// whole `BEHIND_STALL_WINDOW`. This replaces the old `is_transitioning()` suppressor, which
-    /// was racy (TOCTOU) and, worse, blind to the window before we detect our own boundary —
+    /// was racy (TOCTOU) and, worse, blind to the window before we detect our own boundary  -
     /// exactly when a lagging node would wrongly self-demote.
     async fn behind_consensus(&self, epoch: Epoch, round: Round, number: Option<u64>) -> bool {
         if self.consensus_config.shutdown().was_notified() {
@@ -163,7 +161,7 @@ where
         let relative_gc_depth = self.consensus_config.parameters().gc_depth / 4;
         let active_cvv = self.consensus_bus.node_mode().borrow().is_active_cvv();
         let our_epoch = self.consensus_config.committee().epoch();
-        // DAG commit watermark — the progress signal we gate the stall on. Advances on our own
+        // DAG commit watermark - the progress signal we gate the stall on. Advances on our own
         // commits (self-paced), so a gossip burst can't accelerate it the way it does the executed
         // tip or `primary_round`.
         let committed_round = *self.consensus_bus.committed_round_updates().borrow();
@@ -198,7 +196,7 @@ where
 
         // We look behind. Demote only if commit has been flat for the whole stall window: a
         // transitioning or syncing node keeps committing and resets the clock, so it never demotes
-        // — only one stuck for the full window does. record_behind re-arms the clock when it fires,
+        // - only one stuck for the full window does. record_behind re-arms the clock when it fires,
         // so a concurrent clone (they share the Arc<Mutex>) can't re-trigger demotion in a loop.
         let stalled =
             self.behind_tracker.lock().record_behind(committed_round, BEHIND_STALL_WINDOW);

--- a/crates/consensus/primary/src/proposer/run_loop.rs
+++ b/crates/consensus/primary/src/proposer/run_loop.rs
@@ -7,25 +7,19 @@ use crate::{
 };
 use rayls_infrastructure_storage::ProposerStore;
 use rayls_infrastructure_types::{Database, Epoch, RaylsReceiver, RaylsSender, Round};
-use tokio::{sync::oneshot, time::sleep};
+use tokio::sync::oneshot;
 use tracing::{debug, info, warn};
 
 /// Whether a stored `last_proposed` header is stale relative to the proposer's current position,
-/// and therefore must NOT be re-proposed on the max-delay retransmit path.
+/// and therefore must not be re-proposed on the max-delay retransmit path.
 ///
-/// Stale means either:
-/// - a different epoch — the check is `!=`, so a header from any epoch other than the current one
-///   is stale (a future epoch can't occur in normal operation, but the predicate rejects it too).
-///   Rounds reset per epoch, so the epoch is checked *before* the round (a round-3 header of epoch
-///   N+1 is newer than a round-4 header of epoch N), or
-/// - the same epoch but a round below `self_round`.
-///
+/// Stale means a different epoch (rounds reset per epoch, so the epoch is checked first and any
+/// other epoch, past or future, is stale) or the same epoch but a round below `self_round`.
 /// `self_round` can advance past `last_proposed` via the `process_parents` jump-ahead (see
-/// `round.rs`), which bumps the round WITHOUT writing `last_proposed`. Re-proposing a stale header
-/// then draws a "too old"/equivocation rejection from peers and — because the certifier aborts any
-/// in-flight proposal when a new header arrives — cancels the in-flight current-round
-/// certification every cycle, a livelock. Skipping it keeps `last_proposed` monotonic-in-round
-/// within an epoch and lets a fresh current-round header get certified instead.
+/// `round.rs`), which bumps the round without writing `last_proposed`. Re-proposing a stale header
+/// draws a "too old"/equivocation rejection from peers and, because the certifier aborts any
+/// in-flight proposal when a new header arrives, cancels the current-round certification every
+/// cycle: a livelock.
 pub(super) fn last_proposed_is_stale(
     self_round: Round,
     self_epoch: Epoch,
@@ -66,7 +60,7 @@ impl<DB: Database> Proposer<DB> {
                 tokio::select! {
                     biased;
                     _ = &self.rx_shutdown => return Ok(()),
-                    // watch::Receiver::changed() is cancellation-safe — it only updates
+                    // watch::Receiver::changed() is cancellation-safe - it only updates
                     // the "seen" mark, the value persists in the channel.
                     res = replay_rx.changed() => {
                         if res.is_err() || *replay_rx.borrow() {
@@ -85,6 +79,10 @@ impl<DB: Database> Proposer<DB> {
         let mut pending_header = None;
         let mut max_delay_timed_out = false;
         let mut min_delay_timed_out = false;
+        // While throttled the proposer keeps draining digests, parents and shutdown via the
+        // select! and only skips proposing; a bare sleep here would freeze intake for the whole
+        // delay, stalling batch sealing exactly when the node is already behind.
+        let mut throttle_until: Option<tokio::time::Instant> = None;
         loop {
             tokio::select! {
                 _ = &self.rx_shutdown => {
@@ -142,14 +140,21 @@ impl<DB: Database> Proposer<DB> {
                 }
             }
 
-            // Check if pending queue is high before proposing - backpressure mechanism
-            let pending_count = self
-                .consensus_bus
-                .primary_metrics()
-                .node_metrics
-                .certificates_currently_suspended
-                .get()
-                .max(0) as usize;
+            // An active throttle gates proposing only; intake above stays live. The next
+            // select! event (digests, parents, an interval tick) re-evaluates it, so release
+            // lags the deadline by at most one tick.
+            if let Some(deadline) = throttle_until {
+                if tokio::time::Instant::now() < deadline {
+                    continue; // Skip this proposal cycle
+                }
+                throttle_until = None;
+            }
+
+            // Check if pending queue is high before proposing - backpressure mechanism.
+            // Read the typed watch owned by the certificate manager, never the metrics
+            // gauge: a metrics-facade regression reading zero would silently delete this
+            // brake.
+            let pending_count = *self.consensus_bus.suspended_cert_count().borrow();
 
             if pending_count > PENDING_BACKPRESSURE_THRESHOLD {
                 warn!(
@@ -158,7 +163,7 @@ impl<DB: Database> Proposer<DB> {
                     threshold = PENDING_BACKPRESSURE_THRESHOLD,
                     "Pending queue high, delaying proposal"
                 );
-                sleep(BACKPRESSURE_DELAY).await;
+                throttle_until = Some(tokio::time::Instant::now() + BACKPRESSURE_DELAY);
                 continue; // Skip this proposal cycle
             }
 
@@ -172,7 +177,7 @@ impl<DB: Database> Proposer<DB> {
                     threshold = EXECUTION_LAG_THRESHOLD,
                     "Execution lagging behind consensus, delaying proposal"
                 );
-                sleep(EXECUTION_BACKPRESSURE_DELAY).await;
+                throttle_until = Some(tokio::time::Instant::now() + EXECUTION_BACKPRESSURE_DELAY);
                 continue; // Skip this proposal cycle
             }
 
@@ -211,12 +216,12 @@ impl<DB: Database> Proposer<DB> {
             // No *outer* mode-transition guard here: this condition only decides *whether* to enter
             // the re-propose path. Epoch/round staleness of `last_proposed` IS guarded, inside the
             // re-propose block below (see `last_proposed_is_stale`). A stale header can't fork
-            // regardless — the certifier rejects any header whose epoch != committee.epoch(), and
+            // regardless - the certifier rejects any header whose epoch != committee.epoch(), and
             // re-proposing across a mode transition is *why* `run_mode_transition` deliberately
             // preserves `LastProposed`: the header we re-send is byte-identical to the one peers
             // already saw, so they replay their cached vote instead of scoring it as equivocation.
             // (Rebuilding one instead would embed a newer exec anchor, changing the digest at an
-            // already-proposed round — the livelock this store entry exists to prevent.) The old
+            // already-proposed round - the livelock this store entry exists to prevent.) The old
             // `is_transitioning()` check was racy (TOCTOU) and thus never a correctness guarantee.
             let should_repropose_header = !should_create_header && max_delay_timed_out;
 
@@ -262,16 +267,9 @@ impl<DB: Database> Proposer<DB> {
                 min_delay_timed_out = false;
             } else if should_repropose_header {
                 if let Ok(Some(last_proposed)) = self.proposer_store.get_last_proposed() {
-                    // Only re-propose a header that is still current. `self.round` can advance
-                    // past our last stored header via the `process_parents` jump-ahead (see
-                    // `round.rs`), which bumps the round WITHOUT writing `last_proposed`. So
-                    // `last_proposed` legitimately lags `self.round`. Re-proposing that stale
-                    // header is guaranteed a "too old" rejection by peers, and — because the
-                    // certifier aborts any in-flight proposal when a new header arrives — it also
-                    // cancels the in-flight current-round certification every cycle, a livelock.
-                    // Skip it; wait to build a fresh header at `self.round`. (A header from an
-                    // older epoch is likewise stale — rounds reset per epoch, so compare epochs
-                    // before rounds.)
+                    // Only re-propose a header that is still current; a stale one livelocks
+                    // certification (see `last_proposed_is_stale`). Skip it and wait to build a
+                    // fresh header at `self.round`.
                     if last_proposed_is_stale(
                         self.round,
                         self.committee.epoch(),
@@ -331,8 +329,8 @@ mod tests {
     use super::last_proposed_is_stale;
 
     // The re-propose guard must skip a stored header that is behind the proposer's current
-    // position — this is what stops the round-N→round-(N-1) `last_proposed` regression that
-    // caused the equivocation wedge (val1 rebuilding a conflicting round-4 header on restart).
+    // position; re-proposing it regresses `last_proposed` by a round and rebuilds a conflicting
+    // header on restart, an equivocation wedge.
     #[test]
     fn stale_when_header_round_behind_current_round_same_epoch() {
         // self at round 4, stored header at round 3, same epoch → stale (must skip).
@@ -357,14 +355,14 @@ mod tests {
     #[test]
     fn stale_when_older_epoch_even_if_round_looks_higher() {
         // rounds reset per epoch: a round-4 header of epoch 579 is stale once we're in epoch 580
-        // at round 2 — epoch must be checked before round, or we'd wrongly re-propose it.
+        // at round 2 - epoch must be checked before round, or we'd wrongly re-propose it.
         assert!(last_proposed_is_stale(2, 580, 4, 579));
     }
 
     #[test]
     fn stale_when_newer_epoch_even_if_same_round() {
         // the check is `!=`, not `<`: a header from a *future* epoch is stale too. This can't
-        // happen in normal operation, but the predicate pins it — guards against a later change
+        // happen in normal operation, but the predicate pins it - guards against a later change
         // to `<` that would wrongly re-propose it.
         assert!(last_proposed_is_stale(2, 579, 2, 580));
     }

--- a/crates/consensus/primary/src/state_sync/cert_collector.rs
+++ b/crates/consensus/primary/src/state_sync/cert_collector.rs
@@ -22,8 +22,16 @@ use tracing::{debug, info, warn};
 static LOCAL_MIN_REQUEST_SIZE: LazyLock<usize> =
     LazyLock::new(|| encode(&Certificate::default()).len());
 /// The minimal response wrapper using a default, empty message.
-static MESSAGE_OVERHEAD: LazyLock<usize> =
-    LazyLock::new(|| encode(&PrimaryResponse::RequestedCertificates(vec![])).len());
+///
+/// Measured on an empty vector, so it accounts for a single-byte ULEB128 length. A response
+/// carrying 128 or more certificates encodes a wider length prefix, so reserve the widest a
+/// `usize` count can take rather than under-reserving by a few bytes at the cap.
+static MESSAGE_OVERHEAD: LazyLock<usize> = LazyLock::new(|| {
+    encode(&PrimaryResponse::RequestedCertificates(vec![])).len() + ULEB128_MAX_EXTRA_BYTES
+});
+
+/// Widest additional ULEB128 length prefix beyond the single byte an empty vector encodes.
+const ULEB128_MAX_EXTRA_BYTES: usize = 9;
 
 #[cfg(test)]
 #[path = "../tests/cert_collector_tests.rs"]
@@ -61,7 +69,7 @@ pub(crate) struct CertificateCollector<DB> {
     staging_size: usize,
     /// The round currently being staged.
     staging_round: Option<Round>,
-    /// Optional exclusive upper bound — stop fetching at or above this round.
+    /// Optional exclusive upper bound - stop fetching at or above this round.
     exclusive_upper_bound: Option<Round>,
 }
 
@@ -69,7 +77,7 @@ impl<DB> CertificateCollector<DB>
 where
     DB: Database,
 {
-    /// Create a new certificate collector with the given parameters
+    /// Create a new certificate collector with the given parameters.
     pub(crate) fn new(
         request: MissingCertificatesRequest,
         config: ConsensusConfig<DB>,
@@ -175,7 +183,7 @@ where
         Ok(None)
     }
 
-    /// Try to fetch the next available certificate
+    /// Try to fetch the next available certificate.
     pub(crate) fn next_certificate(&mut self) -> PrimaryNetworkResult<Option<Certificate>> {
         while let Some(Reverse((round, origin))) = self.fetch_queue.pop() {
             match self.config.node_storage().read_by_index(&origin, round)? {
@@ -289,7 +297,10 @@ where
             }
             match self.next_certificate() {
                 Ok(Some(cert)) => {
-                    let bytes = encode(&cert).len();
+                    // Size the certificate without building the bytes: the codec encodes the
+                    // response anyway, so encoding here would serialize every certificate served
+                    // twice.
+                    let bytes = bcs::serialized_size(&cert).unwrap_or_else(|_| encode(&cert).len());
                     match self.stage_certificate(cert, bytes) {
                         Staging::Continue => {}
                         Staging::Yield => return self.ready.pop_front().map(Ok),

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -16,13 +16,10 @@ use rayls_infrastructure_config::ConsensusConfig;
 use rayls_infrastructure_storage::CertificateStore;
 use rayls_infrastructure_types::{
     error::{CertificateError, HeaderError},
-    Certificate, CertificateDigest, Database, Hash as _, Noticer, RaylsReceiver as _,
-    RaylsSender as _,
+    Certificate, CertificateDigest, CertificateDigestSet, Database, Hash as _, Noticer,
+    RaylsReceiver as _, RaylsSender as _,
 };
-use std::{
-    collections::{HashSet, VecDeque},
-    sync::Arc,
-};
+use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, warn};
 
@@ -206,7 +203,7 @@ where
     async fn get_missing_parents(
         &self,
         certificate: &Certificate,
-    ) -> CertManagerResult<HashSet<CertificateDigest>> {
+    ) -> CertManagerResult<CertificateDigestSet> {
         let _scope = monitored_scope("primary::rayls-consensus-state-sync::get_missing_parents");
 
         // handle genesis cert
@@ -219,13 +216,13 @@ where
                     );
                 }
             }
-            return Ok(HashSet::new());
+            return Ok(CertificateDigestSet::default());
         }
 
         // check storage
         let existence =
             self.config.node_storage().multi_contains(certificate.header().parents().iter())?;
-        let missing_parents: HashSet<_> = certificate
+        let missing_parents: CertificateDigestSet = certificate
             .header()
             .parents()
             .iter()

--- a/crates/consensus/primary/src/state_sync/cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/cert_manager.rs
@@ -161,7 +161,9 @@ where
                         "certificate suspended - missing parents"
                     );
                     self.pending.insert_pending(cert, missing_parents)?;
-                    // metrics
+                    let _ =
+                        self.consensus_bus.suspended_cert_count().send(self.pending.num_pending());
+                    // metrics mirror only - decisions read the watch above
                     self.consensus_bus
                         .primary_metrics()
                         .node_metrics

--- a/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
@@ -102,6 +102,8 @@ impl PendingCertificateManager {
             self.missing_for_pending.entry((parent_round, parent)).or_default().insert(digest);
         }
 
+        let _ = self.consensus_bus.suspended_cert_count().send(self.pending.len());
+        // metrics mirror only - decisions read the watch above
         self.consensus_bus
             .primary_metrics()
             .node_metrics

--- a/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
+++ b/crates/consensus/primary/src/state_sync/pending_cert_manager.rs
@@ -7,8 +7,10 @@ use crate::{
     error::{CertManagerError, CertManagerResult},
     ConsensusBus,
 };
-use rayls_infrastructure_types::{Certificate, CertificateDigest, Hash as _, Round};
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use rayls_infrastructure_types::{
+    Certificate, CertificateDigest, CertificateDigestMap, CertificateDigestSet, Hash as _, Round,
+};
+use std::collections::{BTreeMap, VecDeque};
 use tracing::{debug, warn};
 
 /// Warn when pending certificates exceed this threshold.
@@ -23,12 +25,12 @@ struct PendingCertificate {
     certificate: Certificate,
     /// The certificate's missing parents that must be retrieved before the pending certificate is
     /// accepted.
-    missing_parent_digests: HashSet<CertificateDigest>,
+    missing_parent_digests: CertificateDigestSet,
 }
 
 impl PendingCertificate {
     /// Create a new instance of Self.
-    fn new(certificate: Certificate, missing_parents: HashSet<CertificateDigest>) -> Self {
+    fn new(certificate: Certificate, missing_parents: CertificateDigestSet) -> Self {
         Self { certificate, missing_parent_digests: missing_parents }
     }
 }
@@ -41,15 +43,15 @@ impl PendingCertificate {
 /// NOTE: all pending certificates must be verified.
 #[derive(Debug)]
 pub(super) struct PendingCertificateManager {
-    /// Each certificate entry tracks both the certificate itself and its dependency state
-    ///
     /// Pending certificates that cannot be accepted yet.
-    pending: HashMap<CertificateDigest, PendingCertificate>,
-    /// Map of a the missing certificate digests and the pending certificates that are blocked by
+    ///
+    /// Each entry tracks both the certificate itself and its dependency state.
+    pending: CertificateDigestMap<PendingCertificate>,
+    /// Map of the missing certificate digests and the pending certificates that are blocked by
     /// them.
     ///
     /// The keys are (round, digest) to enable garbage collection by round.
-    missing_for_pending: BTreeMap<(Round, CertificateDigest), HashSet<CertificateDigest>>,
+    missing_for_pending: BTreeMap<(Round, CertificateDigest), CertificateDigestSet>,
     /// Consensus channels.
     consensus_bus: ConsensusBus,
 }
@@ -64,7 +66,7 @@ impl PendingCertificateManager {
     pub(super) fn insert_pending(
         &mut self,
         certificate: Certificate,
-        missing_parents: HashSet<CertificateDigest>,
+        missing_parents: CertificateDigestSet,
     ) -> CertManagerResult<()> {
         let digest = certificate.digest();
         let parent_round = certificate.round().saturating_sub(1);
@@ -189,7 +191,7 @@ impl PendingCertificateManager {
         Some((round, digest))
     }
 
-    /// Returns whether a certificate is being tracked
+    /// Returns whether a certificate is being tracked.
     pub(super) fn is_pending(&self, digest: &CertificateDigest) -> bool {
         self.pending.contains_key(digest)
     }

--- a/crates/consensus/primary/src/test_utils/helpers.rs
+++ b/crates/consensus/primary/src/test_utils/helpers.rs
@@ -22,21 +22,17 @@ use std::{
 };
 use tempfile::TempDir;
 
+/// Create a temporary directory that is removed on drop.
 pub fn temp_dir() -> TempDir {
     tempfile::tempdir().expect("Failed to open temporary directory")
 }
 
-////////////////////////////////////////////////////////////////
-// Keys, Committee
-////////////////////////////////////////////////////////////////
-
+/// Generate a random BLS keypair.
 pub fn random_key() -> BlsKeypair {
     BlsKeypair::generate(&mut rand::rngs::StdRng::from_os_rng())
 }
 
-////////////////////////////////////////////////////////////////
-// Headers, Votes, Certificates
-////////////////////////////////////////////////////////////////
+/// Create a header payload of `number_of_batches` random batch digests for worker 0.
 pub fn fixture_payload(number_of_batches: u8) -> IndexMap<BlockHash, WorkerId> {
     let mut payload: IndexMap<BlockHash, WorkerId> = IndexMap::new();
 
@@ -50,6 +46,7 @@ pub fn fixture_payload(number_of_batches: u8) -> IndexMap<BlockHash, WorkerId> {
     payload
 }
 
+/// Create a header payload of `number_of_batches` batch digests drawn from `rand`.
 pub fn fixture_payload_with_rand<R: Rng + ?Sized>(
     number_of_batches: u8,
     rand: &mut R,
@@ -66,7 +63,7 @@ pub fn fixture_payload_with_rand<R: Rng + ?Sized>(
 }
 
 /// Create a transaction with a randomly generated keypair.
-pub fn transaction_with_rand<R: Rng + ?Sized>(rand: &mut R) -> Vec<u8> {
+pub fn transaction_with_rand<R: Rng + ?Sized>(rand: &mut R) -> Bytes {
     let mut tx_factory = TransactionFactory::new_random_from_seed(rand);
     let chain = test_chain_spec_arc();
     // TODO: this is excessively high, but very unlikely to ever fail
@@ -84,6 +81,7 @@ pub fn transaction_with_rand<R: Rng + ?Sized>(rand: &mut R) -> Vec<u8> {
     )
 }
 
+/// Create a two-transaction batch for `worker_id` with transactions drawn from `rand`.
 pub fn batch_with_rand<R: Rng + ?Sized>(rand: &mut R, worker_id: WorkerId) -> Batch {
     Batch::new_for_test(
         vec![transaction_with_rand(rand), transaction_with_rand(rand)],
@@ -93,10 +91,6 @@ pub fn batch_with_rand<R: Rng + ?Sized>(rand: &mut R, worker_id: WorkerId) -> Ba
         0,
     )
 }
-
-////////////////////////////////////////////////////////////////
-// Batches
-////////////////////////////////////////////////////////////////
 
 /// Creates one certificate per authority starting and finishing at the specified rounds
 /// (inclusive).
@@ -454,6 +448,7 @@ pub fn make_signed_certificates(
     rounds_of_certificates(range, initial_parents, &ids[..], failure_probability, generator)
 }
 
+/// Create an unsigned certificate whose header payload is drawn from `rand`.
 pub fn mock_certificate_with_rand<R: RngCore + ?Sized>(
     committee: &Committee,
     origin: AuthorityIdentifier,

--- a/crates/consensus/worker/Cargo.toml
+++ b/crates/consensus/worker/Cargo.toml
@@ -23,7 +23,6 @@ prometheus = { workspace = true }
 eyre = { workspace = true }
 rayls-consensus-network = { workspace = true }
 serde = { workspace = true }
-consensus-metrics = { workspace = true }
 rand = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/consensus/worker/src/batch-builder/src/batch.rs
+++ b/crates/consensus/worker/src/batch-builder/src/batch.rs
@@ -49,7 +49,7 @@ pub struct BatchBuilderOutput {
     pub(crate) at_capacity: bool,
 }
 
-/// Construct an Rayls batch using the best transactions from the pool.
+/// Construct a Rayls batch using the best transactions from the pool.
 ///
 /// Returns the [`BatchBuilderOutput`] and cannot fail. The batch continues to add
 /// transactions to the proposed block until either:
@@ -84,8 +84,7 @@ pub fn build_batch<P: TxPool>(
 
     // NOTE: batches always build off the latest finalized block
 
-    // collect data for successful transactions
-    // let mut sum_blob_gas_used = 0;
+    // collect data for selected transactions
     let mut total_bytes_size = 0;
     let mut total_possible_gas = 0;
     let mut at_capacity = false;
@@ -94,8 +93,7 @@ pub fn build_batch<P: TxPool>(
     let mut blob_transactions = Vec::new();
     let mut sender_nonce_ranges = SenderNonceRanges::new();
 
-    // begin loop through sorted "best" transactions in pending pool
-    // and execute them to build the block
+    // walk the sorted "best" transactions in the pending pool; they are selected, not executed
     while let Some(pool_tx) = best_txs.next() {
         // skip a transaction already sealed into a batch still in flight, so a stuck inclusion
         // backlog is not re-sealed batch after batch. The skip cannot open a nonce gap: an
@@ -108,10 +106,8 @@ pub fn build_batch<P: TxPool>(
 
         // ensure block has capacity (in gas) for this transaction
         if total_possible_gas + pool_tx.gas_limit() > gas_limit {
-            // the tx could exceed max gas limit for the block
-            // marking as invalid within the context of the `BestTransactions` pulled in this
-            // current iteration  all dependents for this transaction are now considered invalid
-            // before continuing loop
+            // the tx would exceed the batch's gas cap: it and all its dependents are invalid for
+            // the rest of this `BestTransactions` iteration
             best_txs.exceeds_gas_limit(&pool_tx, gas_limit);
             debug!(target: "worker::batch_builder", ?pool_tx, "marking tx invalid due to gas constraint");
             // Only a non-empty batch is "at capacity": a tx whose own gas exceeds the whole cap can
@@ -135,10 +131,8 @@ pub fn build_batch<P: TxPool>(
 
         // ensure block has capacity (in bytes) for this transaction
         if total_bytes_size + tx.size() > max_size {
-            // the tx could exceed max gas limit for the block
-            // marking as invalid within the context of the `BestTransactions` pulled in this
-            // current iteration  all dependents for this transaction are now considered invalid
-            // before continuing loop
+            // the tx would exceed the batch's byte cap: as with the gas branch, it and its
+            // dependents are invalid for the rest of this iteration
             best_txs.max_batch_size(&pool_tx, tx.size(), max_size);
             debug!(target: "worker::batch_builder", ?pool_tx, "marking tx invalid due to bytes constraint");
             // As with the gas branch: a tx larger than the whole batch is unbatchable, not backlog.
@@ -161,9 +155,9 @@ pub fn build_batch<P: TxPool>(
             })
             .or_insert(NonceRange { min: nonce, max: nonce });
 
-        // append transaction to the list of executed transactions
+        // append transaction to the batch
         mined_transactions.push(*pool_tx.hash());
-        transactions.push(tx.into_inner().encoded_2718());
+        transactions.push(tx.into_inner().encoded_2718().into());
     }
 
     // batch

--- a/crates/consensus/worker/src/batch-builder/src/test_utils.rs
+++ b/crates/consensus/worker/src/batch-builder/src/test_utils.rs
@@ -6,7 +6,7 @@ use rayls_execution_evm::{
     SenderIdentifiers, TxPool,
 };
 use rayls_infrastructure_types::{
-    Batch, BatchBuilderArgs, Recovered, TransactionTrait as _, TxHash,
+    Batch, BatchBuilderArgs, Bytes, Recovered, TransactionTrait as _, TxHash,
     ETHEREUM_BLOCK_GAS_LIMIT_56BITS, MIN_PROTOCOL_BASE_FEE,
 };
 use std::{
@@ -16,8 +16,7 @@ use std::{
 
 /// Attempt to update batch with accurate header information.
 ///
-/// NOTE: this is loosely based on reth's auto-seal consensus
-/// NOTE2: this assumes worker 0.
+/// NOTE: loosely based on reth's auto-seal consensus; assumes worker 0.
 pub fn execute_test_batch(test_batch: &mut Batch) {
     let pool = TestPool::new(&test_batch.transactions);
 
@@ -30,7 +29,7 @@ pub fn execute_test_batch(test_batch: &mut Batch) {
     // Don't reset base_fee_per_gas, some tests need that value to remain.
 }
 
-/// A test pool that ensures every transaction is in the pending pool
+/// A test pool that treats every transaction as pending.
 #[derive(Default, Clone, Debug)]
 struct TestPool {
     transactions: Vec<Arc<PoolTxn>>,
@@ -58,7 +57,7 @@ impl TxPool for TestPool {
 
 impl TestPool {
     /// Create a new instance of Self.
-    fn new(txs: &[Vec<u8>]) -> Self {
+    fn new(txs: &[Bytes]) -> Self {
         let mut sender_ids = SenderIdentifiers::default();
         let mut by_id = Vec::with_capacity(txs.len());
         let transactions = txs
@@ -131,7 +130,7 @@ struct BestTestTransactions {
 }
 
 impl BestTestTransactions {
-    /// Mark the transaction and it's descendants as invalid.
+    /// Marks the transaction and its descendants as invalid.
     fn mark_invalid(&mut self, tx: &Arc<PoolTxn>) {
         self.invalid.insert(*tx.hash());
     }
@@ -143,7 +142,7 @@ impl BestTransactions for BestTestTransactions {
     }
 
     fn no_updates(&mut self) {
-        // does not need to implement it for tests because tests does not push data while running
+        // no-op: tests never push transactions while the iterator runs
     }
 
     fn skip_blobs(&mut self) {

--- a/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
@@ -38,8 +38,7 @@ use tracing::debug;
 async fn test_make_batch_el_to_cl() {
     let tmp_dir = TempDir::new().expect("temp dir");
     let task_manager = TaskManager::default();
-    //
-    //
+    // consensus layer
 
     let network_client = LocalNetwork::new_with_empty_id();
     let store = open_db(tmp_dir.path().join("c-db"));
@@ -61,13 +60,11 @@ async fn test_make_batch_el_to_cl() {
         WorkerNetworkHandle::new_for_test(task_manager.get_spawner()),
     );
     batch_provider.spawn_batch_builder("test builder", &task_manager);
-    //
-    //
+    // execution layer
 
     // testnet genesis with TxFactory funded
     let genesis = test_genesis();
 
-    // let genesis = genesis.extend_accounts(account);
     let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
 
     let reth_env = RethEnv::new_for_temp_chain(chain.clone(), tmp_dir.path(), &task_manager, None)
@@ -148,14 +145,13 @@ async fn test_make_batch_el_to_cl() {
     // spawn batch_builder once worker is ready
     let _batch_builder = tokio::spawn(batch_builder.run());
 
-    //
-    //
+    // test batch flow
 
     // wait for new batch
     let mut sealed_batch = None;
     for _ in 0..5 {
         let _ = tokio::time::sleep(Duration::from_secs(1)).await;
-        // Ensure the batch is stored - use with_read_txn for proper transaction scoping
+        // ensure the batch is stored
         if let Ok(Some((digest, wb))) = store.with_read_txn(|txn| Ok(txn.iter::<Batches>().next()))
         {
             sealed_batch = Some(SealedBatch::new(wb, digest));
@@ -180,9 +176,9 @@ async fn test_make_batch_el_to_cl() {
     // ensure expected transaction is in batch
     let expected_batch = Batch {
         transactions: vec![
-            transaction1.encoded_2718(),
-            transaction2.encoded_2718(),
-            transaction3.encoded_2718(),
+            transaction1.encoded_2718().into(),
+            transaction2.encoded_2718().into(),
+            transaction3.encoded_2718().into(),
         ],
         received_at: None,
         ..*sealed_batch.batch()
@@ -192,9 +188,8 @@ async fn test_make_batch_el_to_cl() {
     let batch_txs = sealed_batch.batch().transactions();
     assert_eq!(batch_txs, expected_batch.batch().transactions());
 
-    // ensure enough time passes for store to pass
+    // give the store time to commit
     let _ = tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-    // Use with_read_txn for proper transaction scoping
     let first_batch = store.with_read_txn(|txn| Ok(txn.iter::<Batches>().next())).ok().flatten();
     debug!("first batch? {:?}", first_batch);
 
@@ -232,8 +227,7 @@ async fn test_make_batch_el_to_cl() {
 /// Before a canonical state change, mine the 5th transaction in the next batch.
 #[tokio::test]
 async fn test_batch_builder_produces_valid_batches() {
-    //
-    //
+    // execution layer
     // testnet genesis with TxFactory funded
     let genesis = test_genesis();
 
@@ -331,8 +325,7 @@ async fn test_batch_builder_produces_valid_batches() {
     // spawn batch_builder once worker is ready
     let _batch_builder = tokio::spawn(batch_builder.run());
 
-    //
-    //
+    // test batch flow
 
     // plenty of time for batch production
     let duration = std::time::Duration::from_secs(5);
@@ -378,9 +371,9 @@ async fn test_batch_builder_produces_valid_batches() {
     // ensure expected transaction is in batch
     let expected_batch = Batch {
         transactions: vec![
-            transaction1.encoded_2718(),
-            transaction2.encoded_2718(),
-            transaction3.encoded_2718(),
+            transaction1.encoded_2718().into(),
+            transaction2.encoded_2718().into(),
+            transaction3.encoded_2718().into(),
         ],
         received_at: None,
         ..*first_batch.batch()
@@ -428,8 +421,7 @@ async fn test_batch_builder_produces_valid_batches() {
 /// Before a canonical state change, mine the 4th transaction in the next block.
 #[tokio::test]
 async fn test_canonical_notification_updates_pool() {
-    //
-    //
+    // execution layer
     // testnet genesis with TxFactory funded
     let genesis = test_genesis();
     let chain: Arc<RethChainSpec> = Arc::new(genesis.into());
@@ -506,8 +498,7 @@ async fn test_canonical_notification_updates_pool() {
     // spawn batch_builder once worker is ready
     let _batch_builder = tokio::spawn(batch_builder.run());
 
-    //
-    //
+    // test block flow
 
     // submit new transaction before sending ack
     let _ = tx_factory
@@ -527,9 +518,9 @@ async fn test_canonical_notification_updates_pool() {
     // ensure expected transaction is in batch
     let mut first_batch = Batch {
         transactions: vec![
-            transaction1.encoded_2718(),
-            transaction2.encoded_2718(),
-            transaction3.encoded_2718(),
+            transaction1.encoded_2718().into(),
+            transaction2.encoded_2718().into(),
+            transaction3.encoded_2718().into(),
         ],
         ..Default::default()
     };

--- a/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
@@ -170,7 +170,7 @@ async fn test_make_batch_el_to_cl() {
         ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
     );
 
-    let valid_batch_result = batch_validator.validate_batch(sealed_batch.clone()).await;
+    let valid_batch_result = batch_validator.validate_batch(&sealed_batch).await;
     assert!(valid_batch_result.is_ok());
 
     // ensure expected transaction is in batch
@@ -365,7 +365,7 @@ async fn test_batch_builder_produces_valid_batches() {
         ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
     );
 
-    let valid_batch_result = batch_validator.validate_batch(first_batch.clone()).await;
+    let valid_batch_result = batch_validator.validate_batch(&first_batch).await;
     assert!(valid_batch_result.is_ok());
 
     // ensure expected transaction is in batch
@@ -391,7 +391,7 @@ async fn test_batch_builder_produces_valid_batches() {
     let _ = ack.send(Ok(()));
 
     // validate second block
-    let valid_batch_result = batch_validator.validate_batch(next_batch.clone()).await;
+    let valid_batch_result = batch_validator.validate_batch(&next_batch).await;
     assert!(valid_batch_result.is_ok());
 
     // assert only transaction in block
@@ -594,7 +594,7 @@ async fn test_canonical_notification_updates_pool() {
             .await
             .expect("block builder's sender didn't drop")
             .expect("batch was built");
-        assert!(batch_validator.validate_batch(batch).await.is_ok());
+        assert!(batch_validator.validate_batch(&batch).await.is_ok());
         let _ = ack.send(Ok(()));
         tokio::task::yield_now().await;
     }

--- a/crates/consensus/worker/src/batch-validator/src/validator.rs
+++ b/crates/consensus/worker/src/batch-validator/src/validator.rs
@@ -74,7 +74,7 @@ impl BatchValidation for BatchValidator {
             return Ok(());
         }
 
-        // A validator belongs to a worker and that worker only handles batches with it's id.
+        // A validator belongs to a worker and that worker only handles batches with its id.
         if batch.worker_id != self.worker_id {
             return Err(BatchValidationError::InvalidWorkerId {
                 expected_worker_id: self.worker_id,
@@ -221,7 +221,7 @@ impl BatchValidator {
     /// Validate the size of transactions (in bytes).
     fn validate_batch_size_bytes(
         &self,
-        transactions: &[Vec<u8>],
+        transactions: &[Bytes],
         epoch: Epoch,
     ) -> BatchValidationResult<()> {
         // calculate size (in bytes) of included transactions
@@ -246,7 +246,7 @@ impl BatchValidator {
     #[inline]
     fn decode_transactions(
         &self,
-        transactions: &Vec<Vec<u8>>,
+        transactions: &Vec<Bytes>,
         digest: BlockHash,
     ) -> BatchValidationResult<Vec<TransactionSigned>> {
         transactions
@@ -877,7 +877,7 @@ mod tests {
 
             // track totals
             total_bytes += tx.len();
-            too_many_txs.push(tx);
+            too_many_txs.push(tx.into());
         }
 
         // NOTE: these assertions aren't important but want to know if tx size changes
@@ -915,7 +915,7 @@ mod tests {
         let expected_len = too_big.len();
         assert_eq!(expected_len, 2_000_090);
 
-        let invalid_txs = vec![too_big];
+        let invalid_txs = vec![too_big.into()];
         block.transactions = invalid_txs;
         // ensure size method correctly accounts for struct+txs
         assert_eq!(block.size(), 2_000_178);
@@ -953,7 +953,7 @@ mod tests {
         let (mut batch, _) = valid_batch.split();
 
         // test batch with bad decode
-        batch.transactions = vec![b"this is a bad batch".to_vec()];
+        batch.transactions = vec![b"this is a bad batch".to_vec().into()];
 
         assert_matches!(
             validator.validate_batch(batch.clone().seal_slow()).await,
@@ -1011,7 +1011,7 @@ mod tests {
         );
 
         // test batch with eip4844 tx
-        batch.transactions = vec![signed_tx.encoded_2718()];
+        batch.transactions = vec![signed_tx.encoded_2718().into()];
 
         assert_matches!(
             validator.validate_batch(batch.clone().seal_slow()).await,

--- a/crates/consensus/worker/src/batch-validator/src/validator.rs
+++ b/crates/consensus/worker/src/batch-validator/src/validator.rs
@@ -61,11 +61,12 @@ impl BatchValidation for BatchValidator {
     /// Validate a peer's batch.
     ///
     /// Workers do not execute full batches. This method validates the required information.
-    async fn validate_batch(&self, sealed_batch: SealedBatch) -> Result<(), BatchValidationError> {
+    async fn validate_batch(&self, sealed_batch: &SealedBatch) -> Result<(), BatchValidationError> {
         // ensure digest matches batch
-        let (batch, digest) = sealed_batch.split();
+        let batch = &sealed_batch.batch;
+        let digest = sealed_batch.digest();
 
-        let verified_hash = batch.clone().seal_slow().digest();
+        let verified_hash = batch.digest();
         if digest != verified_hash {
             return Err(BatchValidationError::InvalidDigest);
         }
@@ -103,8 +104,11 @@ impl BatchValidation for BatchValidator {
         // all batches for a worker and epoch share one base fee
         self.validate_basefee(batch.base_fee_per_gas)?;
 
-        self.validated_batches.retain(|_, v| *v > rayls_infrastructure_types::now() - 60_000); // keep last minute
-        self.validated_batches.insert(digest, rayls_infrastructure_types::now());
+        // `now()` is in seconds, so the dedup window is 60; sweep before insert so the map
+        // stays bounded by the recent-batch rate.
+        let now = rayls_infrastructure_types::now();
+        self.validated_batches.retain(|_, v| *v > now.saturating_sub(60));
+        self.validated_batches.insert(digest, now);
 
         Ok(())
     }
@@ -157,8 +161,9 @@ impl BatchValidation for BatchValidator {
 
             let tx_pool = tx_pool.clone();
             self.reth_env.get_task_spawner().spawn_task("submit-tx-batch", async move {
-                for tx in parsed_txns.into_iter().flatten() {
-                    match tx_pool.add_raw_transaction_external(tx).await {
+                let txs: Vec<_> = parsed_txns.into_iter().flatten().collect();
+                for res in tx_pool.add_raw_transactions_external(txs).await {
+                    match res {
                         Ok(_) => {}
                         // A hash this pool already holds is ordinary gossip dedup: multiple
                         // observers forward overlapping pools, and a forwarder re-sends what
@@ -365,7 +370,7 @@ pub struct NoopBatchValidator;
 #[cfg(any(test, feature = "test-utils"))]
 #[async_trait::async_trait]
 impl BatchValidation for NoopBatchValidator {
-    async fn validate_batch(&self, _batch: SealedBatch) -> Result<(), BatchValidationError> {
+    async fn validate_batch(&self, _batch: &SealedBatch) -> Result<(), BatchValidationError> {
         Ok(())
     }
 
@@ -669,18 +674,37 @@ mod tests {
 
     #[serial]
     #[tokio::test]
+    async fn dedup_cache_sweep_keeps_only_the_last_minute() {
+        let tmp_dir = TempDir::new().unwrap();
+        let task_manager = TaskManager::default();
+        let TestTools { valid_batch, validator } = test_tools(tmp_dir.path(), &task_manager).await;
+
+        // Seed an entry two minutes old; the sweep promises to keep only the last minute.
+        let stale = FixedBytes::<32>::random();
+        validator.validated_batches.insert(stale, rayls_infrastructure_types::now() - 120);
+
+        validator.validate_batch(&valid_batch).await.unwrap();
+
+        assert!(
+            !validator.validated_batches.contains_key(&stale),
+            "two-minute-old dedup entry survived the keep-last-minute sweep"
+        );
+    }
+
+    #[serial]
+    #[tokio::test]
     async fn test_valid_batch() {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();
         let TestTools { valid_batch, validator } = test_tools(tmp_dir.path(), &task_manager).await;
-        let result = validator.validate_batch(valid_batch.clone()).await;
+        let result = validator.validate_batch(&valid_batch.clone()).await;
         assert!(result.is_ok());
 
         // ensure non-serialized data does not affect validity
         let (mut batch, _) = valid_batch.split();
         batch.received_at = Some(rayls_infrastructure_types::now());
         let different_block = batch.seal_slow();
-        let result = validator.validate_batch(different_block).await;
+        let result = validator.validate_batch(&different_block).await;
         assert!(result.is_ok());
     }
 
@@ -706,7 +730,7 @@ mod tests {
             received_at,
         };
         assert_matches!(
-            validator.validate_batch(invalid_batch.seal_slow()).await,
+            validator.validate_batch(&invalid_batch.seal_slow()).await,
             Err(BatchValidationError::CanonicalChain { block_hash }) if block_hash == wrong_parent_hash
         );
     }
@@ -722,7 +746,7 @@ mod tests {
         batch.epoch += 1;
 
         assert_matches!(
-        validator.validate_batch(batch.clone().seal_slow()).await,
+        validator.validate_batch(&batch.clone().seal_slow()).await,
         Err(BatchValidationError::InvalidEpoch{expected, found}) if expected == 0 && found == 1
         );
     }
@@ -889,7 +913,7 @@ mod tests {
         let invalid_batch = block.clone().seal_slow();
 
         assert_matches!(
-            validator.validate_batch(invalid_batch).await,
+            validator.validate_batch(&invalid_batch).await,
             Err(BatchValidationError::HeaderTransactionBytesExceedsMax(wrong)) if wrong == total_bytes
         );
 
@@ -923,7 +947,7 @@ mod tests {
         // ensure size method correct accounts for struct+txs+digest
         assert_eq!(invalid_batch.size(), 2_000_210);
         assert_matches!(
-            validator.validate_batch(invalid_batch).await,
+            validator.validate_batch(&invalid_batch).await,
             Err(BatchValidationError::HeaderTransactionBytesExceedsMax(wrong)) if wrong == expected_len
         );
     }
@@ -939,7 +963,7 @@ mod tests {
         // test batch with no transactions
         batch.transactions = Vec::new();
         assert_matches!(
-            validator.validate_batch(batch.clone().seal_slow()).await,
+            validator.validate_batch(&batch.clone().seal_slow()).await,
             Err(BatchValidationError::EmptyBatch)
         );
     }
@@ -956,7 +980,7 @@ mod tests {
         batch.transactions = vec![b"this is a bad batch".to_vec().into()];
 
         assert_matches!(
-            validator.validate_batch(batch.clone().seal_slow()).await,
+            validator.validate_batch(&batch.clone().seal_slow()).await,
             Err(BatchValidationError::RecoverTransaction(_, _))
         );
     }
@@ -967,21 +991,21 @@ mod tests {
         let tmp_dir = TempDir::new().unwrap();
         let task_manager = TaskManager::default();
         let TestTools { valid_batch, validator } = test_tools(tmp_dir.path(), &task_manager).await;
-        // Note validator will use MIN_PROROCOL_BASE_FEE.
+        // Note validator will use MIN_PROTOCOL_BASE_FEE.
         let (mut batch, _) = valid_batch.split();
 
-        assert_matches!(validator.validate_batch(batch.clone().seal_slow()).await, Ok(()));
+        assert_matches!(validator.validate_batch(&batch.clone().seal_slow()).await, Ok(()));
 
         batch.base_fee_per_gas = 0;
         assert_matches!(
-            validator.validate_batch(batch.clone().seal_slow()).await,
+            validator.validate_batch(&batch.clone().seal_slow()).await,
             Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
         );
 
         let badfee = MIN_PROTOCOL_BASE_FEE * 100;
         batch.base_fee_per_gas = badfee;
         assert_matches!(
-            validator.validate_batch(batch.clone().seal_slow()).await,
+            validator.validate_batch(&batch.clone().seal_slow()).await,
             Err(BatchValidationError::InvalidBaseFee { expected_base_fee: _, base_fee: _ })
         );
     }
@@ -1014,7 +1038,7 @@ mod tests {
         batch.transactions = vec![signed_tx.encoded_2718().into()];
 
         assert_matches!(
-            validator.validate_batch(batch.clone().seal_slow()).await,
+            validator.validate_batch(&batch.clone().seal_slow()).await,
             Err(BatchValidationError::InvalidTx4844(_))
         );
     }

--- a/crates/consensus/worker/src/batch_fetcher.rs
+++ b/crates/consensus/worker/src/batch_fetcher.rs
@@ -1,21 +1,18 @@
-//! Fetch batches from peers
+//! Batch retrieval from local storage and remote workers.
 
 use crate::{metrics::WorkerMetrics, network::WorkerNetworkHandle};
 use async_trait::async_trait;
 use rayls_consensus_network::error::NetworkError;
 use rayls_infrastructure_storage::tables::Batches;
-use rayls_infrastructure_types::{now, Batch, BlockHash, Database, DbTxMut};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use rayls_infrastructure_types::{now, B256Map, B256Set, Batch, BlockHash, Database, DbTxMut};
+use std::{sync::Arc, time::Duration};
 use tracing::{debug, warn};
 
 #[cfg(test)]
 #[path = "tests/batch_fetcher.rs"]
 mod batch_fetcher_tests;
 
+/// Fetcher that fills missing batches from the local store first, then from peers.
 #[derive(Debug)]
 pub(crate) struct BatchFetcher<DB> {
     network: Arc<dyn RequestBatchesNetwork>,
@@ -40,11 +37,11 @@ impl<DB: Database> BatchFetcher<DB> {
     /// Retries up to [`Self::MAX_FETCH_RETRIES`] times. If some digests remain
     /// unfetchable (e.g. garbage-collected by peers), the partial result is
     /// returned so callers are not blocked indefinitely.
-    pub(crate) async fn fetch(&self, digests: HashSet<BlockHash>) -> HashMap<BlockHash, Batch> {
+    pub(crate) async fn fetch(&self, digests: B256Set) -> B256Map<Batch> {
         debug!(target: "batch_fetcher", "Attempting to fetch {} digests from peers", digests.len(),);
 
         let mut remaining_digests = digests;
-        let mut fetched_batches = HashMap::new();
+        let mut fetched_batches = B256Map::default();
         let mut retries = 0usize;
 
         loop {
@@ -65,7 +62,7 @@ impl<DB: Database> BatchFetcher<DB> {
             let _timer = self.metrics.worker_remote_fetch_latency.start_timer();
             if let Ok(new_batches) = self.safe_request_batches(&remaining_digests).await {
                 // Set received_at timestamp for remote batches.
-                let mut updated_new_batches = HashMap::new();
+                let mut updated_new_batches = B256Map::default();
                 for (digest, batch) in
                     new_batches.iter().filter(|(d, _)| remaining_digests.remove(*d))
                 {
@@ -107,14 +104,12 @@ impl<DB: Database> BatchFetcher<DB> {
         }
     }
 
-    async fn fetch_local(&self, digests: HashSet<BlockHash>) -> HashMap<BlockHash, Batch> {
-        let mut fetched_batches = HashMap::new();
+    async fn fetch_local(&self, digests: B256Set) -> B256Map<Batch> {
+        let mut fetched_batches = B256Map::default();
         if digests.is_empty() {
             return fetched_batches;
         }
 
-        // Continue to bulk request from local worker until no remaining digests
-        // are available.
         debug!(target: "batch_fetcher", "Local attempt to fetch {} digests", digests.len());
         if let Ok(local_batches) = self.batch_store.multi_get::<Batches>(digests.iter()) {
             for (digest, batch) in digests.into_iter().zip(local_batches.into_iter()) {
@@ -130,12 +125,13 @@ impl<DB: Database> BatchFetcher<DB> {
         fetched_batches
     }
 
-    /// Issue request_batches RPC and verifies response integrity
+    /// Requests the digests from peers; responses are trusted because each batch is already
+    /// covered by a certificate.
     async fn safe_request_batches(
         &self,
-        digests_to_fetch: &HashSet<BlockHash>,
-    ) -> Result<HashMap<BlockHash, Batch>, NetworkError> {
-        let mut fetched_batches = HashMap::new();
+        digests_to_fetch: &B256Set,
+    ) -> Result<B256Map<Batch>, NetworkError> {
+        let mut fetched_batches = B256Map::default();
         if digests_to_fetch.is_empty() {
             return Ok(fetched_batches);
         }
@@ -146,7 +142,6 @@ impl<DB: Database> BatchFetcher<DB> {
             .await?;
         for batch in batches {
             let batch_digest = batch.digest();
-            // This batch is part of a certificate, so no need to validate it.
             fetched_batches.insert(batch_digest, batch);
         }
 

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -191,15 +191,13 @@ fn collect_requested_batches_blocking<DB: Database>(
     max_response_size: usize,
     consensus_config: ConsensusConfig<DB>,
 ) -> WorkerNetworkResult<Vec<Batch>> {
-    // assume reasonable min is 1 encoded batch (no transactions)
-    // NOTE: caller needs to account for batches + msg overhead, and batches must have
-    // transactions
+    // the floor is one encoded empty batch; the requester must budget for batches plus message
+    // overhead on top
     if max_response_size < *LOCAL_MIN_REQUEST_SIZE {
         debug!(target: "cert-collector", "batch request max size too small: {}", max_response_size);
         return Err(WorkerNetworkError::InvalidRequest("Request size too small".into()));
     }
 
-    // return error for empty batches
     if batch_digests.is_empty() {
         debug!(target: "cert-collector", "batch request empty");
         return Err(WorkerNetworkError::InvalidRequest("Empty batch digests".into()));
@@ -271,36 +269,7 @@ fn collect_requested_batches_blocking<DB: Database>(
 
 // support IT tests
 #[cfg(any(test, feature = "test-utils"))]
-impl<DB> RequestHandler<DB>
-where
-    DB: Database,
-{
-    // /// Publicly available for tests.
-    // /// See [Self::process_gossip].
-    // pub async fn pub_process_gossip(&self, msg: &GossipMessage) -> WorkerNetworkResult<()> {
-    //     self.process_gossip(msg).await
-    // }
-
-    // /// Publicly available for tests.
-    // /// See [Self::process_report_batch].
-    // pub async fn pub_process_report_batch(
-    //     &self,
-    //     peer: &BlsPublicKey,
-    //     sealed_batch: SealedBatch,
-    // ) -> WorkerNetworkResult<()> {
-    //     self.process_report_batch(peer, sealed_batch).await
-    // }
-
-    // /// Publicly available for tests.
-    // /// See [Self::process_request_batches].
-    // pub async fn pub_process_request_batches(
-    //     &self,
-    //     batch_digests: Vec<BlockHash>,
-    //     max_response_size: usize,
-    // ) -> WorkerNetworkResult<Vec<Batch>> {
-    //     self.process_request_batches(batch_digests, max_response_size).await
-    // }
-}
+impl<DB> RequestHandler<DB> where DB: Database {}
 
 #[cfg(test)]
 mod tests {
@@ -354,7 +323,7 @@ mod tests {
         let store = config.node_storage().clone();
 
         // Equal-sized batches so the budget maps cleanly to a batch count.
-        let sample = Batch { transactions: vec![vec![1u8; 256]], ..Default::default() };
+        let sample = Batch { transactions: vec![vec![1u8; 256].into()], ..Default::default() };
         let batch_size = sample.size();
 
         const TOTAL: usize = 20;
@@ -390,12 +359,12 @@ mod tests {
         let store = config.node_storage().clone();
 
         let hot_digest = B256::repeat_byte(0x11);
-        let hot_batch = Batch { transactions: vec![vec![1u8; 64]], ..Default::default() };
+        let hot_batch = Batch { transactions: vec![vec![1u8; 64].into()], ..Default::default() };
         store.insert::<Batches>(&hot_digest, &hot_batch).expect("insert hot batch");
 
         // The cold batch exists only as a jar row plus its auxiliary-index entry, never hot.
         let cold_digest = B256::repeat_byte(0x22);
-        let cold_batch = Batch { transactions: vec![vec![2u8; 64]], ..Default::default() };
+        let cold_batch = Batch { transactions: vec![vec![2u8; 64].into()], ..Default::default() };
         let cold = store.cold().expect("cold attached");
         cold.batches().begin_epoch(1, 0).expect("begin epoch");
         cold.batches()
@@ -426,7 +395,7 @@ mod tests {
         let store = config.node_storage().clone();
 
         let hot = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
-        let hot_batch = Batch { transactions: vec![vec![1u8; 64]], ..Default::default() };
+        let hot_batch = Batch { transactions: vec![vec![1u8; 64].into()], ..Default::default() };
         for digest in &hot {
             store.insert::<Batches>(digest, &hot_batch).expect("insert hot batch");
         }
@@ -463,8 +432,8 @@ mod tests {
         let store = config.node_storage().clone();
 
         const PRESENT: usize = 4;
-        let within_cap = Batch { transactions: vec![vec![1u8; 64]], ..Default::default() };
-        let past_cap = Batch { transactions: vec![vec![2u8; 64]], ..Default::default() };
+        let within_cap = Batch { transactions: vec![vec![1u8; 64].into()], ..Default::default() };
+        let past_cap = Batch { transactions: vec![vec![2u8; 64].into()], ..Default::default() };
 
         // Stored batches sit on both sides of the cap, separated by a run of digests with nothing
         // stored. Misses cost no response bytes, so only the cap can decide where serving stops,

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -323,7 +323,8 @@ mod tests {
         let store = config.node_storage().clone();
 
         // Equal-sized batches so the budget maps cleanly to a batch count.
-        let sample = Batch { transactions: vec![vec![1u8; 256].into()], ..Default::default() };
+        let sample =
+            Batch { transactions: vec![Bytes::from(vec![1u8; 256])], ..Default::default() };
         let batch_size = sample.size();
 
         const TOTAL: usize = 20;
@@ -359,12 +360,14 @@ mod tests {
         let store = config.node_storage().clone();
 
         let hot_digest = B256::repeat_byte(0x11);
-        let hot_batch = Batch { transactions: vec![vec![1u8; 64].into()], ..Default::default() };
+        let hot_batch =
+            Batch { transactions: vec![Bytes::from(vec![1u8; 64])], ..Default::default() };
         store.insert::<Batches>(&hot_digest, &hot_batch).expect("insert hot batch");
 
         // The cold batch exists only as a jar row plus its auxiliary-index entry, never hot.
         let cold_digest = B256::repeat_byte(0x22);
-        let cold_batch = Batch { transactions: vec![vec![2u8; 64].into()], ..Default::default() };
+        let cold_batch =
+            Batch { transactions: vec![Bytes::from(vec![2u8; 64])], ..Default::default() };
         let cold = store.cold().expect("cold attached");
         cold.batches().begin_epoch(1, 0).expect("begin epoch");
         cold.batches()
@@ -395,7 +398,8 @@ mod tests {
         let store = config.node_storage().clone();
 
         let hot = [B256::repeat_byte(0x11), B256::repeat_byte(0x22)];
-        let hot_batch = Batch { transactions: vec![vec![1u8; 64].into()], ..Default::default() };
+        let hot_batch =
+            Batch { transactions: vec![Bytes::from(vec![1u8; 64])], ..Default::default() };
         for digest in &hot {
             store.insert::<Batches>(digest, &hot_batch).expect("insert hot batch");
         }
@@ -432,8 +436,10 @@ mod tests {
         let store = config.node_storage().clone();
 
         const PRESENT: usize = 4;
-        let within_cap = Batch { transactions: vec![vec![1u8; 64].into()], ..Default::default() };
-        let past_cap = Batch { transactions: vec![vec![2u8; 64].into()], ..Default::default() };
+        let within_cap =
+            Batch { transactions: vec![Bytes::from(vec![1u8; 64])], ..Default::default() };
+        let past_cap =
+            Batch { transactions: vec![Bytes::from(vec![2u8; 64])], ..Default::default() };
 
         // Stored batches sit on both sides of the cap, separated by a run of digests with nothing
         // stored. Misses cost no response bytes, so only the cap can decide where serving stops,

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -148,7 +148,7 @@ where
 
         let client = self.consensus_config.local_network().clone();
         let store = self.consensus_config.node_storage().clone();
-        self.validator.validate_batch(sealed_batch.clone()).await?;
+        self.validator.validate_batch(&sealed_batch).await?;
 
         let (mut batch, digest) = sealed_batch.split();
 

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -77,7 +77,7 @@ where
                     WorkerNetworkError::InvalidTopic
                 );
                 let store = self.consensus_config.node_storage();
-                if !matches!(store.get::<Batches>(&batch_hash), Ok(Some(_))) {
+                if !store.contains_key::<Batches>(&batch_hash).unwrap_or(false) {
                     // A committee member already holds the batch; a non-committee node prefetches
                     // what it will soon need.
                     match self.network_handle.request_batches(vec![batch_hash]).await {

--- a/crates/consensus/worker/src/network/handler.rs
+++ b/crates/consensus/worker/src/network/handler.rs
@@ -142,7 +142,7 @@ where
         sealed_batch: SealedBatch,
     ) -> WorkerNetworkResult<()> {
         // return error if reporter isn't in current committee
-        if !self.consensus_config.committee_pub_keys().contains(peer) {
+        if self.consensus_config.committee().authority_by_key(peer).is_none() {
             return Err(WorkerNetworkError::NonCommitteeBatch);
         }
 

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -17,8 +17,8 @@ use rayls_infrastructure_network_types::{
 };
 use rayls_infrastructure_storage::tables::Batches;
 use rayls_infrastructure_types::{
-    encode, now, Batch, BatchValidation, BlockHash, BlsPublicKey, Bytes, Database, DbTxMut,
-    RaylsReceiver, SealedBatch, TaskKind, TaskSpawner, TxHash, WorkerId,
+    encode, now, B256Set, Batch, BatchValidation, BlockHash, BlsPublicKey, Bytes, Database,
+    DbTxMut, RaylsReceiver, SealedBatch, TaskKind, TaskSpawner, TxHash, WorkerId,
 };
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::sync::{oneshot, Semaphore};
@@ -265,18 +265,15 @@ impl WorkerNetworkHandle {
     ) -> NetworkResult<Vec<Batch>> {
         let mut peers = self.handle.connected_peers().await?;
         if requested_digests.is_empty() || peers.is_empty() {
-            // Nothing to do, either no digests requested or no one to ask.
-            // Return nothing.
+            // nothing requested or no one to ask
             return Ok(vec![]);
         }
         let mut remaining_digests = requested_digests.clone();
         let num_peers = peers.len();
         let mut all_batches = Vec::new();
-        // Attempt to try different batches with different peers.
-        // Ideally this will work first time and spread out the network traffic.
-        // It is possible for this algorithm to send same batches to the same peer,
-        // it is not that precise but should mix up things sufficiently to get batches
-        // if peers have them.
+        // Spread digests across peers and rotate the assignment each round so load is shared and
+        // a digest one peer lacks is asked of another. The rotation is approximate: a digest may
+        // land on the same peer twice.
         for _ in 0..num_peers {
             let mut batch_of_batches = Vec::with_capacity(num_peers);
             (0..num_peers).for_each(|_| batch_of_batches.push(vec![]));
@@ -303,13 +300,11 @@ impl WorkerNetworkHandle {
                         for batch in batches {
                             let batch_digest = batch.digest();
                             if requested_digests.contains(&batch_digest) {
-                                // Sanity check we actually asked for this digest...
                                 if !all_batches.contains(&batch) {
                                     remaining_digests.retain(|d| *d != batch_digest);
                                     all_batches.push(batch);
                                 }
                             } else {
-                                // Got a batch we did not ask for...
                                 warn!(target: "worker::network", "recieved a batch not requested {batch_digest}");
                             }
                         }
@@ -646,7 +641,7 @@ impl<DB: Database> PrimaryToWorkerClient for PrimaryReceiverHandler<DB> {
         Err(eyre::eyre!("failed to synchronize batches!".to_string()))
     }
 
-    async fn fetch_batches(&self, digests: HashSet<BlockHash>) -> eyre::Result<FetchBatchResponse> {
+    async fn fetch_batches(&self, digests: B256Set) -> eyre::Result<FetchBatchResponse> {
         let Some(batch_fetcher) = self.batch_fetcher.as_ref() else {
             return Err(eyre::eyre!(
                 "fetch_batches() is unsupported via RPC interface, please call via local worker handler instead".to_string(),

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -611,7 +611,7 @@ impl<DB: Database> PrimaryToWorkerClient for PrimaryReceiverHandler<DB> {
         for sealed_batch in sealed_batches_from_response.into_iter() {
             if !message.is_certified {
                 // This batch is not part of a certificate, so we need to validate it.
-                if let Err(err) = self.validator.validate_batch(sealed_batch.clone()).await {
+                if let Err(err) = self.validator.validate_batch(&sealed_batch).await {
                     return Err(eyre::eyre!("Invalid batch: {err}"));
                 }
             }

--- a/crates/consensus/worker/src/network/mod.rs
+++ b/crates/consensus/worker/src/network/mod.rs
@@ -582,12 +582,12 @@ impl<DB: Database> PrimaryToWorkerClient for PrimaryReceiverHandler<DB> {
         let mut missing = HashSet::new();
         for digest in message.digests.iter() {
             // Check if we already have the batch.
-            match self.store.get::<Batches>(digest) {
-                Ok(None) => {
+            match self.store.contains_key::<Batches>(digest) {
+                Ok(false) => {
                     missing.insert(*digest);
                     debug!("Requesting sync for batch {digest}");
                 }
-                Ok(Some(_)) => {
+                Ok(true) => {
                     trace!("Digest {digest} already in store, nothing to sync");
                 }
                 Err(e) => {

--- a/crates/consensus/worker/src/quorum_waiter.rs
+++ b/crates/consensus/worker/src/quorum_waiter.rs
@@ -1,7 +1,6 @@
 //! Wait for a quorum of acks from workers before sharing with the primary.
 
 use crate::{metrics::WorkerMetrics, network::WorkerNetworkHandle};
-use consensus_metrics::monitored_future;
 use futures::stream::{futures_unordered::FuturesUnordered, StreamExt as _};
 use rayls_consensus_network::error::NetworkError;
 use rayls_infrastructure_types::{
@@ -16,20 +15,15 @@ use tokio::sync::oneshot;
 
 use tracing::debug;
 
-/// Interface to QuorumWaiter, exists primarily for tests.
+/// Interface to the quorum waiter, indirected so tests can substitute it.
 pub trait QuorumWaiterTrait: Send + Sync + Clone + Unpin + 'static {
-    /// Send a batch to committee peers in an attempt to get quorum on it's validity.
+    /// Sends a batch to committee peers and resolves once its quorum outcome is known.
     ///
-    /// Returns a JoinHandle to a future that will timeout.  Each peer attempt can:
-    /// - Accept the batch and it's stake to quorum
-    /// - Reject the batch explicitly in which case it's stake will never be added to quorum (can
-    ///   cause total batch rejection)
-    /// - Have an error of some type stopping it's stake from adding to quorum but possibly not
-    ///   forever
-    ///
-    /// If the future resolves to Ok then the batch has reached quorum other wise examine the error.
-    /// An error of QuorumWaiterError::QuorumRejected indicates the batch will never be accepted
-    /// otherwise it might be possible if the network improves.
+    /// The receiver yields `Ok` once a quorum of stake has acked the batch, within `timeout`.
+    /// Each peer can accept (adding its stake), reject explicitly (its stake is lost for good and
+    /// may make quorum impossible), or fail transiently (its stake is lost for this attempt).
+    /// [`QuorumWaiterError::QuorumRejected`] is permanent; the other errors may clear if the
+    /// network recovers.
     fn verify_batch(
         &self,
         batch: SealedBatch,
@@ -44,7 +38,7 @@ struct QuorumWaiterInner {
     authority: Authority,
     /// The committee information.
     committee: Committee,
-    /// A network sender to broadcast the batches to the other workers.
+    /// A network sender to publish the batches to the other workers.
     network: WorkerNetworkHandle,
     /// Record metrics for quorum waiter.
     metrics: Arc<WorkerMetrics>,
@@ -67,33 +61,30 @@ impl QuorumWaiter {
         Self { inner: Arc::new(QuorumWaiterInner { authority, committee, network, metrics }) }
     }
 
-    /// Helper function. It waits for a future to complete and then delivers a value.
+    /// Awaits one peer's ack and maps it to that peer's stake, or to an error carrying it.
     async fn waiter(
         bls: BlsPublicKey,
         wait_for: oneshot::Receiver<Result<(), NetworkError>>,
         deliver: VotingPower,
     ) -> Result<VotingPower, WaiterError> {
         match wait_for.await {
-            Ok(r) => {
-                match r {
-                    Ok(_) => Ok(deliver),
-                    Err(NetworkError::RPCError(msg)) => {
-                        tracing::error!(
-                            target = "worker::quorum_waiter",
-                            "RPCError, peer {bls}: {msg}"
-                        );
-                        Err(WaiterError::Rejected(deliver))
-                    }
-                    // Non-exhaustive enum...
-                    Err(err) => {
-                        tracing::error!(
-                            target = "worker::quorum_waiter",
-                            "Network error, peer {bls}: {err:?}"
-                        );
-                        Err(WaiterError::Network(deliver))
-                    }
+            Ok(r) => match r {
+                Ok(_) => Ok(deliver),
+                Err(NetworkError::RPCError(msg)) => {
+                    tracing::error!(
+                        target = "worker::quorum_waiter",
+                        "RPCError, peer {bls}: {msg}"
+                    );
+                    Err(WaiterError::Rejected(deliver))
                 }
-            }
+                Err(err) => {
+                    tracing::error!(
+                        target = "worker::quorum_waiter",
+                        "Network error, peer {bls}: {err:?}"
+                    );
+                    Err(WaiterError::Network(deliver))
+                }
+            },
             Err(_) => Err(WaiterError::Network(deliver)),
         }
     }
@@ -113,37 +104,29 @@ impl QuorumWaiterTrait for QuorumWaiter {
         task_spawner.spawn_task(task_name, async move {
             let timeout_res = tokio::time::timeout(timeout, async move {
                 let start_time = Instant::now();
-                // Broadcast the batch to the other workers.
+                // Publish the batch to the other workers.
                 let peers: Vec<_> =
                     inner.committee.others_keys_except(inner.authority.protocol_key());
                 let handlers = inner.network.report_batch_to_peers(&peers, sealed_batch);
                 let _timer = inner.metrics.batch_broadcast_quorum_latency.start_timer();
 
                 // Collect all the handlers to receive acknowledgements.
-                let mut wait_for_quorum: FuturesUnordered<
-                    oneshot::Receiver<Result<VotingPower, WaiterError>>,
-                > = FuturesUnordered::new();
+                let mut wait_for_quorum = FuturesUnordered::new();
                 // Total stake available for the entire committee.
                 // Can use this to determine anti-quorum more quickly.
                 let mut available_stake: u64 = 0;
                 // Stake from a committee member that has rejected this batch.
                 let mut rejected_stake: u64 = 0;
+                // Each waiter is only an await on a peer ack, so it runs inline in the
+                // FuturesUnordered; a task per peer would cost a task and a channel per peer per
+                // batch for no concurrency gain.
                 peers
                     .into_iter()
-                    .zip(handlers.into_iter().enumerate())
-                    .map(|(name, (i, handler))| {
+                    .zip(handlers.into_iter())
+                    .map(|(name, handler)| {
                         let stake = inner.committee.voting_power(&name);
                         available_stake = available_stake.saturating_add(stake);
-                        let (tx, rx) = oneshot::channel();
-                        let task_name = format!("qw-peer-{i}");
-                        spawner_clone.spawn_task(task_name, {
-                            monitored_future!(async move {
-                                // forward result through oneshot channel
-                                let res = Self::waiter(name, handler, stake).await;
-                                let _ = tx.send(res);
-                            })
-                        });
-                        rx
+                        Self::waiter(name, handler, stake)
                     })
                     .for_each(|f| wait_for_quorum.push(f));
 
@@ -179,7 +162,7 @@ impl QuorumWaiterTrait for QuorumWaiter {
                         break Ok(());
                     }
                     if let Some(res) = wait_for_quorum.next().await {
-                        match res? {
+                        match res {
                             Ok(stake) => {
                                 total_stake = total_stake.saturating_add(stake);
                                 available_stake = available_stake.saturating_sub(stake);
@@ -257,18 +240,25 @@ impl QuorumWaiterTrait for QuorumWaiter {
     }
 }
 
+/// Reasons a batch failed to reach quorum.
 #[derive(Clone, Debug, Error)]
 pub enum QuorumWaiterError {
+    /// Enough stake rejected the batch that quorum can never be reached.
     #[error("Block was rejected by enough peers to never reach quorum")]
     QuorumRejected,
+    /// Too much stake is unreachable for quorum this attempt; may clear if the network recovers.
     #[error("Anti quorum reached for batch (note this may not be permanent)")]
     AntiQuorum,
+    /// The quorum deadline elapsed.
     #[error("Timed out waiting for quorum")]
     Timeout,
+    /// A network failure prevented the attempt.
     #[error("Network Error")]
     Network,
+    /// A peer returned an RPC status error.
     #[error("RPC Status Error {0}")]
     Rpc(String),
+    /// The waiter task dropped its result channel.
     #[error("Oneshot receiver dropped.")]
     DroppedReceiver,
 }
@@ -279,6 +269,7 @@ impl From<oneshot::error::RecvError> for QuorumWaiterError {
     }
 }
 
+/// Per-peer failure, carrying the stake that outcome removes from the running tally.
 #[derive(Clone, Debug, Error)]
 enum WaiterError {
     #[error("Block was rejected by peer")]

--- a/crates/consensus/worker/src/tests/batch_fetcher.rs
+++ b/crates/consensus/worker/src/tests/batch_fetcher.rs
@@ -1,9 +1,10 @@
-//! Batch fetcher tests
+//! Batch fetcher tests.
 use super::*;
 use crate::test_utils::TestRequestBatchesNetwork;
 use rayls_execution_evm::test_utils::transaction;
 use rayls_infrastructure_storage::open_db;
 use rayls_infrastructure_types::test_chain_spec_arc;
+use std::collections::{HashMap, HashSet};
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -259,7 +260,7 @@ async fn test_fetcher_returns_partial_on_unfetchable_digests() {
     let batch2 = Batch { transactions: vec![transaction(chain)], ..Default::default() };
     let unfetchable_digest = batch2.digest();
 
-    // Only put batch1 on the network — batch2 is nowhere.
+    // Only put batch1 on the network; batch2 is nowhere.
     network.put(&[1, 2], batch1.clone()).await;
 
     let digests = HashSet::from_iter(vec![batch1.digest(), unfetchable_digest]);
@@ -272,7 +273,7 @@ async fn test_fetcher_returns_partial_on_unfetchable_digests() {
     // Must complete (not hang forever) and return only batch1.
     let fetched = tokio::time::timeout(std::time::Duration::from_secs(15), fetcher.fetch(digests))
         .await
-        .expect("fetch must not hang — MAX_FETCH_RETRIES should bound it");
+        .expect("fetch must not hang - MAX_FETCH_RETRIES should bound it");
 
     assert!(fetched.contains_key(&batch1.digest()), "fetchable batch must be returned");
     assert!(

--- a/crates/consensus/worker/src/worker.rs
+++ b/crates/consensus/worker/src/worker.rs
@@ -1,7 +1,7 @@
 //! The receiving side of the execution layer's `BatchProvider`.
 //!
 //! Consensus `BatchProvider` takes a batch from the EL, stores it,
-//! and sends it to the quorum waiter for broadcasting to peers.
+//! and sends it to the quorum waiter for publishing to peers.
 
 use crate::{
     batch_fetcher::BatchFetcher,
@@ -152,15 +152,15 @@ pub struct Worker<DB, QW> {
     id: WorkerId,
     /// Use `QuorumWaiter` to attest to batches.
     quorum_waiter: Option<QW>,
-    /// Metrics handler
+    /// Metrics handler.
     node_metrics: Arc<WorkerMetrics>,
     /// The network client to send our batches to the primary.
     client: LocalNetwork,
     /// The batch store to store our own batches.
     store: DB,
-    /// Channel sender for alternate batch submision if not calling seal directly.
+    /// Channel sender for alternate batch submission if not calling seal directly.
     tx_batches: BatchSender,
-    /// Channel receiver for alternate batch submision if not calling seal directly.
+    /// Channel receiver for alternate batch submission if not calling seal directly.
     /// This will be "taken" on batch spawn and become None.
     rx_batches: Option<BatchReceiver>,
     /// The amount of time to wait on a reply from peer before timing out.
@@ -171,9 +171,8 @@ pub struct Worker<DB, QW> {
     batch_tracker: Option<Arc<BatchTracker>>,
 }
 
-// Need to imlement clone directly because of the rx_batches field.
-// This field is a use once field when spawning the batch manager so this is fine.
-// Code will panic quickly if this is messed up.
+// Manual impl: `rx_batches` is consumed once by `spawn_batch_builder`, so a clone starts without
+// it; a clone that tries to spawn panics immediately on the `take`.
 impl<DB: Clone, QW: Clone> Clone for Worker<DB, QW> {
     fn clone(&self) -> Self {
         Self {
@@ -224,8 +223,8 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         }
     }
 
-    /// Spawn a little task to accept batches from a channel and seal them that way.
-    /// Allows the engine to remain removed from the worker.
+    /// Spawns the task that seals batches arriving on the submit channel, keeping the engine
+    /// decoupled from the worker.
     pub fn spawn_batch_builder(&mut self, prefix: &str, task_manager: &TaskManager) {
         let this_clone = self.clone();
         let mut rx_batches = self.rx_batches.take().expect("have batch receive");
@@ -235,6 +234,14 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
             async move {
                 loop {
                     tokio::select! {
+                        // shutdown wins: a drained batch-builder must stop sealing promptly so
+                        // the epoch transition is not held by another seal round trip
+                        biased;
+
+                        _ = &rx_shutdown => {
+                            info!(target: "worker::batch_provider", "shutdown received, exiting batch-builder loop");
+                            break;
+                        }
                         batch = rx_batches.recv() => {
                             let Some((batch, sender_nonce_ranges, tx)) = batch else {
                                 break;
@@ -247,10 +254,6 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
                             if tx.send(res).is_err() {
                                 error!(target: "worker::batch_provider", "Error sending result to channel caller!  Channel closed.");
                             }
-                        }
-                        _ = &rx_shutdown => {
-                            info!(target: "worker::batch_provider", "shutdown received, exiting batch-builder loop");
-                            break;
                         }
                     }
                 }
@@ -336,7 +339,7 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
         Ok(())
     }
 
-    /// Seal and broadcast the current batch.
+    /// Seals and publishes the current batch.
     pub async fn seal(
         &self,
         sealed_batch: SealedBatch,
@@ -380,10 +383,8 @@ impl<DB: Database, QW: QuorumWaiterTrait> Worker<DB, QW> {
                             return Err(BlockSealError::FatalDBFailure);
                         }
 
-                        // Publish the digest for any nodes listening to this gossip (non-committee
-                        // members). Note, ignore error- this should not
-                        // happen and should not cause an issue (except the
-                        // underlying p2p network may be in trouble but that will manifest quickly).
+                        // Publish the digest for non-committee listeners. A publish error is
+                        // ignored: it only signals a p2p problem that surfaces elsewhere quickly.
                         let _ = self.network_handle.publish_batch(digest).await;
                     }
                     Err(e) => {

--- a/crates/execution/evm/benches/lib.rs
+++ b/crates/execution/evm/benches/lib.rs
@@ -5,17 +5,16 @@ use rand::{rngs::StdRng, SeedableRng as _};
 use rayls_execution_evm::{
     reth_env::types::reth_recover_raw_transactions, test_utils::TransactionFactory,
 };
-use rayls_infrastructure_types::{TransactionSigned, U256};
+use rayls_infrastructure_types::{Bytes, TransactionSigned, U256};
 use reth::rpc::server_types::eth::utils::recover_raw_transaction as reth_recover_raw_transaction;
 use std::sync::Arc;
 use tracing::error;
 
-/// Helper to generate a list of dummy signed transactions as Vec<u8>.
-fn generate_dummy_transactions(count: usize) -> Vec<Vec<u8>> {
+/// Generates `count` deterministic signed transactions, encoded as [`Bytes`].
+fn generate_dummy_transactions(count: usize) -> Vec<Bytes> {
     let mut rng = StdRng::seed_from_u64(42);
     let mut txs = Vec::with_capacity(count);
     for _ in 0..count {
-        // Use TransactionFactory to generate a random transaction and encode it
         let mut tf = TransactionFactory::new_random_from_seed(&mut rng);
         let tx = tf.create_eip1559_encoded(
             Arc::new(rayls_infrastructure_types::test_genesis().into()),
@@ -45,7 +44,7 @@ fn test_reth_recover_raw_transactions_sequentialbench(c: &mut Criterion) {
     let txs = generate_dummy_transactions(200);
     let batch_digest = Some(FixedBytes::<32>::ZERO);
 
-    let rec_fn = |tx_bytes: &Vec<u8>| {
+    let rec_fn = |tx_bytes: &Bytes| {
         reth_recover_raw_transaction::<TransactionSigned>(tx_bytes).inspect_err(|e| {
             error!(
                 target: "engine",

--- a/crates/execution/evm/src/evm/config.rs
+++ b/crates/execution/evm/src/evm/config.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use alloy::eips::eip7685::EMPTY_REQUESTS_HASH;
 use rayls_infrastructure_types::{
-    payload::RLPayload, Address, BlockHeader as _, SealedBlock, SealedHeader, B256,
-    EMPTY_OMMER_ROOT_HASH, U256,
+    payload::RLPayload, BlockHeader as _, SealedBlock, SealedHeader, B256, EMPTY_OMMER_ROOT_HASH,
+    U256,
 };
 use rayls_middleware_rewards::RewardsCounter;
 use reth_chainspec::{EthChainSpec as _, EthereumHardforks as _};

--- a/crates/execution/evm/src/reth_env/execution.rs
+++ b/crates/execution/evm/src/reth_env/execution.rs
@@ -14,7 +14,7 @@ use alloy::{
 };
 use alloy_evm::{revm::context_interface::result::InvalidTransaction, Evm};
 use rayls_infrastructure_types::{
-    payload::RLPayload, BlockNumHash, RecoveredBlock, TransactionSigned, B256, U256,
+    payload::RLPayload, BlockNumHash, Bytes, RecoveredBlock, TransactionSigned, B256, U256,
 };
 use reth_chain_state::{
     ComputedTrieData, DeferredTrieData, ExecutedBlock, LazyOverlay, MemoryOverlayStateProvider,
@@ -45,27 +45,23 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 impl RethEnv {
-    /// Whether every transaction in `transactions` is still pending against the latest state —
-    /// i.e. each tx's nonce is at or ahead of its sender's current account nonce.
+    /// Returns whether every transaction in `transactions` is still pending against the latest
+    /// state, i.e. `tx.nonce >= account.nonce` for its sender.
     ///
-    /// "Pending" here is `tx.nonce >= account.nonce` (at or ahead — the txn hasn't been mined yet);
-    /// the typical retryable case is strictly ahead (nonce-too-high), but a tx exactly at the
-    /// current nonce also counts as pending.
+    /// Restart dedup reconstruction uses this to tell two empty blocks apart: a batch whose
+    /// transactions are still pending produced an empty block only because they were not yet
+    /// executable and is retryable; a batch whose transactions are already mined (nonce too low)
+    /// is done and must stay deduped, or a restart re-executes it and forks the chain.
     ///
-    /// Used by restart dedup reconstruction to tell two empty blocks apart: a batch whose txns are
-    /// still pending produced an empty block only because they aren't yet executable and is
-    /// genuinely retryable; a batch whose txns are already mined (nonce-too-low) is done and must
-    /// stay deduped, else a restart re-executes it and forks the chain.
-    ///
-    /// Conservative: returns `false` for an empty input, if any tx is already mined, or on any
-    /// decode/state error — never reports "retryable" unless it can positively prove it.
-    pub fn batch_txns_all_pending(&self, transactions: &[Vec<u8>]) -> bool {
+    /// Conservative: `false` for an empty input, any already-mined transaction, or any decode or
+    /// state error, so "retryable" is only reported when it can be proven.
+    pub fn batch_txns_all_pending(&self, transactions: &[Bytes]) -> bool {
         if transactions.is_empty() {
             return false;
         }
         let Ok(state) = self.latest() else { return false };
-        // `None` batch_digest: recovery errors here won't carry the digest in their log context,
-        // which is fine — an undecodable tx just makes the batch non-retryable below.
+        // No batch digest for log context: an undecodable tx only makes the batch non-retryable
+        // below.
         for res in reth_recover_raw_transactions(None, transactions) {
             let Ok(recovered) = res else { return false };
             let sender = recovered.signer();
@@ -91,7 +87,7 @@ impl RethEnv {
     pub fn build_block_from_batch_payload(
         &self,
         payload: RLPayload,
-        transactions: &[Vec<u8>],
+        transactions: &[Bytes],
         local_chain: &[ExecutedBlock],
     ) -> RaylsRethResult<(ExecutedBlock, TxValidationCounts)> {
         let parent_header = payload.parent_header.clone();
@@ -133,7 +129,7 @@ impl RethEnv {
 
         // The cache uses get_canonical_block_number() (an atomic on
         // ChainInfoTracker) as its key.  update_chain() inserts blocks into
-        // CIM's maps but does NOT advance that atomic — set_canonical_head()
+        // CIM's maps but does NOT advance that atomic; set_canonical_head()
         // only runs later in finish_executing_output().  So for blocks 2..M
         // in a round the cache returns stale input missing prior blocks'
         // hashed_state + trie_updates.  Extend explicitly with local_chain.
@@ -213,7 +209,7 @@ impl RethEnv {
         let ctx_for_assembler = ctx.clone();
         let mut builder = self.evm_config.create_block_builder(evm, &parent_header, ctx);
 
-        // attach state_hook to the executor if Tier 1 is active — the hook
+        // attach state_hook to the executor if Tier 1 is active; the hook
         // sends per-transaction state diffs to the multiproof/sparse trie task
         let sparse_root_fn = if let Some((state_hook, sparse_root_fn)) = sparse_setup {
             builder.executor_mut().set_state_hook(Some(state_hook));
@@ -274,14 +270,13 @@ impl RethEnv {
 
             committed_txs.push(recovered.clone());
 
-            // update add to total fees
             let miner_fee = recovered
                 .effective_tip_per_gas(basefee)
                 .expect("fee is always valid; execution succeeded");
             total_fees += U256::from(miner_fee) * U256::from(gas_used);
         }
 
-        // Phase 2: finish the executor — runs post-execution system calls
+        // Phase 2: finish the executor: runs post-execution system calls
         // (epoch closing) and drops the state_hook, which signals the sparse
         // trie to begin finalizing
         let finish_start = std::time::Instant::now();
@@ -295,7 +290,7 @@ impl RethEnv {
         // Phase 4: compute hashed post state from bundle
         let hashed_state = state_provider.hashed_post_state(&db.bundle_state);
 
-        // Phase 5: compute state root — SDK handles sparse trie internally
+        // Phase 5: compute state root: SDK handles sparse trie internally
         let mut tier_label;
         let (state_root, trie_updates) = if let Some(sparse_root_fn) = sparse_root_fn {
             tier_label = "sparse";
@@ -362,7 +357,7 @@ impl RethEnv {
         let trie_updates_sorted = Arc::new(trie_updates.into_sorted());
 
         // compute trie changesets (old node values before this block) and cache
-        // them for the parallel state root overlay. This is cheap — just cursor
+        // them for the parallel state root overlay. This is cheap: just cursor
         // reads of old trie node values, no state root recomputation.
         {
             if let Ok(db_provider) = self.blockchain_provider.database_provider_ro() {
@@ -501,10 +496,10 @@ impl RethEnv {
             first=?blocks.first().map(|b| b.recovered_block.num_hash()),
             last=?blocks.last().map(|b| b.recovered_block.num_hash()),
             count = blocks.len(),
-            "finalizing output — updating head + notifications",
+            "finalizing output - updating head + notifications",
         );
 
-        // Build notification from blocks (cheap — blocks contain Arcs).
+        // Build notification from blocks (cheap: blocks contain Arcs).
         // Blocks are already in CIM from build_block_from_batch_payload.
         let notification = NewCanonicalChain::Commit { new: blocks }.to_chain_notification();
         canonical_in_memory_state.set_canonical_head(sealed_head.clone());

--- a/crates/execution/evm/src/reth_env/solver.rs
+++ b/crates/execution/evm/src/reth_env/solver.rs
@@ -25,18 +25,15 @@ use tracing::{debug, warn};
 pub type CanonicalRootOracle = Box<dyn Fn(u64) -> Option<B256> + Send + Sync>;
 
 impl RethEnv {
-    /// Return the sorted base ancestor overlay (the non-persisted window),
-    /// memoized by `(last_persisted, canonical_head)`. Mirrors
-    /// [`Self::cached_ancestor_trie_input`] over sorted types:
-    ///
-    /// 1. Exact hit: clone the two cached `Arc`s.
-    /// 2. Incremental extend: merge the newly-canonical blocks' deltas with `extend_ref_and_sort`
-    ///    (a linear merge) instead of re-sorting the window.
-    /// 3. Full recompute: sort the base overlay once when `last_persisted` changed.
+    /// Return the sorted base ancestor overlay (the non-persisted window), memoized by
+    /// `(last_persisted, canonical_head)`. Mirrors [`Self::cached_ancestor_trie_input`] over
+    /// sorted types in three tiers: (1) an exact hit clones the two cached `Arc`s; (2) a head
+    /// advance merges the newly-canonical blocks' deltas with `extend_ref_and_sort` (a linear
+    /// merge) instead of re-sorting the window; (3) a `last_persisted` change sorts the base
+    /// overlay once.
     ///
     /// Lock ordering: `persistence_state` is read before the sorted-cache lock, and
-    /// `cached_ancestor_trie_input` runs only on the recompute path with the lock
-    /// released.
+    /// `cached_ancestor_trie_input` runs only on the recompute path with the lock released.
     pub(super) fn cached_sorted_ancestor_input(
         &self,
     ) -> (Arc<HashedPostStateSorted>, Arc<TrieUpdatesSorted>) {
@@ -182,7 +179,7 @@ mod tests {
     use rayls_infrastructure_config::NodeInfo;
     use rayls_infrastructure_types::{
         generate_proof_of_possession_bls, payload::RLPayload, Address, BlsKeypair, BlsSignature,
-        Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput, GenesisAccount,
+        Bytes, Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput, GenesisAccount,
         NodeP2pInfo, ReputationScores, SealedHeader, SignatureVerificationState, TaskManager, B256,
         U256,
     };
@@ -226,7 +223,7 @@ mod tests {
     fn execute_and_advance_head(
         reth_env: &RethEnv,
         payload: RLPayload,
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Bytes>,
     ) -> eyre::Result<ExecutedBlock> {
         let (block, _counts) =
             reth_env.build_block_from_batch_payload(payload, &transactions, &[])?;

--- a/crates/execution/evm/src/reth_env/tests.rs
+++ b/crates/execution/evm/src/reth_env/tests.rs
@@ -3,7 +3,7 @@ use alloy::{primitives::utils::parse_ether, sol_types::SolCall};
 use rand::{rngs::StdRng, SeedableRng as _};
 use rayls_infrastructure_config::{NodeInfo, RLS_IMPL_ADDRESS};
 use rayls_infrastructure_types::{
-    generate_proof_of_possession_bls, payload::RLPayload, Address, BlsKeypair, BlsSignature,
+    generate_proof_of_possession_bls, payload::RLPayload, Address, BlsKeypair, BlsSignature, Bytes,
     Certificate, CommittedSubDag, ConsensusHeader, ConsensusOutput, GenesisAccount, NodeP2pInfo,
     ReputationScores, SignatureVerificationState, TaskManager, B256, U256,
 };
@@ -60,7 +60,7 @@ fn consensus_output_for_tests(round: u32, epoch: u32, subdag_index: u64) -> Cons
 async fn execute_payload_and_update_canonical_chain(
     reth_env: &RethEnv,
     payload: RLPayload,
-    transactions: Vec<Vec<u8>>,
+    transactions: Vec<Bytes>,
 ) -> eyre::Result<ExecutedBlock> {
     let (block, _validation_counts) =
         reth_env.build_block_from_batch_payload(payload, &transactions, &[])?;
@@ -600,7 +600,7 @@ async fn test_close_epochs() -> eyre::Result<()> {
     }
     .abi_encode()
     .into();
-    // stake no longer sends ETH — the ConsensusRegistry pulls ERC-20 RLS via transferFrom
+    // stake no longer sends ETH: the ConsensusRegistry pulls ERC-20 RLS via transferFrom
     let stake_tx = new_validator_eoa.create_eip1559_encoded(
         chain.clone(),
         None,
@@ -1472,8 +1472,8 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
 
     // Simulate post-genesis history under the HASHED keys, as replay's indexer
     // would append:
-    //   slot_b — one open shard [5] (has room → prepend in place)
-    //   slot_c — a FULL sealed shard [1..=2000] + a full open shard [2001..=4000],
+    //   slot_b: one open shard [5] (has room → prepend in place)
+    //   slot_c: a FULL sealed shard [1..=2000] + a full open shard [2001..=4000],
     //            so prepending block 0 (total 4001) must re-chunk into three
     //            <=2000 shards (the cascade / overflow case).
     {
@@ -1569,7 +1569,7 @@ async fn test_fix_genesis_history_rekeys_and_preserves_post_genesis() -> eyre::R
 /// history has no key mismatch (read and write both use the plain address), so
 /// genesis init already seeds it correctly and the fix is a no-op. It only has
 /// work to do after an `IndexAccountHistoryStage` first-sync clear, which this
-/// test simulates — and multi-shard accounts (post-genesis changesets) are left
+/// test simulates, and multi-shard accounts (post-genesis changesets) are left
 /// untouched.
 #[cfg(feature = "archive-replay")]
 #[tokio::test]

--- a/crates/execution/evm/src/reth_env/types.rs
+++ b/crates/execution/evm/src/reth_env/types.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloy::primitives::BlockHash;
 use rayls_infrastructure_config::FEE_AGGREGATOR_ADDRESS;
 use rayls_infrastructure_types::{
-    Address, NonceRange, RecoveredBlock, SenderNonceRanges, TransactionSigned, B256,
+    Address, Bytes, NonceRange, RecoveredBlock, SenderNonceRanges, TransactionSigned, B256,
 };
 use rayon::prelude::*;
 use reth::rpc::{
@@ -63,9 +63,9 @@ pub struct NonceTooHighDetail {
 /// Per-batch counts of transactions dropped during EVM execution, classified by reason.
 #[derive(Debug, Default)]
 pub struct TxValidationCounts {
-    /// Transactions with nonce higher than account state (gap — tx is lost).
+    /// Transactions with nonce higher than account state (gap: tx is lost).
     pub nonce_too_high: u32,
-    /// Transactions with nonce lower than account state (already executed — harmless).
+    /// Transactions with nonce lower than account state (already executed: harmless).
     pub nonce_too_low: u32,
     /// Transactions dropped for other validation reasons.
     pub other: u32,
@@ -96,32 +96,32 @@ impl TxValidationCounts {
 /// Receiver for failed transaction notifications.
 pub type ExecutedBatchDigestReceiver = broadcast::Receiver<BlockHash>;
 
-/// This will contain the address to receive base fees.  It is set per chain and
-/// will not change.  Implemented as a static OnceLock to work around the Reth lib interface.
+/// Chain-wide base-fee recipient, set once at startup. A static `OnceLock` because the reth EVM
+/// hooks that read it take no handle to node state.
 static BASEFEE_ADDRESS: OnceLock<Address> = OnceLock::new();
 
-/// Return the chains basefee address if set.
-/// Note the basefee address is set once for the chain and will not change (outside of a hard fork).
-/// Defaults to FEE_AGGREGATOR_ADDRESS so transaction base fees flow directly to fee distribution.
+/// Returns the chain's base-fee address, defaulting to `FEE_AGGREGATOR_ADDRESS` so base fees flow
+/// directly to fee distribution. Fixed for the life of the chain outside a hard fork.
 pub fn basefee_address() -> Address {
     *BASEFEE_ADDRESS.get().unwrap_or(&FEE_AGGREGATOR_ADDRESS)
 }
 
-/// Set the basefee address.  This will only work on the first call and should be during program
-/// initialization. Calling more than once will do nothing, not calling early can lead to an unset
-/// basefee address and a chain fork.
-/// Defaults to FEE_AGGREGATOR_ADDRESS for direct fee collection.
+/// Sets the base-fee address; only the first call takes effect, so it must run during
+/// initialization. A call after blocks have executed is ignored, and a node that executed with
+/// the default while its peers used a configured address has already forked.
 pub(super) fn set_basefee_address(address: Option<Address>) {
-    // Ignore the error. Should probably panic on error but this will break some test environments.
+    // A repeat call is ignored rather than a panic: test environments build several envs per
+    // process.
     let _ = BASEFEE_ADDRESS.set(address.unwrap_or(FEE_AGGREGATOR_ADDRESS));
 }
 
-/// Recover a batch of raw transactions, using parallelization for large batches.
+/// Recovers signers for a batch of raw transactions, fanning out over rayon once the batch is
+/// large enough for the thread hand-off to pay for itself.
 pub fn reth_recover_raw_transactions(
     batch_digest: Option<FixedBytes<32>>,
-    transactions: &[Vec<u8>],
+    transactions: &[Bytes],
 ) -> Vec<EthResult<Recovered<TransactionSigned>>> {
-    let rec_fn = |tx_bytes: &Vec<u8>| {
+    let rec_fn = |tx_bytes: &Bytes| {
         reth_recover_raw_transaction::<TransactionSigned>(tx_bytes).inspect_err(|e| {
             error!(
                 target: "engine",
@@ -133,15 +133,13 @@ pub fn reth_recover_raw_transactions(
     };
 
     if transactions.len() > 100 {
-        // use parallel iterator to speed up recovery of transactions
         transactions.par_iter().map(rec_fn).collect()
     } else {
-        // use normal iterator for small number of transactions
         transactions.iter().map(rec_fn).collect()
     }
 }
 
-/// Rpc Server type, used for getting the node started.
+/// RPC module set the node is started with.
 pub type RpcServer = TransportRpcModules<()>;
 
 /// The type to receive executed blocks from the engine and update canonical/finalized block state.
@@ -161,17 +159,14 @@ pub type ToTree = std::sync::mpsc::Sender<
     >,
 >;
 
-// replace deprecated reth name with this type
-/// Type alias to replace deprecated reth struct with new generic type:
-/// A block with senders recovered from the block’s transactions.
+/// A sealed block with the senders recovered from its transactions.
 ///
-/// This type is a SealedBlock with a list of senders that match the transactions in the block.
+/// Stands in for the deprecated reth `BlockWithSenders` over the generic [`RecoveredBlock`].
 pub type BlockWithSenders = RecoveredBlock<reth_ethereum_primitives::Block>;
 
 /// Shared handle to the payload processor for concurrent state root computation.
 pub(crate) type SharedPayloadProcessor = Arc<parking_lot::Mutex<PayloadProcessor<RaylsEvmConfig>>>;
 
-/// Type wrapper for a Reth DB.
-/// Used primary as a opaque type to allow
-/// the node launcher to create the DB upfront and reuse.
+/// Shared handle to the reth database, opened once by the node launcher and reused by every
+/// component.
 pub type RethDb = Arc<DatabaseEnv>;

--- a/crates/execution/evm/src/test_utils.rs
+++ b/crates/execution/evm/src/test_utils.rs
@@ -185,7 +185,7 @@ impl RethEnv {
     /// by simulating deploying proxy contract. The results are then put into genesis.
     pub fn execution_outcome_for_tests(
         &self,
-        txs: Vec<Vec<u8>>,
+        txs: Vec<Bytes>,
         parent: &SealedHeader,
     ) -> BundleState {
         // create "empty" header with default values
@@ -263,10 +263,10 @@ impl RethEnv {
     }
 }
 
-/// Transaction factory
+/// Factory for signed test transactions from one keypair with a running nonce.
 #[derive(Clone, Copy, Debug)]
 pub struct TransactionFactory {
-    /// Keypair for signing transactions
+    /// Keypair for signing transactions.
     keypair: ExecutionKeypair,
     /// The nonce for the next transaction constructed.
     nonce: u64,
@@ -291,7 +291,7 @@ impl TransactionFactory {
         Self { keypair, nonce: 0 }
     }
 
-    /// create a new instance of self from a provided seed.
+    /// Create a new instance of self from a provided seed.
     pub fn new_random_from_seed<R: Rng + ?Sized>(rand: &mut R) -> Self {
         let secp = Secp256k1::new();
         let (secret_key, _public_key) = secp.generate_keypair(rand);
@@ -299,7 +299,7 @@ impl TransactionFactory {
         Self { keypair, nonce: 0 }
     }
 
-    /// create a new instance of self from a random seed.
+    /// Create a new instance of self from a random seed.
     pub fn new_random() -> Self {
         let secp = Secp256k1::new();
         let (secret_key, _public_key) = secp.generate_keypair(&mut StdRng::from_os_rng());
@@ -335,8 +335,8 @@ impl TransactionFactory {
         to: Option<Address>,
         value: U256,
         input: Bytes,
-    ) -> Vec<u8> {
-        self.create_eip1559(chain, gas_limit, gas_price, to, value, input).encoded_2718()
+    ) -> Bytes {
+        self.create_eip1559(chain, gas_limit, gas_price, to, value, input).encoded_2718().into()
     }
 
     /// Create and sign an EIP1559 transaction.
@@ -462,6 +462,7 @@ impl TransactionFactory {
         hash.hash
     }
 
+    // allow: long-doc defaults table for nine optional parameters
     /// Create and sign an EIP1559 transaction with all possible parameters passed.
     ///
     /// All arguments are optional and default to:
@@ -518,14 +519,14 @@ impl TransactionFactory {
         TransactionSigned::new_unhashed(transaction, signature)
     }
 
-    /// Sign the transaction hash with the key in memory
+    /// Sign the transaction hash with the key in memory.
     fn sign_hash(&self, hash: B256) -> EthSignature {
         let secret = B256::from_slice(&self.keypair.secret_bytes());
         let signature = sign_message(secret, hash);
         signature.expect("failed to sign transaction")
     }
 
-    /// Helper to instantiate an `alloy-signer-local::PrivateKeySigner` wrapping the default account
+    /// Instantiate an `alloy-signer-local::PrivateKeySigner` wrapping the default account.
     pub fn get_default_signer(&self) -> eyre::Result<PrivateKeySigner> {
         // circumvent Secp256k1 <> k256 type incompatibility via FieldBytes intermediary
         let binding = self.keypair.secret_key().secret_bytes();
@@ -566,7 +567,7 @@ pub fn get_gas_price(reth_env: &RethEnv) -> u128 {
 }
 
 /// Create a random encoded transaction.
-pub fn transaction(chain: Arc<RethChainSpec>) -> Vec<u8> {
+pub fn transaction(chain: Arc<RethChainSpec>) -> Bytes {
     let mut tx_factory = TransactionFactory::new_random();
     let gas_price = 100_000;
     let value = U256::from(10).checked_pow(U256::from(18)).expect("1e18 doesn't overflow U256");
@@ -582,8 +583,7 @@ pub fn transaction(chain: Arc<RethChainSpec>) -> Vec<u8> {
     )
 }
 
-/// will create a batch with randomly formed transactions
-/// dictated by the parameter number_of_transactions
+/// Create a batch of `number_of_transactions` random transactions.
 pub fn fixture_batch_with_transactions(number_of_transactions: u32) -> Batch {
     let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
     let transactions = (0..number_of_transactions).map(|_v| transaction(chain.clone())).collect();
@@ -598,8 +598,7 @@ pub fn batch(chain: Arc<RethChainSpec>) -> Batch {
     Batch { transactions, ..Default::default() }
 }
 
-/// generate multiple fixture batches. The number of generated batches
-/// are dictated by the parameter num_of_batches.
+/// Create `num_of_batches` fixture batches, the i-th holding i transactions.
 pub fn batches(chain: Arc<RethChainSpec>, num_of_batches: usize) -> Vec<Batch> {
     let mut batches = Vec::new();
 

--- a/crates/execution/evm/src/txn_pool.rs
+++ b/crates/execution/evm/src/txn_pool.rs
@@ -263,12 +263,12 @@ impl WorkerTxPool {
         self.pool.add_transaction(TransactionOrigin::Local, recovered).await
     }
 
-    /// Adds a transaction with external origin.
-    pub async fn add_raw_transaction_external(
+    /// Adds external transactions to the pool in one call, one outcome per input in order.
+    pub async fn add_raw_transactions_external(
         &self,
-        tx: EthPooledTransaction,
-    ) -> Result<AddedTransactionOutcome, crate::PoolError> {
-        self.pool.add_transaction(TransactionOrigin::External, tx).await
+        txs: Vec<EthPooledTransaction>,
+    ) -> Vec<Result<AddedTransactionOutcome, crate::PoolError>> {
+        self.pool.add_transactions(TransactionOrigin::External, txs).await
     }
 
     /// Admit forwarded transactions and return the hashes the pool rejected as stale.

--- a/crates/execution/evm/src/worker.rs
+++ b/crates/execution/evm/src/worker.rs
@@ -1,14 +1,10 @@
-//! Node implementation for reth compatibility
+//! Worker-side stand-in for the reth network traits its RPC namespaces require.
 //!
-//! Inspired by reth_node_ethereum crate.
-//!
-//! A network implementation for worker RPC.
-//!
-//! This is useful for wiring components together that don't require network but still need to be
-//! generic over it.
+//! Workers have no devp2p network, but reth's `net`, `web3`, and `eth` RPC modules are generic
+//! over one; this answers their queries from the worker's libp2p peer count and leaves the
+//! `admin`-only methods as no-ops.
 
 use crate::{reth_env::ChainSpec, WorkerTxPool};
-use parking_lot::RwLock;
 use rayls_consensus_worker::WorkerNetworkHandle;
 use reth::{network::config::SecretKey, rpc::builder::RpcServerHandle};
 use reth_chainspec::ChainSpec as RethChainSpec;
@@ -21,7 +17,10 @@ use reth_network_api::{
 use reth_network_peers::{Enr, NodeRecord, PeerId as RethPeerId};
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -32,7 +31,7 @@ pub struct WorkerComponents {
     rpc_handle: RpcServerHandle,
     /// The worker's transaction pool.
     pool: WorkerTxPool,
-    /// Keep the WorkerNetwork around so we can update it's task(s).
+    /// Network stand-in, kept so its peer-count task can be respawned each epoch.
     network: WorkerNetwork,
 }
 
@@ -42,7 +41,7 @@ impl WorkerComponents {
         Self { rpc_handle, pool, network }
     }
 
-    /// Return a reference to the rpc handle
+    /// Return a reference to the rpc handle.
     pub fn rpc_handle(&self) -> &RpcServerHandle {
         &self.rpc_handle
     }
@@ -52,23 +51,22 @@ impl WorkerComponents {
         self.pool.clone()
     }
 
-    /// Return the worker network inteface (RPC helper) for this worker.
+    /// Return the worker network interface (RPC helper) for this worker.
     pub fn worker_network(&self) -> &WorkerNetwork {
         &self.network
     }
 }
 
-/// A type that implements traits used by Reth for it's RPC.
-/// Traits are filled out to provide data for net, web3 and eth namespaces when available.
-/// Much of these traits are NO-OPS are not used, they support the admin namespace for
-/// instance which Rayls does not use or support.
+/// Implementation of the reth network traits behind the `net`, `web3`, and `eth` RPC namespaces.
+///
+/// Most methods are no-ops: they back the `admin` namespace, which Rayls does not serve.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct WorkerNetwork {
-    /// Chainspec
+    /// Chain spec.
     chain_spec: RethChainSpec,
-    /// Track our peer count for queries.
-    peer_count: Arc<RwLock<usize>>,
+    /// Connected peer count, refreshed by the polling task and served to `net_peerCount`.
+    peer_count: Arc<AtomicUsize>,
     /// App version.
     version: &'static str,
 }
@@ -80,7 +78,7 @@ impl WorkerNetwork {
         worker_network: WorkerNetworkHandle,
         version: &'static str,
     ) -> Self {
-        let peer_count = Arc::new(RwLock::new(0));
+        let peer_count = Arc::new(AtomicUsize::new(0));
         Self::spawn_peer_count_task(&peer_count, worker_network);
         Self { chain_spec: chain_spec.reth_chain_spec(), peer_count, version }
     }
@@ -91,22 +89,18 @@ impl WorkerNetwork {
         Self::spawn_peer_count_task(&self.peer_count, worker_network);
     }
 
-    /// Rayls: Spawn peer count polling task.
-    fn spawn_peer_count_task(peer_count: &Arc<RwLock<usize>>, worker_network: WorkerNetworkHandle) {
+    /// Spawn the peer-count polling task on the handle's task spawner.
+    fn spawn_peer_count_task(peer_count: &Arc<AtomicUsize>, worker_network: WorkerNetworkHandle) {
         let peer_count = peer_count.clone();
         let spawner = worker_network.get_task_spawner().clone();
         spawner.spawn_task("Worker Network Peers", async move {
-            // Use a bounded number of iterations as a safety check
-            // This ensures the task doesn't run forever even if abort fails
-            // The task will be re-spawned on epoch change anyway
+            // Bounded so a task that outlives its abort cannot poll forever; the epoch rollover
+            // respawns it.
             const MAX_ITERATIONS: u32 = 10_000; // ~41 hours at 15 sec intervals
             for _ in 0..MAX_ITERATIONS {
-                // Check peer count - this is interruptible
                 if let Ok(peers) = worker_network.connected_peers_count().await {
-                    let mut guard = peer_count.write();
-                    *guard = peers;
+                    peer_count.store(peers, Ordering::Relaxed);
                 }
-                // Sleep is interruptible by task abort
                 tokio::time::sleep(Duration::from_secs(15)).await;
             }
             tracing::debug!(target: "worker", "Peer count task reached max iterations, exiting");
@@ -153,7 +147,7 @@ impl NetworkInfo for WorkerNetwork {
 impl PeersInfo for WorkerNetwork {
     // net_peerCount
     fn num_connected_peers(&self) -> usize {
-        *self.peer_count.read()
+        self.peer_count.load(Ordering::Relaxed)
     }
 
     // Rayls Unused

--- a/crates/infrastructure/network-types/src/lib.rs
+++ b/crates/infrastructure/network-types/src/lib.rs
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
-//! Network messages for anemo communication
+//! Message types and client traits for primary-worker communication.
 
 pub mod local;
 mod notify;
 mod response;
 pub use notify::*;
-use rayls_infrastructure_types::{Batch, BlockHash};
+use rayls_infrastructure_types::{B256Map, B256Set, Batch};
 pub use response::*;
-use std::collections::{HashMap, HashSet};
 
 // async_trait for object safety, get rid of when possible.
 #[async_trait::async_trait]
 /// Worker to primary messages.
 pub trait WorkerToPrimaryClient: Send + Sync + 'static {
-    /// Report own batch
+    /// Reports a batch this node's worker sealed.
     async fn report_own_batch(&self, request: WorkerOwnBatchMessage) -> eyre::Result<()>;
 
-    /// Report a batch from a peer.
+    /// Reports a batch received from a peer's worker.
     async fn report_others_batch(&self, request: WorkerOthersBatchMessage) -> eyre::Result<()>;
 }
 
-/// Dumb mock to just return Ok on calls for tests.
+/// Mock that acknowledges every call.
 #[derive(Debug)]
 pub struct MockWorkerToPrimary();
 
@@ -35,7 +34,7 @@ impl WorkerToPrimaryClient for MockWorkerToPrimary {
     }
 }
 
-/// Dumb mock that pends forever on calls for tests.
+/// Mock that never completes a call, for tests that exercise a stalled primary.
 #[derive(Debug)]
 pub struct MockWorkerToPrimaryHang();
 
@@ -74,18 +73,18 @@ impl WorkerToPrimaryClient for MockWorkerToPrimaryError {
 #[async_trait::async_trait]
 /// Primary to worker messages.
 pub trait PrimaryToWorkerClient: Send + Sync + 'static {
-    /// Synchronize
+    /// Asks the worker to fetch the batches a header references.
     async fn synchronize(&self, message: WorkerSynchronizeMessage) -> eyre::Result<()>;
 
-    /// Fetch batches
-    async fn fetch_batches(&self, digests: HashSet<BlockHash>) -> eyre::Result<FetchBatchResponse>;
+    /// Fetches the batches for the given digests.
+    async fn fetch_batches(&self, digests: B256Set) -> eyre::Result<FetchBatchResponse>;
 }
 
-/// Type that can return batches.
+/// Mock that serves a fixed set of batches.
 #[derive(Default, Debug)]
 pub struct MockPrimaryToWorkerClient {
-    /// The batches for tests.
-    pub batches: HashMap<BlockHash, Batch>,
+    /// Batches returned by every `fetch_batches` call.
+    pub batches: B256Map<Batch>,
 }
 
 #[async_trait::async_trait]
@@ -94,10 +93,7 @@ impl PrimaryToWorkerClient for MockPrimaryToWorkerClient {
         Ok(())
     }
 
-    async fn fetch_batches(
-        &self,
-        _digests: HashSet<BlockHash>,
-    ) -> eyre::Result<FetchBatchResponse> {
+    async fn fetch_batches(&self, _digests: B256Set) -> eyre::Result<FetchBatchResponse> {
         Ok(FetchBatchResponse { batches: self.batches.clone() })
     }
 }

--- a/crates/infrastructure/network-types/src/local.rs
+++ b/crates/infrastructure/network-types/src/local.rs
@@ -4,14 +4,14 @@ use crate::{
     WorkerSynchronizeMessage, WorkerToPrimaryClient,
 };
 use parking_lot::RwLock;
-use rayls_infrastructure_types::{BlockHash, BlsPublicKey};
-use std::{collections::HashSet, sync::Arc};
+use rayls_infrastructure_types::{B256Set, BlsPublicKey};
+use std::sync::Arc;
 
-/// LocalNetwork provides the interface to send requests to other nodes, and call other components
-/// directly if they live in the same process. It is used by both primary and worker(s).
+/// In-process request path between a primary and its worker(s).
 ///
-/// Currently this only supports local direct calls, and it will be extended to support remote
-/// network calls.
+/// Handlers are registered after construction because the primary and worker are built
+/// independently; before a handler is set, a primary-to-worker request errors and a
+/// worker-to-primary report is dropped with a warning.
 #[derive(Debug, Clone)]
 pub struct LocalNetwork {
     inner: Arc<RwLock<Inner>>,
@@ -33,7 +33,7 @@ impl std::fmt::Debug for Inner {
 }
 
 impl LocalNetwork {
-    /// Create a new instance of [Self].
+    /// Creates a new instance of [Self].
     pub fn new(primary_bls_key: BlsPublicKey) -> Self {
         Self {
             inner: Arc::new(RwLock::new(Inner {
@@ -44,30 +44,30 @@ impl LocalNetwork {
         }
     }
 
-    /// Create a new instance of [Self] with a randomly generated ed25519 key.
+    /// Creates a new instance of [Self] with a default BLS key, for tests.
     pub fn new_with_empty_id() -> Self {
         Self::new(BlsPublicKey::default())
     }
 
-    /// Set the handler for worker to primary messages.
+    /// Sets the handler for worker to primary messages.
     pub fn set_worker_to_primary_local_handler(&self, handler: Arc<dyn WorkerToPrimaryClient>) {
         let mut inner = self.inner.write();
         inner.worker_to_primary_handler = Some(handler);
     }
 
-    /// Set the handler for primary to worker messages.
+    /// Sets the handler for primary to worker messages.
     pub fn set_primary_to_worker_local_handler(&self, handler: Arc<dyn PrimaryToWorkerClient>) {
         let mut inner = self.inner.write();
         inner.primary_to_worker_handler = Some(handler);
     }
 
-    /// Get the handler for worker to primary messages.
+    /// Returns the handler for primary to worker messages.
     async fn get_primary_to_worker_handler(&self) -> Option<Arc<dyn PrimaryToWorkerClient>> {
         let inner = self.inner.read();
         inner.primary_to_worker_handler.clone()
     }
 
-    /// Get the handler for primary to worker messages.
+    /// Returns the handler for worker to primary messages.
     async fn get_worker_to_primary_handler(&self) -> Option<Arc<dyn WorkerToPrimaryClient>> {
         let inner = self.inner.read();
         inner.worker_to_primary_handler.clone()
@@ -85,7 +85,7 @@ impl PrimaryToWorkerClient for LocalNetwork {
         }
     }
 
-    async fn fetch_batches(&self, digests: HashSet<BlockHash>) -> eyre::Result<FetchBatchResponse> {
+    async fn fetch_batches(&self, digests: B256Set) -> eyre::Result<FetchBatchResponse> {
         if let Some(c) = self.get_primary_to_worker_handler().await {
             c.fetch_batches(digests).await
         } else {

--- a/crates/infrastructure/network-types/src/response.rs
+++ b/crates/infrastructure/network-types/src/response.rs
@@ -1,20 +1,17 @@
-//! Response message types
-use rayls_infrastructure_types::{Batch, BlockHash, Certificate};
+//! Response message types.
+use rayls_infrastructure_types::{B256Map, Batch, Certificate};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
-/// Used by the primary to reply to FetchCertificatesRequest.
+/// Reply to a certificate fetch request.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FetchCertificatesResponse {
     /// Certificates sorted from lower to higher rounds.
     pub certificates: Vec<Certificate>,
 }
 
-/// All batches requested by the primary.
+/// Reply to a batch fetch request.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FetchBatchResponse {
     /// The missing batches fetched from peers.
-    pub batches: HashMap<BlockHash, Batch>,
+    pub batches: B256Map<Batch>,
 }
-
-//=== Engine

--- a/crates/infrastructure/storage/src/cold/tests/mod.rs
+++ b/crates/infrastructure/storage/src/cold/tests/mod.rs
@@ -68,7 +68,7 @@ struct Fixture {
 fn batch_for(number: u64, epoch: Epoch) -> Batch {
     Batch {
         // Distinct per block so the byte-identical readback assertion is meaningful.
-        transactions: vec![vec![number as u8; 1 + (number as usize % 7)]],
+        transactions: vec![vec![number as u8; 1 + (number as usize % 7)].into()],
         epoch,
         worker_id: 0,
         seq: number,

--- a/crates/infrastructure/storage/src/cold/tests/mod.rs
+++ b/crates/infrastructure/storage/src/cold/tests/mod.rs
@@ -6,7 +6,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use rayls_infrastructure_types::{
-    encode, Batch, BlockHash, Certificate, CommittedSubDag, ConsensusHeader, Database, DbTx,
+    encode, Batch, BlockHash, Bytes, Certificate, CommittedSubDag, ConsensusHeader, Database, DbTx,
     DbTxMut, Epoch, Header, ReputationScores,
 };
 
@@ -68,7 +68,7 @@ struct Fixture {
 fn batch_for(number: u64, epoch: Epoch) -> Batch {
     Batch {
         // Distinct per block so the byte-identical readback assertion is meaningful.
-        transactions: vec![vec![number as u8; 1 + (number as usize % 7)].into()],
+        transactions: vec![Bytes::from(vec![number as u8; 1 + (number as usize % 7)])],
         epoch,
         worker_id: 0,
         seq: number,

--- a/crates/infrastructure/storage/src/mdbx/database.rs
+++ b/crates/infrastructure/storage/src/mdbx/database.rs
@@ -400,9 +400,13 @@ impl Drop for MdbxDatabase {
     }
 }
 
+/// Bytes in a kilobyte.
 pub const KILOBYTE: usize = 1024;
+/// Bytes in a megabyte.
 pub const MEGABYTE: usize = KILOBYTE * 1024;
+/// Bytes in a gigabyte.
 pub const GIGABYTE: usize = MEGABYTE * 1024;
+/// Bytes in a terabyte.
 pub const TERABYTE: usize = GIGABYTE * 1024;
 
 /// Rayls: Default max read transaction duration in seconds.
@@ -719,7 +723,9 @@ impl Database for MdbxDatabase {
     }
 
     fn contains_key<T: Table>(&self, key: &T::Key) -> eyre::Result<bool> {
-        self.with_read_txn(|tx| Ok(tx.get::<T>(key)?.is_some()))
+        // A presence check must not copy and decode the value: `raw_get` borrows the page, while
+        // `get` would copy a row of up to 2MB and run a decode that aborts on a corrupt row.
+        self.with_read_txn(|tx| Ok(tx.raw_get::<T>(key)?.is_some()))
     }
 
     fn get<T: Table>(&self, key: &T::Key) -> eyre::Result<Option<T::Value>> {
@@ -897,8 +903,8 @@ where
 /// The `Database::raw_iter`/`reverse_raw_iter` variants own their read
 /// transaction *inside* the returned iterator, so a borrow into the mmap would
 /// dangle if the boxed iterator were dropped while a yielded item is still
-/// held. The `DbTx` variants don't need this — their transaction outlives the
-/// iterator — so they yield the borrow directly.
+/// held. The `DbTx` variants don't need this - their transaction outlives the
+/// iterator - so they yield the borrow directly.
 fn into_owned_pair<'i>((k, v): (Cow<'_, [u8]>, Cow<'_, [u8]>)) -> (Cow<'i, [u8]>, Cow<'i, [u8]>) {
     (Cow::Owned(k.into_owned()), Cow::Owned(v.into_owned()))
 }

--- a/crates/infrastructure/types/src/committee.rs
+++ b/crates/infrastructure/types/src/committee.rs
@@ -1,4 +1,4 @@
-//! Committee of validators reach consensus.
+//! Committee of validators that reach consensus, and the authority records it holds.
 
 use crate::{
     bcs_layout::{BcsCursor, BcsLayout, BcsLayoutError, BcsRead},
@@ -52,6 +52,7 @@ pub struct BootstrapServer {
 }
 
 impl BootstrapServer {
+    /// Creates a bootstrap record from the primary's and worker's p2p info.
     pub fn new(primary_node: P2pNode, worker_node: P2pNode) -> Self {
         Self { primary: primary_node, worker: worker_node }
     }
@@ -73,46 +74,64 @@ struct AuthorityInner {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Authority {
     inner: Arc<AuthorityInner>,
+    /// Cached at construction: deriving the id hashes the BLS key and allocates,
+    /// and callers ask for it on every round.
+    id: AuthorityIdentifier,
 }
 
 impl Authority {
-    /// The constructor is not public by design. Everyone who wants to create authorities should do
-    /// it via Committee (more specifically can use [CommitteeBuilder]). As some internal properties
-    /// of Authority are initialised via the Committee, to ensure that the user will not
-    /// accidentally use stale Authority data, should always derive them via the Commitee.
+    /// Private by design: authorities are created through [CommitteeBuilder] so that every
+    /// authority a caller holds belongs to a committee and cannot go stale against it.
     fn new(
         protocol_key: BlsPublicKey,
         voting_power: VotingPower,
         execution_address: Address,
     ) -> Self {
-        Self { inner: Arc::new(AuthorityInner { protocol_key, voting_power, execution_address }) }
+        let id = Self::derive_id(&protocol_key);
+        Self {
+            inner: Arc::new(AuthorityInner { protocol_key, voting_power, execution_address }),
+            id,
+        }
     }
 
-    /// Version of new that can be called directly.  Useful for testing, if you are calling this
-    /// outside of a test you are wrong (see comment on new).
+    /// Builds an authority outside a committee. Test-only; production code must go through
+    /// [CommitteeBuilder] (see `new`).
     pub fn new_for_test(
         protocol_key: BlsPublicKey,
         voting_power: VotingPower,
         execution_address: Address,
     ) -> Self {
-        Self { inner: Arc::new(AuthorityInner { protocol_key, voting_power, execution_address }) }
+        let id = Self::derive_id(&protocol_key);
+        Self {
+            inner: Arc::new(AuthorityInner { protocol_key, voting_power, execution_address }),
+            id,
+        }
     }
 
-    pub fn id(&self) -> AuthorityIdentifier {
-        let bytes = self.inner.protocol_key.to_bytes();
+    /// Derives the identifier, a pure function of the protocol key, once per authority.
+    fn derive_id(protocol_key: &BlsPublicKey) -> AuthorityIdentifier {
+        let bytes = protocol_key.to_bytes();
         let mut hasher = crate::DefaultHashFunction::new();
         hasher.update(&bytes);
         AuthorityIdentifier(Arc::new(*hasher.finalize().as_bytes()))
     }
 
+    /// Returns the authority's identifier.
+    pub fn id(&self) -> AuthorityIdentifier {
+        self.id.clone()
+    }
+
+    /// Returns the BLS key the authority signs consensus messages with.
     pub fn protocol_key(&self) -> &BlsPublicKey {
         &self.inner.protocol_key
     }
 
+    /// Returns the authority's voting power.
     pub fn voting_power(&self) -> VotingPower {
         self.inner.voting_power
     }
 
+    /// Returns the address that receives the authority's fees.
     pub fn execution_address(&self) -> Address {
         self.inner.execution_address
     }
@@ -134,7 +153,8 @@ impl<'de> Deserialize<'de> for Authority {
         D: serde::Deserializer<'de>,
     {
         let inner = AuthorityInner::deserialize(deserializer)?;
-        Ok(Self { inner: Arc::new(inner) })
+        let id = Self::derive_id(&inner.protocol_key);
+        Ok(Self { inner: Arc::new(inner), id })
     }
 }
 
@@ -143,15 +163,15 @@ impl<'de> Deserialize<'de> for Authority {
 struct CommitteeInner {
     /// The authorities of epoch.
     authorities: BTreeMap<BlsPublicKey, Authority>,
-    /// Keeps and index of the Authorities by their respective identifier
+    /// Index of the authorities by identifier.
     #[serde(skip)]
     authorities_by_id: BTreeMap<AuthorityIdentifier, Authority>,
-    /// The epoch number of this committee
+    /// The epoch number of this committee.
     epoch: Epoch,
-    /// The quorum threshold (2f+1)
+    /// The quorum threshold (2f+1).
     #[serde(skip)]
     quorum_threshold: VotingPower,
-    /// The validity threshold (f+1)
+    /// The validity threshold (f+1).
     #[serde(skip)]
     validity_threshold: VotingPower,
     /// The bootstrap servers to initially join a network (probably the initial committee).
@@ -176,7 +196,7 @@ impl CommitteeInner {
         assert!(self.authorities_by_id.len() > 1, "committee size must be larger than 1");
         // Dev builds relax the floor to allow a single-validator committee. The
         // single-node-only invariant is enforced at node startup (see node.rs), not
-        // here — this constructor is shared by the multi-validator consensus test suite.
+        // here - this constructor is shared by the multi-validator consensus test suite.
         #[cfg(feature = "dev-single-node-setup")]
         assert!(!self.authorities_by_id.is_empty(), "committee size must be at least 1");
     }
@@ -234,13 +254,12 @@ impl PartialEq for Committee {
 
 impl Eq for Committee {}
 
-// Every authority gets uniquely identified by the AuthorityIdentifier
-// The type can be easily swapped without needing to change anything else in the implementation.
-// Currently it is the hash of the authorities BLS key (which will be stable).
+/// Unique identifier of an authority: the hash of its BLS key, so it is stable across epochs.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Serialize, Deserialize)]
 pub struct AuthorityIdentifier(Arc<[u8; 32]>);
 
 impl AuthorityIdentifier {
+    /// Builds an identifier from a repeated byte, for tests that need distinct ids.
     pub fn dummy_for_test(byte: u8) -> Self {
         Self(Arc::new([byte; 32]))
     }
@@ -322,11 +341,8 @@ impl Committee {
         Self { inner: Arc::new(RwLock::new(committee)) }
     }
 
-    /// Expose new for tests.  If you are calling this outside of a test you are wrong, see comment
-    /// on new.
-    ///
-    /// Pass an optional epoch_boundary timestamp. Defaults to u64::MAX to disable epoch
-    /// transitions.
+    /// Builds a committee without the builder. Test-only; production code must go through
+    /// [CommitteeBuilder] (see `new`).
     pub fn new_for_test(
         authorities: BTreeMap<BlsPublicKey, Authority>,
         epoch: Epoch,
@@ -352,7 +368,7 @@ impl Committee {
         assert!(committee.authorities_by_id.len() > 1, "committee size must be larger than 1");
         // Dev builds relax the floor to allow a single-validator committee. The
         // single-node-only invariant is enforced at node startup (see node.rs), not
-        // here — this constructor is shared by the multi-validator consensus test suite.
+        // here - this constructor is shared by the multi-validator consensus test suite.
         #[cfg(feature = "dev-single-node-setup")]
         assert!(!committee.authorities_by_id.is_empty(), "committee size must be at least 1");
         // Some sanity checks to ensure that we'll not end up in invalid state
@@ -371,23 +387,26 @@ impl Committee {
         self.inner.read().epoch
     }
 
-    /// Provided an identifier it returns the corresponding authority
+    /// Returns the authority with the given identifier.
     pub fn authority(&self, identifier: &AuthorityIdentifier) -> Option<Authority> {
         self.inner.read().authorities_by_id.get(identifier).cloned()
     }
 
+    /// Returns the authority with the given BLS key.
     pub fn authority_by_key(&self, key: &BlsPublicKey) -> Option<Authority> {
         self.inner.read().authorities.get(key).cloned()
     }
 
+    /// Returns all authorities, sorted by identifier.
+    ///
+    /// Callers rely on the order (leader schedules index into it), so it comes from the id-keyed
+    /// index, never from the key-keyed map.
     pub fn authorities(&self) -> Vec<Authority> {
-        // Return sorted by id (using the id keyed BTree) since this may be important to some code.
         self.inner.read().authorities_by_id.values().cloned().collect()
     }
 
-    /// Return true if the authority for id is in the committee.
+    /// Returns true if the authority for id is in the committee.
     pub fn is_authority(&self, id: &AuthorityIdentifier) -> bool {
-        // Return sorted by id (using the id keyed BTree) since this may be important to some code.
         self.inner.read().authorities_by_id.contains_key(id)
     }
 
@@ -396,11 +415,12 @@ impl Committee {
         self.inner.read().authorities.len()
     }
 
-    /// Return the stake of a specific authority.
+    /// Returns the voting power of the authority with the given key, or 0 if absent.
     pub fn voting_power(&self, name: &BlsPublicKey) -> VotingPower {
         self.inner.read().authorities.get(&name.clone()).map_or_else(|| 0, |x| x.inner.voting_power)
     }
 
+    /// Returns the voting power of the authority with the given id, or 0 if absent.
     pub fn voting_power_by_id(&self, id: &AuthorityIdentifier) -> VotingPower {
         self.inner
             .read()
@@ -419,21 +439,22 @@ impl Committee {
         self.inner.read().validity_threshold
     }
 
-    /// Returns true if the provided stake has reached quorum (2f+1)
+    /// Returns true if the provided stake has reached quorum (2f+1).
     pub fn reached_quorum(&self, voting_power: VotingPower) -> bool {
         voting_power >= self.quorum_threshold()
     }
 
-    /// Returns true if the provided stake has reached availability (f+1)
+    /// Returns true if the provided stake has reached availability (f+1).
     pub fn reached_validity(&self, voting_power: VotingPower) -> bool {
         voting_power >= self.validity_threshold()
     }
 
+    /// Returns the summed voting power of the committee.
     pub fn total_voting_power(&self) -> VotingPower {
         self.inner.read().total_voting_power()
     }
 
-    /// Return all the network addresses in the committee.
+    /// Returns the (identifier, BLS key) of every primary except `myself`.
     pub fn others_primaries_by_id(
         &self,
         myself: Option<&AuthorityIdentifier>,
@@ -476,18 +497,17 @@ impl Committee {
         self.inner.read().authorities.values().map(|authority| *authority.protocol_key()).collect()
     }
 
-    /// Return the bootstrap record for key if it exists.
+    /// Returns the bootstrap record for key if it exists.
     pub fn get_bootstrap(&self, key: &BlsPublicKey) -> Option<BootstrapServer> {
         self.inner.read().bootstrap_servers.get(key).cloned()
     }
 
-    /// Return the map of bootstrap servers.
+    /// Returns the map of bootstrap servers.
     pub fn bootstrap_servers(&self) -> BTreeMap<BlsPublicKey, BootstrapServer> {
         self.inner.read().bootstrap_servers.clone()
     }
 
-    /// Used for testing - not recommended to use for any other case.
-    /// It creates a new instance with updated epoch
+    /// Builds a copy of this committee at a new epoch. Test-only.
     pub fn advance_epoch_for_test(&self, new_epoch: Epoch) -> Committee {
         Committee::new_for_test(
             self.inner.read().authorities.clone(),
@@ -496,10 +516,10 @@ impl Committee {
         )
     }
 
-    /// Return the number of workers that are in use for this committee.
-    /// This is a protocol level value, all nodes have to agree on this and be
-    /// running the required number of workers.
-    /// Currently 1 but may change with a future fork on an epoch boundary.
+    /// Returns the number of workers per authority.
+    ///
+    /// A protocol-level value: every node must agree on it and run that many workers, so a change
+    /// can only land at an epoch boundary.
     pub fn number_of_workers(&self) -> usize {
         1
     }
@@ -539,12 +559,12 @@ pub struct CommitteeBuilder {
 }
 
 impl CommitteeBuilder {
-    /// Create a new instance of [CommitteeBuilder] for making a new [Committee].
+    /// Creates a builder for a [Committee] at the given epoch.
     pub fn new(epoch: Epoch) -> Self {
         Self { epoch, authorities: BTreeMap::default(), bootstrap_server: BTreeMap::default() }
     }
 
-    /// Add an authority and bootstrap server to the committee builder.
+    /// Adds an authority and its bootstrap server.
     pub fn add_authority_and_bootstrap(
         &mut self,
         protocol_key: BlsPublicKey,
@@ -559,7 +579,7 @@ impl CommitteeBuilder {
         self.bootstrap_server.insert(protocol_key, bootstrap);
     }
 
-    /// Add an authority to the committee builder.
+    /// Adds an authority.
     pub fn add_authority(
         &mut self,
         protocol_key: BlsPublicKey,
@@ -570,7 +590,7 @@ impl CommitteeBuilder {
         self.authorities.insert(protocol_key, authority);
     }
 
-    /// Add an authority to the committee builder.
+    /// Adds a bootstrap server.
     pub fn add_bootstrap_server(
         &mut self,
         protocol_key: BlsPublicKey,
@@ -581,6 +601,7 @@ impl CommitteeBuilder {
         self.bootstrap_server.insert(protocol_key, bootstrap);
     }
 
+    /// Builds the committee, computing its thresholds and indexes.
     pub fn build(self) -> Committee {
         Committee::new(self.authorities, self.epoch, self.bootstrap_server)
     }
@@ -591,17 +612,18 @@ impl CommitteeBuilder {
 pub struct CommitteeLookahead(BTreeMap<Epoch, Vec<BlsPublicKey>>);
 
 impl CommitteeLookahead {
+    /// Builds the lookahead, dropping epochs with no keys.
     pub fn from_entries(entries: impl IntoIterator<Item = (Epoch, Vec<BlsPublicKey>)>) -> Self {
         Self(entries.into_iter().filter(|(_, keys)| !keys.is_empty()).collect())
     }
 
+    /// Returns the committee keys for `epoch`, if known.
     pub fn get(&self, epoch: Epoch) -> Option<&[BlsPublicKey]> {
         self.0.get(&epoch).map(|k| k.as_slice())
     }
 }
 
-/// The quorum threshold (2f+1)
-/// This assumes all committee members have the same voting power of 1.
+/// Returns the quorum threshold (2f+1) for a committee whose members all have voting power 1.
 pub fn quorum_threshold(committee_members: u64) -> u64 {
     ((2 * committee_members) / 3) + 1
 }

--- a/crates/infrastructure/types/src/executed_batch_registry.rs
+++ b/crates/infrastructure/types/src/executed_batch_registry.rs
@@ -1,9 +1,11 @@
-use alloy::primitives::B256;
-use parking_lot::Mutex;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
+//! Deduplication of executed batch digests across restarts and retries.
+
+use alloy::primitives::{
+    map::{B256Map, B256Set},
+    B256,
 };
+use parking_lot::Mutex;
+use std::sync::Arc;
 use tracing::{info, warn};
 
 /// Maximum number of nonce_too_high retries before a digest is kept permanently.
@@ -12,20 +14,22 @@ const MAX_NONCE_TOO_HIGH_RETRIES: u8 = 3;
 /// Deduplication registry for executed batch digests.
 #[derive(Clone, Debug, Default)]
 pub struct ExecutedBatchRegistry {
-    digests: Arc<Mutex<HashSet<B256>>>,
-    retry_counts: Arc<Mutex<HashMap<B256, u8>>>,
+    /// Digests that have been executed, or whose retry budget is spent.
+    digests: Arc<Mutex<B256Set>>,
+    /// Nonce-too-high retries spent per digest; bounded by `MAX_NONCE_TOO_HIGH_RETRIES`.
+    retry_counts: Arc<Mutex<B256Map<u8>>>,
 }
 
 impl ExecutedBatchRegistry {
-    /// Create from a pre-populated set of digests.
-    pub fn from_digests(digests: HashSet<B256>) -> Self {
+    /// Creates a registry from a pre-populated set of digests.
+    pub fn from_digests(digests: B256Set) -> Self {
         Self {
             digests: Arc::new(Mutex::new(digests)),
-            retry_counts: Arc::new(Mutex::new(HashMap::new())),
+            retry_counts: Arc::new(Mutex::new(B256Map::default())),
         }
     }
 
-    /// Register a batch digest. Return false if already present.
+    /// Registers a batch digest, returning false if it was already present.
     pub fn try_register(&self, batch_digest: B256, output_digest: B256) -> bool {
         let result = self.digests.lock().insert(batch_digest);
         if !result {
@@ -39,14 +43,15 @@ impl ExecutedBatchRegistry {
         result
     }
 
-    /// Check if a batch digest has already been registered without inserting it.
+    /// Returns true if the digest is registered, without inserting it.
     pub fn contains(&self, batch_digest: &B256) -> bool {
         self.digests.lock().contains(batch_digest)
     }
 
-    /// Remove a digest so the batch can be retried (bounded).
+    /// Removes a digest so the batch can be retried.
     ///
-    /// Return false when the retry cap is reached, keeping the digest permanently.
+    /// Returns false once the retry cap is reached; the digest then stays registered so a batch
+    /// that never becomes executable cannot be retried forever.
     pub fn drop_digest(&self, batch_digest: B256) -> bool {
         let mut retries = self.retry_counts.lock();
         let count = retries.entry(batch_digest).or_insert(0);

--- a/crates/infrastructure/types/src/primary/certificate.rs
+++ b/crates/infrastructure/types/src/primary/certificate.rs
@@ -16,18 +16,18 @@ use crate::{
     Authority, AuthorityIdentifier, BlockHash, Committee, Digest, Epoch, Hash, Header, Round,
     TimestampSec, VotingPower,
 };
+use alloy::primitives::map::FbBuildHasher;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::{collections::BTreeMap, fmt};
 
-/// Certificates are the output of consensus.
-/// The certificate issued after a successful round of consensus.
+/// A header signed by a quorum (2f+1) of the committee.
 #[serde_as]
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Certificate {
     /// Certificate's header.
     pub header: Header,
-    /// Container for [BlsAggregateSignatureBytes].
+    /// The aggregate signature over the header and how far it has been verified.
     pub signature_verification_state: SignatureVerificationState,
     /// Bitmap that indicates which authorities from committee signed this certificate.
     #[serde_as(as = "RoaringBitmapSerde")]
@@ -39,7 +39,7 @@ pub struct Certificate {
 }
 
 impl Certificate {
-    /// Create a genesis certificate with empty payload.
+    /// Creates one empty round-0 certificate per authority.
     pub fn genesis(committee: &Committee) -> Vec<Self> {
         committee
             .authorities()
@@ -55,7 +55,7 @@ impl Certificate {
             .collect()
     }
 
-    /// Create a new, unsafe certificate that checks stake.
+    /// Builds a certificate from votes, requiring quorum stake but not verifying signatures.
     pub fn new_unverified(
         committee: &Committee,
         header: Header,
@@ -72,7 +72,7 @@ impl Certificate {
         )
     }
 
-    /// Create a new, unsafe certificate that does not check stake.
+    /// Builds a certificate from votes without a stake check, for tests.
     pub fn new_unsigned_for_test(
         committee: &Committee,
         header: Header,
@@ -89,7 +89,7 @@ impl Certificate {
         )
     }
 
-    /// Create a new certificate without verifying authority signatures.
+    /// Aggregates the votes into a certificate without verifying authority signatures.
     fn new_internal(
         committee: &Committee,
         header: Header,
@@ -165,17 +165,17 @@ impl Certificate {
         })
     }
 
-    /// Return the group of authorities that signed this certificate.
+    /// Returns the keys of the authorities that signed this certificate.
     ///
-    /// This function requires that certificate was verified against given committee
+    /// The certificate must belong to `committee`'s epoch.
     pub fn signed_authorities_with_committee(&self, committee: &Committee) -> Vec<BlsPublicKey> {
         assert_eq!(committee.epoch(), self.epoch());
         let (_stake, pks) = self.signed_by(&committee.bls_keys());
         pks
     }
 
-    /// Return the total stake and group of authorities that formed the committee for this
-    /// certificate.
+    /// Returns the signing weight and the signers' keys, given the committee keys in committee
+    /// order.
     pub fn signed_by(&self, committee: &[BlsPublicKey]) -> (VotingPower, Vec<BlsPublicKey>) {
         // Ensure the certificate has a quorum.
         let mut weight = 0;
@@ -197,30 +197,9 @@ impl Certificate {
         (weight, pks)
     }
 
-    /// Validate the certificate and verify signatures against the committee.
-    ///
-    /// The method returns a certificate with verified signature state.
-    ///
-    /// [SignatureVerificationState] stores both the verification status and signature bytes
-    /// together. While this creates some data redundancy with signed_authorities, keeping them
-    /// coupled provides important benefits:
-    ///
-    /// 1. Atomic State Updates - Changes to verification status are guaranteed to reference the
-    ///    exact signature bytes that were verified. This prevents state/signature mismatches that
-    ///    could occur if stored separately.
-    ///
-    /// 2. Verification Integrity - The verification status can only transition while operating on
-    ///    the specific signature bytes that were validated. This maintains a clear chain of trust
-    ///    through the verification process.
-    ///
-    /// 3. Invariant Preservation - Makes it impossible to have invalid states like:
-    ///    - VerifiedDirectly status with different signature bytes than what was actually verified
-    ///    - An Unsigned state containing signature bytes
-    ///    - A Verified state with missing/corrupted signature bytes
-    ///
-    /// While storing signatures in both places uses more memory, the strong correctness guarantees
-    /// outweigh the storage cost for certificate verification where maintaining cryptographic
-    /// integrity is critical.
+    /// Validates the certificate against the committee and verifies its aggregate signature,
+    /// returning it in verified state. See [`SignatureVerificationState`] for why the state and
+    /// the signature bytes travel together.
     pub fn validate_and_verify(self, committee: &Committee) -> CertificateResult<Certificate> {
         // ensure the header is from the correct epoch
         ensure!(
@@ -249,8 +228,8 @@ impl Certificate {
         Ok(verified_cert)
     }
 
-    /// Performs a signature verification of a certificate against committee.
-    /// Will clear the state first and revalidate even if it appears to be valid.
+    /// Verifies the aggregate signature against `committee`, resetting the verification state
+    /// first so an already-verified certificate is re-checked.
     pub fn verify_cert(mut self, committee: &[BlsPublicKey]) -> CertificateResult<Certificate> {
         self = self.validate_received()?;
         let (weight, pks) = self.signed_by(committee);
@@ -264,7 +243,7 @@ impl Certificate {
         Ok(verified_cert)
     }
 
-    /// Check the verification state and try to verify directly.
+    /// Verifies the signature unless the state already says it was verified.
     #[allow(deprecated)]
     fn verify_signature(mut self, pks: Vec<BlsPublicKey>) -> CertificateResult<Certificate> {
         // get signature from verification state
@@ -291,7 +270,7 @@ impl Certificate {
         Ok(self)
     }
 
-    /// Validate certificate was received and ready for verification.
+    /// Marks a received certificate as unverified so it must pass signature verification.
     pub fn validate_received(mut self) -> CertificateResult<Self> {
         self.set_signature_verification_state(SignatureVerificationState::Unverified(
             self.aggregated_signature()
@@ -310,7 +289,7 @@ impl Certificate {
         self.header.epoch()
     }
 
-    /// The nonce this certificate.
+    /// The nonce of this certificate's header.
     pub fn nonce(&self) -> u64 {
         self.header.nonce()
     }
@@ -325,7 +304,7 @@ impl Certificate {
         &self.header
     }
 
-    /// The aggregate signature for the certriciate.
+    /// The aggregate signature, absent for genesis.
     #[allow(deprecated)]
     pub fn aggregated_signature(&self) -> Option<BlsSignature> {
         match &self.signature_verification_state {
@@ -337,7 +316,7 @@ impl Certificate {
         }
     }
 
-    /// State of the Signature verification
+    /// The signature verification state.
     pub fn signature_verification_state(&self) -> &SignatureVerificationState {
         &self.signature_verification_state
     }
@@ -349,19 +328,17 @@ impl Certificate {
         &self.created_at
     }
 
-    /// Set the state of the Signature verification.
+    /// Sets the signature verification state.
     pub fn set_signature_verification_state(&mut self, state: SignatureVerificationState) {
         self.signature_verification_state = state;
     }
 
-    /// The bitmap of signed authorities for the certificate.
-    ///
-    /// This is the aggregate signature of all authorities for the certificate.
+    /// The bitmap of authorities, in committee order, whose votes form the aggregate signature.
     pub fn signed_authorities(&self) -> &roaring::RoaringBitmap {
         &self.signed_authorities
     }
 
-    /// Helper method if the certificate's verification state is verified.
+    /// Returns true if the signature has been verified or the certificate is genesis.
     #[allow(deprecated)]
     pub fn is_verified(&self) -> bool {
         matches!(
@@ -372,25 +349,17 @@ impl Certificate {
         )
     }
 
-    // Used for testing.
-
-    /// Change the certificate's header.
-    ///
-    /// Only Used for testing.
+    /// Replaces the certificate's header. Test-only.
     pub fn update_header_for_test(&mut self, header: Header) {
         self.header = header;
     }
 
-    /// Return a mutable reference to the header.
-    ///
-    /// Only Used for testing.
+    /// Returns the header mutably. Test-only.
     pub fn header_mut_for_test(&mut self) -> &mut Header {
         &mut self.header
     }
 
-    /// Change the certificate's created_at timestamp.
-    ///
-    /// Only Used for testing.
+    /// Replaces the creation timestamp. Test-only.
     pub fn update_created_at_for_test(&mut self, timestamp: TimestampSec) {
         self.created_at = timestamp;
     }
@@ -409,7 +378,7 @@ impl From<&Certificate> for Vec<u8> {
 }
 
 impl Certificate {
-    /// Skip one BCS-encoded certificate, returning the embedded header's byte span (the range
+    /// Skips one BCS-encoded certificate, returning the embedded header's byte span (the range
     /// [`Header::digest`] hashes, and therefore the certificate's digest preimage).
     pub fn skip_with_header_span<'a>(c: &mut BcsCursor<'a>) -> Result<&'a [u8], BcsLayoutError> {
         let header = c.take_span::<Header>()?;
@@ -429,42 +398,23 @@ impl BcsLayout for Certificate {
     }
 }
 
-// This will be used to take advantage of the
-// certificate chain that is formed via the DAG by only verifying the
-// leaves of the certificate chain when they are fetched from validators
-// during catchup.
-/// SignatureVerificationState stores both the verification status and signature bytes together.
-/// While this creates some data redundancy with signed_authorities, keeping them coupled provides
-/// important benefits:
-/// - atomic state updates: changes to verification status are guaranteed to reference the exact
-///   signature bytes that were verified. this prevents state/signature mismatches that could occur
-///   if stored separately.
+/// Verification status of a certificate's aggregate signature, carrying the signature bytes.
 ///
-/// - verification integrity: the verification status can only transition while operating on the
-///   specific signature bytes that were validated. this maintains a clear chain of trust through
-///   the verification process.
-///
-/// - impossible to have invalid states like:
-///    - `VerifiedDirectly` status with different signature bytes than what was actually verified
-///    - an unsigned state containing signature bytes
-///    - a verified state with missing/corrupted signature bytes
+/// The bytes live inside the state rather than beside it so a status can only be reached by
+/// operating on the exact bytes it describes: a verified state cannot hold bytes other than the
+/// ones that were verified, and an unsigned state cannot hold a quorum signature.
 #[derive(Copy, Clone, Serialize, Deserialize, Debug)]
 pub enum SignatureVerificationState {
-    /// This state occurs when the certificate has not yet received a quorum of
-    /// signatures.
+    /// The certificate has not yet received a quorum of signatures.
     Unsigned(BlsSignature),
-    /// This state occurs when a certificate has just been received from the network
-    /// and has not been verified yet.
+    /// The certificate arrived from the network and has not been verified.
     Unverified(BlsSignature),
-    /// This state occurs when a certificate was either created locally, received
-    /// via brodacast, or fetched but was not the parent of another certificate.
-    /// Therefore this certificate had to be verified directly.
+    /// The aggregate signature was verified on this node.
     VerifiedDirectly(BlsSignature),
     /// Kept for BCS variant index stability with existing consensus DBs.
     #[deprecated(note = "not assigned, kept for serialization index stability")]
     VerifiedIndirectly(BlsSignature),
-    /// This state occurs only for genesis certificates which always has valid
-    /// signatures bytes but the bytes are garbage so we don't mark them as verified.
+    /// A genesis certificate, which carries no signature and needs no verification.
     Genesis,
 }
 
@@ -490,10 +440,7 @@ impl BcsLayout for SignatureVerificationState {
     }
 }
 
-/// Process certificate received by setting the verification state.
-///
-/// Recover signature bytes from the aggregated signature and set the signature verification state
-/// to unverified.
+/// Marks a received certificate as unverified so it must pass signature verification.
 pub fn validate_received_certificate(
     mut certificate: Certificate,
 ) -> CertificateResult<Certificate> {
@@ -505,14 +452,26 @@ pub fn validate_received_certificate(
     Ok(certificate)
 }
 
-/// Certificate digest.
+/// Digest of a certificate, equal to the digest of its header.
 #[derive(
     Clone, Copy, Default, PartialEq, Eq, std::hash::Hash, PartialOrd, Ord, Serialize, Deserialize,
 )]
 pub struct CertificateDigest(Digest<{ crypto::DIGEST_LENGTH }>);
 
+/// Hash map keyed by [`CertificateDigest`].
+///
+/// The key is already a uniformly distributed 32-byte hash, so the hasher consumes its bytes
+/// directly instead of running SipHash over them on every lookup. Sound because the derived
+/// `Hash` writes exactly the digest's 32 bytes: array length prefixes route through
+/// `write_usize`, which this hasher discards.
+pub type CertificateDigestMap<V> =
+    std::collections::HashMap<CertificateDigest, V, FbBuildHasher<32>>;
+
+/// Hash set of [`CertificateDigest`]; see [`CertificateDigestMap`] for why the hasher is sound.
+pub type CertificateDigestSet = std::collections::HashSet<CertificateDigest, FbBuildHasher<32>>;
+
 impl CertificateDigest {
-    /// Create a new instance of CertificateDigest.
+    /// Creates a digest from its raw bytes.
     pub fn new(digest: [u8; crypto::DIGEST_LENGTH]) -> Self {
         CertificateDigest(Digest { digest })
     }
@@ -590,9 +549,29 @@ impl PartialEq for Certificate {
 
 #[cfg(test)]
 mod tests {
+
+    /// The fixed-bytes hasher requires every key to hash as exactly 32 bytes and enforces it
+    /// with a debug assertion, so this exercises real map operations to pin that
+    /// `CertificateDigest`'s derived `Hash` satisfies the contract. A key that also wrote a
+    /// length prefix would trip the assertion here.
+    #[test]
+    fn certificate_digest_map_hashes_exactly_the_digest_bytes() {
+        let mut map = super::CertificateDigestMap::default();
+        let mut set = super::CertificateDigestSet::default();
+        for byte in 0..8u8 {
+            let digest = CertificateDigest::new([byte; crypto::DIGEST_LENGTH]);
+            map.insert(digest, byte);
+            set.insert(digest);
+        }
+        let probe = CertificateDigest::new([3u8; crypto::DIGEST_LENGTH]);
+        assert_eq!(map.get(&probe), Some(&3));
+        assert!(set.contains(&probe));
+        assert_eq!(map.len(), 8);
+    }
+
     use super::*;
 
-    /// Create a minimal certificate for serialization tests.
+    /// Creates a minimal certificate for serialization tests.
     fn make_test_certificate(state: SignatureVerificationState) -> Certificate {
         Certificate {
             header: Header::default(),
@@ -602,7 +581,7 @@ mod tests {
         }
     }
 
-    /// Verify BCS roundtrip for every SignatureVerificationState variant.
+    /// Verifies the BCS roundtrip for every SignatureVerificationState variant.
     /// Removing or reordering variants breaks persisted certificate deserialization.
     #[test]
     #[allow(deprecated)]
@@ -644,7 +623,7 @@ mod tests {
         }
     }
 
-    /// Pin BCS variant indices to expected positions.
+    /// Pins BCS variant indices to expected positions.
     /// BCS uses ULEB128 variant indices; shifting breaks DB compatibility.
     #[test]
     #[allow(deprecated)]

--- a/crates/infrastructure/types/src/primary/header.rs
+++ b/crates/infrastructure/types/src/primary/header.rs
@@ -1,3 +1,5 @@
+//! Consensus header: a primary's per-round proposal of worker batches and parent certificates.
+
 use crate::{
     bcs_layout::{BcsCursor, BcsLayout, BcsLayoutError},
     crypto, encode,
@@ -17,29 +19,29 @@ use std::{collections::BTreeSet, fmt};
 pub struct Header {
     /// Primary that created the header. Must be the same primary that broadcasted the header.
     pub author: AuthorityIdentifier,
-    /// The round for this header
+    /// The round for this header.
     pub round: Round,
     /// The epoch this Header was created in.
     pub epoch: Epoch,
     /// The timestamp for when the header was requested to be created.
     pub created_at: TimestampSec,
-    /// IndexMap of the [BatchDigest] to the [WorkerId]
+    /// Batch digests proposed by this header, each mapped to the worker that sealed it.
     #[serde(with = "indexmap::map::serde_seq")]
     pub payload: IndexMap<BlockHash, WorkerId>,
     /// Parent certificates for this Header.
     pub parents: BTreeSet<CertificateDigest>,
-    /// Hash and number of the latest known execution block when this Header was build.
-    /// This may be our parent block or may not but it does include our latest
-    /// execution result in a signed and validated structure which validates
-    /// this execution block as well.
+    /// Hash and number of the latest execution block known when the header was built.
+    ///
+    /// Carrying it in a signed header lets peers validate the author's execution result along with
+    /// the proposal.
     pub latest_execution_block: BlockNumHash,
-    /// The [HeaderDigest].
+    /// Cached digest. Off-wire, so a decoded header recomputes it on first use.
     #[serde(skip)]
     pub digest: OnceCell<HeaderDigest>,
 }
 
 impl Header {
-    /// Initialize a new instance of [HeaderV1]
+    /// Creates a header and seals its digest.
     pub fn new(
         author: AuthorityIdentifier,
         round: Round,
@@ -63,14 +65,14 @@ impl Header {
         header
     }
 
-    /// Hashed digest for Header
+    /// Returns the header digest, computing and caching it on first use.
     pub fn digest(&self) -> HeaderDigest {
         *self.digest.get_or_init(|| Hash::digest(self))
     }
 
-    /// Ensure the header is valid based on the current committee and workercache.
+    /// Validates the header against the current committee.
     ///
-    /// The digest is calculated with the sealed header, so the EL data is also verified.
+    /// The digest covers the whole header, so the execution-layer fields are verified with it.
     pub fn validate(&self, committee: &Committee) -> HeaderResult<()> {
         // Ensure the header is from the correct epoch.
         if self.epoch != committee.epoch() {
@@ -82,8 +84,11 @@ impl Header {
             return Err(HeaderError::TooManyParents(self.parents.len(), committee.size()));
         }
 
-        // Ensure the header digest is well formed.
-        if Hash::digest(self) != self.digest() {
+        // Hash once: a decoded header's cell is empty (the digest is off-wire), so seeding it
+        // with the computed value fills the cache, while a cell set before a later mutation still
+        // fails the comparison.
+        let computed = Hash::digest(self);
+        if *self.digest.get_or_init(|| computed) != computed {
             return Err(HeaderError::InvalidHeaderDigest);
         }
 
@@ -127,23 +132,17 @@ impl Header {
         &self.parents
     }
 
-    // Used for testing.
-
-    /// Replace the header's payload with a new one.
-    ///
-    /// Only used for testing.
+    /// Replaces the header's payload. Test-only.
     pub fn update_payload_for_test(&mut self, new_payload: IndexMap<BlockHash, WorkerId>) {
         self.payload = new_payload;
     }
 
-    /// Replace the header's round with a new one.
-    ///
-    /// Only used for testing.
+    /// Replaces the header's round. Test-only.
     pub fn update_round_for_test(&mut self, new_round: Round) {
         self.round = new_round;
     }
 
-    /// Clear the header's parents.
+    /// Clears the header's parents. Test-only.
     pub fn clear_parents_for_test(&mut self) {
         self.parents.clear();
     }
@@ -161,9 +160,8 @@ impl From<Header> for CertificateDigest {
 }
 
 impl HeaderBuilder {
-    /// "Build" the header by taking all fields and calculating the hash.
-    /// This is used for tests, if used for "real" code then at least latest_execution_block will
-    /// need to be visited.
+    /// Builds the header and seals its digest. Test-only: `latest_execution_block` defaults to
+    /// zero, which a real proposal must never carry.
     pub fn build(self) -> Header {
         let h = Header {
             author: self.author.expect("author set for header builder"),
@@ -181,7 +179,7 @@ impl HeaderBuilder {
         h
     }
 
-    /// Helper method to directly set values of the payload
+    /// Adds `batch` to the payload under `worker_id`.
     pub fn with_payload_batch(mut self, batch: Batch, worker_id: WorkerId) -> Self {
         if self.payload.is_none() {
             self.payload = Some(Default::default());
@@ -201,7 +199,7 @@ impl HeaderBuilder {
 pub struct HeaderDigest(Digest<{ crypto::DIGEST_LENGTH }>);
 
 impl HeaderDigest {
-    /// Create a new HeaderDigest based on the crate's `DIGEST_LENGTH` constant.
+    /// Creates a digest from its raw bytes.
     pub fn new(digest: [u8; crypto::DIGEST_LENGTH]) -> Self {
         HeaderDigest(Digest { digest })
     }

--- a/crates/infrastructure/types/src/processor/batch_ordering.rs
+++ b/crates/infrastructure/types/src/processor/batch_ordering.rs
@@ -150,10 +150,11 @@ impl From<&BatchOrderingState> for StoredBatchOrderingState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{encode, try_decode, Batch, ExecHeader};
+    use crate::{encode, try_decode, Batch, Bytes, ExecHeader};
 
     fn legacy_state_with_parked() -> BatchOrderingState {
-        let batch = Batch::new_for_test(vec![vec![0u8; 64].into()], ExecHeader::default(), 0, 0, 7);
+        let batch =
+            Batch::new_for_test(vec![Bytes::from(vec![0u8; 64])], ExecHeader::default(), 0, 0, 7);
         let digest = batch.digest();
         let prepared = PreparedBatch {
             batch: Arc::new(batch),

--- a/crates/infrastructure/types/src/processor/batch_ordering.rs
+++ b/crates/infrastructure/types/src/processor/batch_ordering.rs
@@ -153,7 +153,7 @@ mod tests {
     use crate::{encode, try_decode, Batch, ExecHeader};
 
     fn legacy_state_with_parked() -> BatchOrderingState {
-        let batch = Batch::new_for_test(vec![vec![0u8; 64]], ExecHeader::default(), 0, 0, 7);
+        let batch = Batch::new_for_test(vec![vec![0u8; 64].into()], ExecHeader::default(), 0, 0, 7);
         let digest = batch.digest();
         let prepared = PreparedBatch {
             batch: Arc::new(batch),

--- a/crates/infrastructure/types/src/worker/sealed_batch.rs
+++ b/crates/infrastructure/types/src/worker/sealed_batch.rs
@@ -1,7 +1,4 @@
-//! Batch implementation for consensus.
-//!
-//! Batches hold transactions and other data. This type is used to represent worker proposals that
-//! have reached quorum.
+//! Worker batches: the transaction payloads a worker proposes, sealed by digest for consensus.
 
 use crate::{
     crypto, encode, Address, BlockHash, Bytes, Epoch, ExecHeader, TimestampSec,
@@ -13,7 +10,7 @@ use thiserror::Error;
 
 use super::WorkerId;
 
-/// The batch for workers to communicate for consensus.
+/// A batch paired with its digest.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct SealedBatch {
     /// The immutable batch fields.
@@ -23,62 +20,58 @@ pub struct SealedBatch {
 }
 
 impl SealedBatch {
-    /// Create a new instance of Self.
+    /// Creates a sealed batch from a batch and a digest.
     ///
     /// WARNING: this does not verify the provided digest matches the provided batch.
     pub fn new(batch: Batch, digest: BlockHash) -> Self {
         Self { batch, digest }
     }
 
-    /// Consume self to extract the batch so it can be modified.
+    /// Consumes the seal and returns the batch so it can be modified.
     pub fn unseal(self) -> Batch {
         self.batch
     }
 
-    /// Return the sealed batch fields.
+    /// Returns the sealed batch.
     pub fn batch(&self) -> &Batch {
         &self.batch
     }
 
-    /// Return the digest of the sealed batch.
+    /// Returns the digest of the sealed batch.
     pub fn digest(&self) -> BlockHash {
         self.digest
     }
 
-    /// Split Self into separate parts.
-    ///
-    /// This is the inverse of [`Batch::seal_slow`].
+    /// Splits the seal into its batch and digest, the inverse of [`Batch::seal_slow`].
     pub fn split(self) -> (Batch, BlockHash) {
         (self.batch, self.digest)
     }
 
-    /// Size of the sealed batch.
+    /// Returns the in-memory size of the sealed batch in bytes.
     pub fn size(&self) -> usize {
         self.batch.size() + size_of::<BlockHash>()
     }
 }
 
-/// The batch for workers to communicate for consensus.
+/// A worker's proposal: transaction payloads plus the fields that fix their execution context.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Batch {
-    /// The collection of transactions in this batch as bytes.
-    pub transactions: Vec<Vec<u8>>,
+    /// The encoded transactions in this batch.
+    ///
+    /// `Bytes` is refcounted, so cloning a `Batch` through the seal, quorum, and ordering stages
+    /// bumps a reference instead of deep-copying every payload. `Vec<Bytes>` and `Vec<Vec<u8>>`
+    /// are bcs-identical (each element a length-prefixed byte run), so peers holding either shape
+    /// interoperate byte for byte.
+    pub transactions: Vec<Bytes>,
     /// The epoch that this batch belongs to.
     pub epoch: Epoch,
-    /// The 160-bit address to which all fees collected from the successful mining of this batch
-    /// be transferred; formally Hc.
+    /// The address that receives the fees collected from this batch.
     pub beneficiary: Address,
-    /// A scalar representing EIP1559 base fee which can move up or down each batch according
-    /// to a formula which is a function of gas used in parent batch and gas target
-    /// (batch gas limit divided by elasticity multiplier) of parent batch.
-    /// The algorithm results in the base fee per gas increasing when batches are
-    /// above the gas target, and decreasing when batches are below the gas target. The base fee
-    /// per gas is sent to governance address.
+    /// The EIP-1559 base fee in effect for this batch; a peer rejects a batch whose base fee
+    /// differs from the one it expects.
     pub base_fee_per_gas: u64,
-    /// The worker id for the worker that originated this batch.
-    /// Worker ids will be consistent across validators (i.e. worker 0 talks to other worker 0s,
-    /// etc). We can use this for tracking to support base fee calculations.
-    /// Note: worker id 0 is the default.
+    /// The id of the worker that sealed this batch. Worker ids are consistent across validators
+    /// (worker 0 talks to every other worker 0); 0 is the default.
     pub worker_id: WorkerId,
     /// Monotonically increasing sequence number per worker, used for ordering.
     /// Persists across epochs and restarts. All validators see the same value.
@@ -88,20 +81,18 @@ pub struct Batch {
     /// and executes those batches immediately without ordering constraints.
     #[serde(default)]
     pub seq: u64,
-    /// Timestamp of when the entity was received by another node. This will help
-    /// calculate latencies that are not affected by clock drift or network
-    /// delays. This field is not set for own batches.
+    /// When this node received the batch; unset for its own batches. Used for latency
+    /// measurements that clock drift cannot skew.
+    ///
+    /// Node-local, so it is off-wire and excluded from the digest.
     #[serde(skip)]
-    // This field changes often so don't serialize (i.e. don't use it in the digest)
     pub received_at: Option<TimestampSec>,
 }
 
 impl Batch {
-    /// Create a new batch for testing only!
-    ///
-    /// This is NOT a valid batch for consensus.
+    /// Creates a batch for tests. Not a valid batch for consensus.
     pub fn new_for_test(
-        transactions: Vec<Vec<u8>>,
+        transactions: Vec<Bytes>,
         header: ExecHeader,
         worker_id: WorkerId,
         epoch: Epoch,
@@ -118,54 +109,47 @@ impl Batch {
         }
     }
 
-    /// Size of the batch in bytes (including transactions).
+    /// Returns the in-memory size of the batch in bytes, including its transactions.
     pub fn size(&self) -> usize {
         size_of::<Self>() + self.transactions.iter().map(|tx| tx.len()).sum::<usize>()
     }
 
-    /// Digest for this batch (the hash of the sealed header).
-    ///
-    /// NOTE: `Self::received_at` is skipped during serialization and is excluded from the digest.
+    /// Returns the digest of the batch: the hash of its wire encoding, which excludes
+    /// `received_at`.
     pub fn digest(&self) -> BlockHash {
         let mut hasher = crypto::DefaultHashFunction::new();
         hasher.update(encode(self).as_ref());
-        // finalize
         BlockHash::from_slice(hasher.finalize().as_bytes())
     }
 
-    /// Returns a reference to the collection of transaction bytes.
-    pub fn transactions(&self) -> &Vec<Vec<u8>> {
+    /// Returns the encoded transactions.
+    pub fn transactions(&self) -> &Vec<Bytes> {
         &self.transactions
     }
 
-    /// Returns a mutable reference to a collection of transaction bytes.
-    pub fn transactions_mut(&mut self) -> &mut Vec<Vec<u8>> {
+    /// Returns the encoded transactions mutably.
+    pub fn transactions_mut(&mut self) -> &mut Vec<Bytes> {
         &mut self.transactions
     }
 
-    /// Returns the received at time if available.
+    /// Returns when this node received the batch, if it is not its own.
     pub fn received_at(&self) -> Option<TimestampSec> {
         self.received_at
     }
 
-    /// Sets the received-at time.
+    /// Records when this node received the batch.
     pub fn set_received_at(&mut self, time: TimestampSec) {
         self.received_at = Some(time)
     }
 
-    /// Seal the header with a known hash.
+    /// Seals the batch with a known digest.
     ///
-    /// WARNING: This method does not verify whether the hash is correct.
+    /// WARNING: this does not verify the digest matches the batch.
     pub fn seal(self, digest: BlockHash) -> SealedBatch {
         SealedBatch::new(self, digest)
     }
 
-    /// Seal the batch.
-    ///
-    /// Calculate the hash and seal the batch so it can't be changed.
-    ///
-    /// NOTE: `Batch::received_at` is skipped during serialization and is excluded from the
-    /// digest.
+    /// Computes the digest and seals the batch so it can no longer change.
     pub fn seal_slow(self) -> SealedBatch {
         let digest = self.digest();
         self.seal(digest)
@@ -198,17 +182,16 @@ impl From<&[u8]> for SealedBatch {
     }
 }
 
-/// Return the max gas per batch in effect for the epoch.
+/// Returns the gas limit per batch in effect for `epoch`.
 ///
-/// Currently always 30,000,000; the epoch parameter lets a fork change it.
+/// Epoch-keyed so a future fork can change it at an epoch boundary.
 pub fn max_batch_gas(_epoch: Epoch) -> u64 {
     ETHEREUM_BLOCK_GAS_LIMIT_56BITS
 }
 
-/// Return the max batch size in bytes in effect for the epoch.
+/// Returns the byte-size limit per batch in effect for `epoch`; a larger batch fails to decode.
 ///
-/// Currently always 2,000,000; the epoch parameter lets a fork change it. A larger batch fails
-/// the message size check on decode.
+/// Epoch-keyed so a future fork can change it at an epoch boundary.
 pub fn max_batch_size(_epoch: Epoch) -> usize {
     2_000_000
 }
@@ -320,12 +303,12 @@ pub trait BatchValidation: Send + Sync + Debug {
 /// Errors that can occur during batch submission.
 #[derive(Error, Debug)]
 pub enum SubmitBatchError {
-    /// The transaction is not correctly encoded.
+    /// The transaction bytes do not decode.
     #[error("Invalid transaction bytes")]
     InvalidTransactionBytes,
 }
 
-/// Errors from validating a peer's batch.
+/// Batch validation errors.
 #[derive(Error, Debug)]
 pub enum BatchValidationError {
     /// The sealed batch hash does not match this worker's calculated digest.
@@ -359,21 +342,36 @@ pub enum BatchValidationError {
     /// If any transaction fails to decode, the entire batch validation fails.
     #[error("Failed to decode transaction for batch {0}: {1}")]
     RecoverTransaction(BlockHash, String),
-    /// Error, invalid base fee set.
+    /// The batch's base fee differs from the one this node expects.
     #[error("Invalid base fee, expected {expected_base_fee} got {base_fee}")]
-    InvalidBaseFee { expected_base_fee: u64, base_fee: u64 },
-    /// Error, wrong worker id.
+    InvalidBaseFee {
+        /// The base fee this node expects.
+        expected_base_fee: u64,
+        /// The base fee the batch carries.
+        base_fee: u64,
+    },
+    /// The batch's worker id is not the one this worker pairs with.
     #[error("Invalid worker id, expected {expected_worker_id} got {worker_id}")]
-    InvalidWorkerId { expected_worker_id: WorkerId, worker_id: WorkerId },
+    InvalidWorkerId {
+        /// The worker id this node expects.
+        expected_worker_id: WorkerId,
+        /// The worker id the batch carries.
+        worker_id: WorkerId,
+    },
     /// The batch contains blob transactions EIP-4844.
     #[error("Proposed batch contains blob transaction. Tx hash: {0}")]
     InvalidTx4844(BlockHash),
     /// The total allowable gas in the batch exceeds `u64::MAX`.
     #[error("Overflow calculating max possible gas.")]
     GasOverflow,
-    /// Error, wrong epoch.
+    /// The batch belongs to a different epoch.
     #[error("Invalid epoch, expected epoch {expected} got epoch {found}")]
-    InvalidEpoch { expected: Epoch, found: Epoch },
+    InvalidEpoch {
+        /// The current epoch.
+        expected: Epoch,
+        /// The epoch the batch carries.
+        found: Epoch,
+    },
 }
 
 #[cfg(test)]
@@ -434,5 +432,59 @@ mod committee_slots_tests {
         assert!(slots.covers(3), "down slot 3 fails over to us");
         // slot 2 is live, so it keeps its own senders
         assert!(!slots.covers(2), "a live peer keeps its senders");
+    }
+}
+
+#[cfg(test)]
+mod batch_wire_tests {
+    use super::*;
+    use alloy::primitives::b256;
+
+    /// A transaction-shaped fixture set: empty, tiny, and multi-KB payloads, crossing the 128-byte
+    /// ULEB128 length boundary where bcs switches to a two-byte length prefix.
+    fn tx_fixtures() -> Vec<Vec<u8>> {
+        vec![vec![], vec![0x01], vec![0xab; 127], vec![0xcd; 128], vec![0xef; 3000]]
+    }
+
+    /// A `Vec<u8>` payload and a `Bytes` payload encode to byte-identical bcs, in both directions.
+    /// bcs is positional and non-self-describing, so this equality is what makes the transaction
+    /// container a node-local choice rather than a wire-format change: an un-upgraded peer reads
+    /// either shape as the same bytes.
+    #[test]
+    fn tx_payload_bcs_identical_for_vec_u8_and_bytes() {
+        let vecs = tx_fixtures();
+        let bytes: Vec<Bytes> = vecs.iter().cloned().map(Bytes::from).collect();
+
+        let vecs_encoded = bcs::to_bytes(&vecs).expect("encode Vec<Vec<u8>>");
+        let bytes_encoded = bcs::to_bytes(&bytes).expect("encode Vec<Bytes>");
+        assert_eq!(vecs_encoded, bytes_encoded);
+
+        // Cross-decode: each shape decodes what the other encoded.
+        let decoded_bytes: Vec<Bytes> = bcs::from_bytes(&vecs_encoded).expect("decode as Bytes");
+        let decoded_vecs: Vec<Vec<u8>> = bcs::from_bytes(&bytes_encoded).expect("decode as Vec");
+        assert_eq!(decoded_bytes, bytes);
+        assert_eq!(decoded_vecs, vecs);
+    }
+
+    /// Pins the full `Batch` wire encoding (and therefore its digest) to golden bytes, so any
+    /// encoding drift - field reorder, container change, serde attribute change - fails here.
+    #[test]
+    fn batch_encoding_golden_bytes() {
+        let batch = Batch {
+            transactions: tx_fixtures().into_iter().map(Into::into).collect(),
+            epoch: 7,
+            beneficiary: Address::repeat_byte(0x42),
+            base_fee_per_gas: 1_000_000_007,
+            worker_id: 3,
+            seq: 99,
+            received_at: Some(123), // #[serde(skip)]: must not affect the encoding
+        };
+        assert_eq!(encode(&batch).len(), 3307);
+        assert_eq!(
+            batch.digest(),
+            BlockHash::from(b256!(
+                "57f612eb1bc9989d90e87cb205e2a3e35332613695a7ef2f1ca70e63bb82784f"
+            ))
+        );
     }
 }

--- a/crates/infrastructure/types/src/worker/sealed_batch.rs
+++ b/crates/infrastructure/types/src/worker/sealed_batch.rs
@@ -276,23 +276,22 @@ impl CommitteeSlots {
     }
 }
 
-/// Validation of a peer's batch and admission of transactions received from other nodes.
-///
-/// Invalid transactions receive no further processing.
+/// Validation and admission of transactions, whether forwarded singly or received in a peer's
+/// batch.
 #[async_trait::async_trait]
 pub trait BatchValidation: Send + Sync + Debug {
     /// Determines whether this batch can be voted on.
-    async fn validate_batch(&self, b: SealedBatch) -> Result<(), BatchValidationError>;
+    async fn validate_batch(&self, b: &SealedBatch) -> Result<(), BatchValidationError>;
 
-    /// Admit a gossiped transaction message to the pool if its first transaction maps to a slot
-    /// this validator covers.
+    /// Submits encoded transactions to this node's pool, but only when the first transaction's
+    /// sender maps to a slot this validator covers.
     fn submit_batch_if_mine(
         &self,
         tx_bytes: &[Bytes],
         slots: &CommitteeSlots,
     ) -> Result<(), SubmitBatchError>;
 
-    /// Admit transactions forwarded directly by an observer, returning the hashes rejected as
+    /// Admits transactions forwarded directly by an observer, returning the hashes rejected as
     /// stale (already executed) so the sender stops re-forwarding them.
     ///
     /// Takes the decoded bytes by value so the owned buffer moves into the blocking recovery task

--- a/crates/middleware/bridge/src/subscriber.rs
+++ b/crates/middleware/bridge/src/subscriber.rs
@@ -20,19 +20,15 @@ use rayls_infrastructure_config::LibP2pConfig;
 use rayls_infrastructure_network_types::{local::LocalNetwork, PrimaryToWorkerClient};
 use rayls_infrastructure_storage::CertificateStore;
 use rayls_infrastructure_types::{
-    Address, AuthorityIdentifier, Batch, BlockHash, CameFrom, CertifiedBatch, CommittedSubDag,
-    Committee, ConsensusHeader, ConsensusOutput, Database, Epoch, Hash as _, Noticer,
-    RaylsReceiver, RaylsSender, Round, TaskKind, TaskManager, TaskSpawner, Timestamp, TimestampSec,
-    B256,
+    Address, AuthorityIdentifier, B256Map, B256Set, Batch, BlockHash, CameFrom, CertifiedBatch,
+    CommittedSubDag, Committee, ConsensusHeader, ConsensusOutput, Database, Epoch, Hash as _,
+    Noticer, RaylsReceiver, RaylsSender, Round, TaskKind, TaskManager, TaskSpawner, Timestamp,
+    TimestampSec, B256,
 };
 // production-only: signing the consensus result for gossip
 #[cfg(not(feature = "dev-single-node-setup"))]
 use rayls_infrastructure_types::{encode, to_intent_message, BlsSigner as _};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
@@ -982,7 +978,7 @@ impl<DB: Database> Subscriber<DB> {
                     let sig =
                         self.config.key_config().request_signature_direct(&encode(&to_intent_message(consensus_result_hash)));
 
-                    // pre-publish gossipsub diagnostics (production only — dev has no peers)
+                    // pre-publish gossipsub diagnostics (production only - dev has no peers)
                     #[cfg(not(feature = "dev-single-node-setup"))]
                     {
                         let consensus_output_topic = LibP2pConfig::consensus_output_topic();
@@ -1035,7 +1031,7 @@ impl<DB: Database> Subscriber<DB> {
                     let header_for_cache = ConsensusHeader { parent_hash, sub_dag: sub_dag.clone(), number, extra: B256::default() };
                     store_consensus_header_in_cache(self.config.node_storage(), &header_for_cache);
 
-                    // Dev (single-node): no peers — skip gossip entirely.
+                    // Dev (single-node): no peers - skip gossip entirely.
                     #[cfg(not(feature = "dev-single-node-setup"))]
                     if let Err(e) = self.network_handle.publish_consensus(epoch, round, number, last_parent, self.config.key_config().public_key(), sig).await {
                         error!(target: "subscriber", "error publishing latest consensus to network {:?}: {}", self.inner.authority_id, e);
@@ -1162,7 +1158,7 @@ impl<DB: Database> Subscriber<DB> {
             ..Default::default()
         };
 
-        let mut batch_set: HashSet<BlockHash> = HashSet::new();
+        let mut batch_set = B256Set::default();
 
         for cert in &sub_dag.certificates {
             for (digest, _) in cert.header().payload().iter() {
@@ -1221,9 +1217,9 @@ impl<DB: Database> Subscriber<DB> {
 
     async fn fetch_batches_from_peers(
         &self,
-        batch_digests: HashSet<BlockHash>,
-    ) -> SubscriberResult<HashMap<BlockHash, Batch>> {
-        let mut fetched_blocks = HashMap::new();
+        batch_digests: B256Set,
+    ) -> SubscriberResult<B256Map<Batch>> {
+        let mut fetched_blocks = B256Map::default();
 
         debug!(target: "subscriber", "Attempting to fetch {} digests peers", batch_digests.len(),);
         let blocks = match self.inner.client.fetch_batches(batch_digests.clone()).await {

--- a/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
@@ -468,7 +468,7 @@ mod tests {
 
     /// Builds a minimal batch stored under a header's payload digest.
     fn batch_for(number: u64) -> Batch {
-        Batch { transactions: vec![vec![number as u8]], seq: number, ..Default::default() }
+        Batch { transactions: vec![vec![number as u8].into()], seq: number, ..Default::default() }
     }
 
     /// Builds a consensus header whose certificate payload references `digest`.

--- a/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
@@ -385,8 +385,8 @@ mod tests {
         DatabaseType,
     };
     use rayls_infrastructure_types::{
-        Batch, BlockHash, Certificate, CommittedSubDag, ConsensusHeader, DbTx, DbTxMut, Epoch,
-        Header, ReputationScores,
+        Batch, BlockHash, Bytes, Certificate, CommittedSubDag, ConsensusHeader, DbTx, DbTxMut,
+        Epoch, Header, ReputationScores,
     };
     use tempfile::TempDir;
 
@@ -468,7 +468,11 @@ mod tests {
 
     /// Builds a minimal batch stored under a header's payload digest.
     fn batch_for(number: u64) -> Batch {
-        Batch { transactions: vec![vec![number as u8].into()], seq: number, ..Default::default() }
+        Batch {
+            transactions: vec![Bytes::from(vec![number as u8])],
+            seq: number,
+            ..Default::default()
+        }
     }
 
     /// Builds a consensus header whose certificate payload references `digest`.
@@ -597,7 +601,7 @@ mod tests {
         // producer's in-flight inserts fail fast — but the DB is poisoned either way. The junk
         // never commits, so the seal's reads stay clean; the archival pass then fails on the
         // poisoned DB and surfaces the failure as a `WriteFailed`.
-        let big = Batch { transactions: vec![vec![0u8; 4096]], ..Default::default() };
+        let big = Batch { transactions: vec![Bytes::from(vec![0u8; 4096])], ..Default::default() };
         match db.with_write_txn(|txn| {
             for i in 0..4_000u64 {
                 txn.insert::<Batches>(&digest_for(10_000 + i), &big)?;

--- a/crates/middleware/orchestrator/src/epoch_manager/core.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/core.rs
@@ -23,10 +23,10 @@ use rayls_execution_evm::{reth_env::RethEnv, system_calls::EpochState};
 use rayls_infrastructure_config::{KeyConfig, LibP2pConfig, NetworkConfig, RaylsDirs};
 use rayls_infrastructure_storage::{tables::ConsensusBlocks, EpochStore as _};
 use rayls_infrastructure_types::{
-    error::HeaderError, gas_accumulator::GasAccumulator, BlsAggregateSignature, BlsPublicKey,
-    BlsSignature, CameFrom, ConsensusOutput, Database as ReDatabase, Epoch, EpochCertificate,
-    EpochRecord, EpochVote, Noticer, Notifier, RaylsReceiver, RaylsSender, TaskJoinError, TaskKind,
-    TaskManager, VotesAggregator, B256,
+    error::HeaderError, gas_accumulator::GasAccumulator, B256Map, BlsAggregateSignature,
+    BlsPublicKey, BlsSignature, CameFrom, ConsensusOutput, Database as ReDatabase, Epoch,
+    EpochCertificate, EpochRecord, EpochVote, Noticer, Notifier, RaylsReceiver, RaylsSender,
+    TaskJoinError, TaskKind, TaskManager, VotesAggregator, B256,
 };
 use rayls_middleware_processor::{batch::BatchOrdering, reconstruct_batch_digests};
 use std::{
@@ -1022,7 +1022,7 @@ where
             let mut reached_quorum = false;
             let mut timeout = Duration::from_secs(5);
             let mut timeouts = 0;
-            let mut alt_recs: HashMap<B256, VotesAggregator<EpochVote>> = HashMap::default();
+            let mut alt_recs: B256Map<VotesAggregator<EpochVote>> = B256Map::default();
             loop {
                 // Break promptly when the consumer phase is signalled, rather than only
                 // noticing after the recv timeout. `biased` so shutdown wins over a vote arriving.

--- a/crates/middleware/orchestrator/tests/it/main.rs
+++ b/crates/middleware/orchestrator/tests/it/main.rs
@@ -21,10 +21,10 @@ use rayls_infrastructure_storage::{
     tables::{ConsensusBlockNumbersByDigest, ConsensusBlocks},
 };
 use rayls_infrastructure_types::{
-    gas_accumulator::GasAccumulator, testnet_genesis, Batch, CommittedSubDag, ConsensusHeader,
-    ConsensusOutput, Database, DbTxMut, ExecHeader, Notifier, RaylsReceiver as _, RaylsSender as _,
-    ReputationScores, SealedHeader, TaskManager, B256, DEFAULT_BAD_NODES_STAKE_THRESHOLD,
-    ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+    gas_accumulator::GasAccumulator, testnet_genesis, B256Map, Batch, CommittedSubDag,
+    ConsensusHeader, ConsensusOutput, Database, DbTxMut, ExecHeader, Notifier, RaylsReceiver as _,
+    RaylsSender as _, ReputationScores, SealedHeader, TaskManager, B256,
+    DEFAULT_BAD_NODES_STAKE_THRESHOLD, ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
 };
 use rayls_middleware_bridge::subscriber::spawn_subscriber;
 use rayls_middleware_orchestrator::epoch_manager::catchup_accumulator;
@@ -188,7 +188,7 @@ async fn test_catchup_accumulator() -> eyre::Result<()> {
 fn spawn_consensus(
     fixture: &CommitteeFixture<MemDatabase>,
     consensus_bus: &ConsensusBus,
-    batches: HashMap<B256, Batch>,
+    batches: B256Map<Batch>,
     config: ConsensusConfig<MemDatabase>,
     consensus_store: MemDatabase,
     task_manager: &TaskManager,

--- a/crates/middleware/processor/src/execution/block.rs
+++ b/crates/middleware/processor/src/execution/block.rs
@@ -10,8 +10,8 @@ use rayls_execution_evm::{
     ExecutedBlock,
 };
 use rayls_infrastructure_types::{
-    gas_accumulator::GasAccumulator, payload::RLPayload, ConsensusOutput, SealedHeader, B256,
-    MIN_PROTOCOL_BASE_FEE,
+    gas_accumulator::GasAccumulator, payload::RLPayload, Bytes, ConsensusOutput, SealedHeader,
+    B256, MIN_PROTOCOL_BASE_FEE,
 };
 use tracing::{debug, error};
 
@@ -50,7 +50,7 @@ impl UnsettledExecution {
 /// Execute a batch payload and collect the resulting block.
 pub(crate) fn execute_payload(
     payload: RLPayload,
-    transactions: &[Vec<u8>],
+    transactions: &[Bytes],
     executed_blocks: &mut Vec<ExecutedBlock>,
     reth_env: &RethEnv,
 ) -> EngineResult<UnsettledExecution> {

--- a/crates/middleware/processor/src/lib.rs
+++ b/crates/middleware/processor/src/lib.rs
@@ -36,8 +36,13 @@ use tracing::{debug, error, info, warn};
 
 use crate::batch::BatchOrdering;
 
-/// Maximum queued outputs for execution.
-const MAX_QUEUED_OUTPUTS: usize = 100;
+/// Admission ceiling for the local execution queue.
+///
+/// At the ceiling the engine stops draining its inbound channel instead of growing the queue, so
+/// execution lag backs up the channel and reaches consensus as backpressure rather than being
+/// absorbed as memory (each queued output owns its transaction payloads). Nothing is dropped:
+/// unadmitted outputs wait in the channel until the queue drains.
+pub const MAX_QUEUED_OUTPUTS: usize = 100;
 
 /// Type alias for the blocking task that executes consensus output and returns the finalized
 /// [`SealedHeader`].
@@ -379,8 +384,16 @@ impl<DB: Database> Future for ExecutorEngine<DB> {
         }
 
         loop {
-            // check if output is available from consensus to keep broadcast stream from "lagging"
-            match this.consensus_output_stream.poll_next_unpin(cx) {
+            // At capacity, leave the output in the inbound channel: that is what carries the
+            // backpressure to consensus (see [`MAX_QUEUED_OUTPUTS`]). No waker is registered on
+            // the stream here; the pending execution task wakes the engine when it completes, and
+            // admission resumes once the queue has room.
+            let poll = if this.queued.len() >= MAX_QUEUED_OUTPUTS {
+                Poll::Pending
+            } else {
+                this.consensus_output_stream.poll_next_unpin(cx)
+            };
+            match poll {
                 Poll::Ready(Some((came_from, output))) => {
                     // Dedup and order on the deterministic `(epoch, leader_round)` + subdag
                     // digest, not the node-local `number` (which can drift across handoffs).
@@ -481,18 +494,7 @@ impl<DB: Database> Future for ExecutorEngine<DB> {
                         tracker.output_received(output.number);
                     }
 
-                    // Warn if queue is growing too large - indicates execution lag
-                    if this.queued.len() >= MAX_QUEUED_OUTPUTS {
-                        warn!(
-                            target: "engine",
-                            queue_size = this.queued.len(),
-                            "Execution queue at capacity ({MAX_QUEUED_OUTPUTS}), \
-                             consensus is producing faster than execution can consume"
-                        );
-                    }
                     // Queue the output for local execution.
-                    // We accept even when at capacity to preserve consensus correctness,
-                    // but the warning above indicates a performance issue.
                     this.queued.push_back((came_from, output))
                 }
                 Poll::Ready(None) => {

--- a/crates/middleware/processor/tests/it/main.rs
+++ b/crates/middleware/processor/tests/it/main.rs
@@ -130,6 +130,69 @@ async fn run_engine_with_in_flight(
     Ok(reth_env)
 }
 
+/// At queue capacity the engine must stop draining its inbound channel, so execution lag
+/// backs up to consensus instead of being absorbed as unbounded memory. An engine that admits on
+/// every wake always empties the channel, and the lag never reaches the producer.
+#[tokio::test]
+async fn test_engine_stops_admitting_at_queue_capacity() -> eyre::Result<()> {
+    use futures::poll;
+    use rayls_middleware_processor::MAX_QUEUED_OUTPUTS;
+
+    let tmp_dir = TempDir::new().unwrap();
+    let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
+    let execution_node = default_test_execution_node(
+        Some(chain.clone()),
+        None,
+        &tmp_dir.path().join("exc-node"),
+        None,
+    )
+    .await?;
+    let reth_env = execution_node.get_reth_env().await;
+    let shutdown = Notifier::default();
+    let task_manager = TaskManager::default();
+    let temp_db_dir = TempDir::new().unwrap();
+    let ordering_store = open_db(temp_db_dir.path());
+    let batch_ordering = BatchOrdering::new_with_empty_state(ordering_store);
+
+    let (to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
+    let mut engine = ExecutorEngine::new_for_test(
+        reth_env.clone(),
+        None,
+        from_consensus,
+        chain.sealed_genesis_header(),
+        shutdown.subscribe(),
+        task_manager.get_spawner(),
+        GasAccumulator::default(),
+        None,
+        ETHEREUM_BLOCK_GAS_LIMIT_56BITS,
+        batch_ordering,
+        InFlightTracker::new(),
+    );
+
+    // fill the execution queue to its admission ceiling
+    for _ in 0..MAX_QUEUED_OUTPUTS {
+        engine.push_back_queued_for_test(ConsensusOutput::default());
+    }
+
+    // one output waiting in the channel (capacity 1, so the channel is now full)
+    to_engine
+        .send((rayls_infrastructure_types::CameFrom::Test, ConsensusOutput::default()))
+        .await?;
+    assert_eq!(to_engine.capacity(), 0, "channel holds the pending output");
+
+    // poll the engine: it must decline to admit rather than drain the channel
+    let mut engine = Box::pin(engine);
+    let _ = poll!(&mut engine);
+
+    assert_eq!(
+        to_engine.capacity(),
+        0,
+        "engine drained the channel while at capacity, so lag cannot reach consensus"
+    );
+
+    Ok(())
+}
+
 /// Helper function to assert EIP-4788 correctly executed. (cancun)
 fn assert_eip4788(
     reth_env: &RethEnv,

--- a/crates/middleware/processor/tests/it/main.rs
+++ b/crates/middleware/processor/tests/it/main.rs
@@ -203,6 +203,7 @@ async fn test_empty_output_executes() -> eyre::Result<()> {
         committee.authority(&leader_id).expect("leader in committee").execution_address();
     gas_accumulator.rewards_counter().set_committee(committee);
 
+    // consensus side
     //
     // create consensus output bc transactions in batches
     // are randomly generated
@@ -371,15 +372,13 @@ async fn test_empty_output_executes() -> eyre::Result<()> {
     Ok(())
 }
 
-/// The engine drains its queue, then the channel, and shuts down once the sender is closed.
+/// The engine drains the queued output, then the output still in the channel, and shuts down
+/// gracefully once the sender is dropped, in that order.
 ///
-/// One output is pre-queued (already received) and another is sent on the channel before the
-/// sender is dropped and the engine starts: the queued output executes first, the channel output
-/// second, and the engine exits gracefully with nothing left. Transactions carry priority fees so
-/// the epoch-end governance, batch-producer, and block rewards can be asserted.
-///
-/// NOTE: all batches are built with genesis as the parent; building from historic parents is
-/// currently valid.
+/// One output is queued (already received) and another is sent on the channel before the sender
+/// is dropped and the engine starts. All batches are built with genesis as the parent, which is
+/// valid. Priority-fee transactions are included to assert governance, batch producer, and block
+/// rewards reach the correct addresses at the end of the epoch.
 #[tokio::test]
 async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> eyre::Result<()> {
     let tmp_dir = TempDir::new().expect("temp dir");
@@ -418,10 +417,10 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
         )
         .encoded_2718();
     if let Some(batch) = batches_1.first_mut() {
-        batch.transactions_mut().push(encoded_tx_priority_fee_1)
+        batch.transactions_mut().push(encoded_tx_priority_fee_1.into())
     }
     if let Some(batch) = batches_2.first_mut() {
-        batch.transactions_mut().push(encoded_tx_priority_fee_2)
+        batch.transactions_mut().push(encoded_tx_priority_fee_2.into())
     }
 
     // okay to clone these because they are only used to seed genesis, decode transactions, and
@@ -528,6 +527,8 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     // Reload all_batches so we can calculate mix_hash properly later.
     let all_batches = [batches_1.clone(), batches_2.clone()].concat();
 
+    // consensus side
+
     // create consensus output bc transactions in batches
     // are randomly generated
     //
@@ -592,6 +593,7 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     batch_digests_1.extend(batch_digests_2);
     let all_batch_digests: Vec<BlockHash> = batch_digests_1.into();
 
+    // execution side
     // setup rewards for first two rounds of consensus
     let rewards_counter = gas_accumulator.rewards_counter();
     rewards_counter.set_committee(committee.clone());
@@ -818,13 +820,12 @@ async fn test_happy_path_full_execution_even_after_sending_channel_closed() -> e
     Ok(())
 }
 
-/// A batch of duplicate transactions executes as an empty block and the engine shuts down clean.
+/// A batch whose transactions were already executed produces an empty block, and the engine
+/// drains its queue and shuts down gracefully.
 ///
-/// Transactions carry priority fees so the epoch-end governance, batch-producer, and block
-/// rewards can be asserted.
-///
-/// NOTE: all batches are built with genesis as the parent; building from historic parents is
-/// currently valid.
+/// All batches are built with genesis as the parent, which is valid. Priority-fee transactions
+/// are included to assert governance, batch producer, and block rewards reach the correct
+/// addresses at the end of the epoch.
 #[tokio::test]
 async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<()> {
     let tmp_dir = TempDir::new().unwrap();
@@ -863,10 +864,10 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
         )
         .encoded_2718();
     if let Some(batch) = batches_1.first_mut() {
-        batch.transactions_mut().push(encoded_tx_priority_fee_1)
+        batch.transactions_mut().push(encoded_tx_priority_fee_1.into())
     }
     if let Some(batch) = batches_2.first_mut() {
-        batch.transactions_mut().push(encoded_tx_priority_fee_2)
+        batch.transactions_mut().push(encoded_tx_priority_fee_2.into())
     }
     // duplicate transactions in last batch for each round
     //
@@ -1005,6 +1006,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     assert_eq!(duplicate_batch_round_2.transactions(), duplicated_batch_for_round_2.transactions());
     assert_ne!(duplicate_batch_round_2, duplicated_batch_for_round_2);
 
+    // consensus side
     //
     // create consensus output bc transactions in batches
     // are randomly generated
@@ -1074,6 +1076,7 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     batch_digests_1.extend(batch_digests_2);
     let all_batch_digests: Vec<BlockHash> = batch_digests_1.into();
 
+    // execution side
     // setup rewards for first two rounds of consensus
     let rewards_counter = gas_accumulator.rewards_counter();
     rewards_counter.set_committee(committee.clone());
@@ -1342,12 +1345,12 @@ async fn test_execution_succeeds_with_duplicate_transactions() -> eyre::Result<(
     Ok(())
 }
 
-/// The engine drops a duplicate ConsensusOutput via the deterministic `(epoch, leader_round)` +
-/// subdag-digest guard.
+/// The engine drops a duplicate `ConsensusOutput` via the deterministic `(epoch, leader_round)`
+/// + subdag-digest guard.
 ///
-/// Three empty outputs go through the channel: output_1 (epoch 0, round 0), a byte-for-byte
-/// re-delivery of it (the benign dual-feed case), and output_2 (round 2). Two blocks result, one
-/// per distinct output; the re-delivery is silently dropped.
+/// Three empty outputs are sent: output_1 (epoch 0, round 0), output_dup (a byte-for-byte
+/// re-delivery of output_1, the benign dual-feed case) and output_2 (epoch 0, round 2). Two
+/// blocks are produced, one per distinct output; the re-delivery is silently dropped.
 #[tokio::test]
 async fn test_duplicate_consensus_output_is_dropped() -> eyre::Result<()> {
     let chain: Arc<RethChainSpec> = Arc::new(test_genesis().into());
@@ -1369,6 +1372,7 @@ async fn test_duplicate_consensus_output_is_dropped() -> eyre::Result<()> {
     let leader_id = committee.authorities().first().expect("first authority").id();
     gas_accumulator.rewards_counter().set_committee(committee);
 
+    // consensus side
     //
     // Build three empty ConsensusOutput objects:
     //   output_1: number=0 (valid)
@@ -1397,8 +1401,8 @@ async fn test_duplicate_consensus_output_is_dropped() -> eyre::Result<()> {
         ..Default::default()
     };
 
-    // output_dup: a true re-delivery of output_1 (identical epoch, round, and subdag
-    // content). The deterministic guard drops it as a benign dual-feed duplicate. ---
+    // output_dup: a true re-delivery of output_1 (identical epoch, round, and subdag content).
+    // The deterministic guard drops it as a benign dual-feed duplicate.
     let mut leader_dup = Certificate::default();
     leader_dup.header.round = 0;
     leader_dup.header.created_at = timestamp;
@@ -1439,6 +1443,8 @@ async fn test_duplicate_consensus_output_is_dropped() -> eyre::Result<()> {
         ..Default::default()
     };
     let consensus_output_2_hash = consensus_output_2.consensus_header_hash();
+
+    // execution side
 
     // channel capacity 3 so all outputs can be sent before engine starts
     let (to_engine, from_consensus) = tokio::sync::mpsc::channel(3);
@@ -1581,6 +1587,7 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
         debug!("{idx}\n{:?}\n", batch);
     }
 
+    // consensus side
     //
     // create consensus output bc transactions in batches
     // are randomly generated
@@ -1637,6 +1644,8 @@ async fn test_max_round_terminates_early() -> eyre::Result<()> {
         number: 1,
         ..Default::default()
     };
+
+    // execution side
 
     let (_to_engine, from_consensus) = tokio::sync::mpsc::channel(1);
     // set max round to "1" - this should receive both digests, but stop after the first round
@@ -1871,7 +1880,7 @@ async fn test_dropped_txs_release_in_flight_marks() -> eyre::Result<()> {
     let gapped_hashes: Vec<B256> = gapped.iter().map(|tx| *tx.hash()).collect();
     let batch = batches.first_mut().expect("one batch");
     for tx in &gapped {
-        batch.transactions_mut().push(tx.encoded_2718());
+        batch.transactions_mut().push(tx.encoded_2718().into());
     }
 
     let (genesis, _txs, _signers) = seeded_genesis_from_random_batches(genesis, batches.iter());

--- a/crates/testing/e2e-tests/tests/it/epochs.rs
+++ b/crates/testing/e2e-tests/tests/it/epochs.rs
@@ -20,8 +20,8 @@ use rayls_execution_evm::{
 use rayls_infrastructure_config::{Config, ConfigFmt, ConfigTrait as _, NodeInfo};
 use rayls_infrastructure_types::{
     test_utils::{self, CommandParser},
-    Address, EpochCertificate, EpochRecord, Genesis, GenesisAccount, MIN_RAYLS_PROTOCOL_BASE_FEE,
-    U256,
+    Address, Bytes, EpochCertificate, EpochRecord, Genesis, GenesisAccount,
+    MIN_RAYLS_PROTOCOL_BASE_FEE, U256,
 };
 use rayls_network_cli::genesis::GenesisArgs;
 use std::{collections::BTreeMap, panic, path::Path, process::Child, sync::Arc, time::Duration};
@@ -38,7 +38,7 @@ const SELECTABLE_TRIALS_TARGET: usize = 25;
 // Bumped from 5s: at short cadences a loaded CI runner can miss the epoch-advance
 // window, tripping the `loop_epochs` debounce ("Old and new epoch equal"). The few
 // seconds of CI jitter that break 5s (its debounce tolerance is only ~11s) are
-// roughly absolute, not proportional — so 30s (tolerance ~61s) gives ample margin
+// roughly absolute, not proportional - so 30s (tolerance ~61s) gives ample margin
 // while keeping test_epoch_boundary's shuffle wait under the 60-min job cap.
 // Retry-based record checks stay correct regardless of cadence.
 const EPOCH_DURATION: u64 = 30;
@@ -72,7 +72,7 @@ async fn test_epoch_boundary_inner(
 
     // submit txs to stake and activate the new validator.
     //
-    // A mined tx can still have REVERTED — `watch()` only confirms inclusion, not
+    // A mined tx can still have REVERTED - `watch()` only confirms inclusion, not
     // success. So fetch each receipt and assert it succeeded, naming which tx failed.
     // Without this, a reverted stake/activate silently leaves the validator
     // unregistered and only surfaces much later as a misleading "never shuffled".
@@ -113,7 +113,7 @@ async fn test_epoch_boundary_inner(
     // The new validator can't appear in a *current* committee right away: it goes
     // Active at `activationEpoch` and committees are selected ~2 epochs ahead (see
     // reth_env: "read new committee (always 2 epochs ahead)"). Read its
-    // activationEpoch so we only count genuine selection trials — and assert it's
+    // activationEpoch so we only count genuine selection trials - and assert it's
     // actually eligible. If the stake/activate tx was dropped (e.g. submitted right
     // as an epoch switched; see the submit loop above), the validator never enters
     // the candidate set and "never shuffled" would be a false negative, not bad luck.
@@ -121,11 +121,11 @@ async fn test_epoch_boundary_inner(
     assert_eq!(
         new_val_info.validatorAddress,
         new_validator.address(),
-        "new validator not registered in ConsensusRegistry — stake/activate tx was dropped"
+        "new validator not registered in ConsensusRegistry - stake/activate tx was dropped"
     );
     assert!(
         new_val_info.activationEpoch > 0,
-        "new validator registered but activationEpoch=0 — activate tx was not applied; \
+        "new validator registered but activationEpoch=0 - activate tx was not applied; \
          it can never be shuffled into a committee"
     );
     // Earliest epoch at which it can show up in the *current* committee.
@@ -187,8 +187,8 @@ async fn test_epoch_boundary_inner(
 
     if shuffled {
         // Check that all nodes have valid (certified) Epoch Records. `latest_epoch`
-        // is the current, in-progress epoch — its record isn't certified until it
-        // concludes — so verify only epochs strictly before it (all concluded).
+        // is the current, in-progress epoch - its record isn't certified until it
+        // concludes - so verify only epochs strictly before it (all concluded).
         for p in 8540..=8545u16 {
             let rpc_url = format!("http://127.0.0.1:{p}");
             let provider = ProviderBuilder::new().connect_http(rpc_url.parse()?);
@@ -301,7 +301,7 @@ async fn test_epoch_sync_inner(
 /// verify it against its certificate.
 ///
 /// A node that is still catching up returns `NotFound` (401) for a not-yet-synced
-/// epoch, so a transient error is retried up to `deadline` — this is what makes
+/// epoch, so a transient error is retried up to `deadline` - this is what makes
 /// the completeness check tolerant of a legitimately-lagging node. A record that
 /// IS returned but fails cert verification is a real correctness bug and fails
 /// immediately (no retry). A node that never produces the record fails once the
@@ -658,14 +658,14 @@ struct OnboardTx {
     from: Address,
     to: Address,
     calldata: Vec<u8>,
-    raw: Vec<u8>,
+    raw: Bytes,
 }
 
 /// Generate all the transactions needed to onboard the new validator so it becomes
 /// eligible for committee selection.
 ///
 /// `ConsensusRegistry.stake()` requires the validator to be (1) allowlisted by the
-/// registry owner and (2) to have approved the registry to pull its ERC-20 RLS — and
+/// registry owner and (2) to have approved the registry to pull its ERC-20 RLS - and
 /// it is NOT payable (funds move via `transferFrom`, not `msg.value`). So the full
 /// ordered flow is: governance allowlists → validator approves RLS → validator stakes
 /// (value 0) → validator activates. The validator is already RLS-funded at genesis,
@@ -715,7 +715,7 @@ fn generate_new_validator_txs(
         approve_calldata.clone().into(),
     );
 
-    // 3. Stake — value 0; the registry pulls RLS via transferFrom (non-payable fn).
+    // 3. Stake - value 0; the registry pulls RLS via transferFrom (non-payable fn).
     let proof = ConsensusRegistry::ProofOfPossession {
         uncompressedPubkey: new_validator_info.bls_public_key.serialize().into(),
         uncompressedSignature: new_validator_info.proof_of_possession.serialize().into(),
@@ -734,7 +734,7 @@ fn generate_new_validator_txs(
         stake_calldata.clone().into(),
     );
 
-    // 4. Activate — request entry into a future committee.
+    // 4. Activate - request entry into a future committee.
     let activate_calldata = ConsensusRegistry::activateCall {}.abi_encode();
     let activate_raw = new_validator.create_eip1559_encoded(
         chain.clone(),

--- a/crates/testing/fuzz-targets/fuzz/Cargo.lock
+++ b/crates/testing/fuzz-targets/fuzz/Cargo.lock
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "rayls-infrastructure-types"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -6670,6 +6670,7 @@ dependencies = [
  "reth-primitives",
  "reth-tasks",
  "roaring 0.10.12",
+ "rustc-hash",
  "secp256k1 0.31.1",
  "serde",
  "serde_repr",

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/batch_digest.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/batch_digest.rs
@@ -4,7 +4,6 @@
 //! batch contents. This tests:
 //! - Digest computation never panics on any input
 //! - Two identical batches always produce the same digest (determinism)
-//! - seal_slow().digest matches the pre-computed digest
 //! - Modifying any field changes the digest (collision resistance sanity check)
 //!
 //! Run: cargo +nightly fuzz run batch_digest
@@ -26,16 +25,13 @@ struct FuzzBatch {
 
 fuzz_target!(|input: FuzzBatch| {
     // Limit transactions to prevent OOM.
-    let transactions: Vec<Vec<u8>> = input
+    let transactions: Vec<rayls_infrastructure_types::Bytes> = input
         .transactions
         .into_iter()
         .take(5)
-        .map(|tx| {
-            if tx.len() > 1024 {
-                tx[..1024].to_vec()
-            } else {
-                tx
-            }
+        .map(|mut tx| {
+            tx.truncate(1024);
+            tx.into()
         })
         .collect();
 
@@ -55,10 +51,6 @@ fuzz_target!(|input: FuzzBatch| {
     // Same batch must produce the same digest (determinism).
     let digest2 = batch.clone().digest();
     assert_eq!(digest1, digest2, "digest is not deterministic");
-
-    // NOTE: a `seal_slow().digest == digest()` assertion was removed here — it is a
-    // tautology, since seal_slow() is literally `let d = self.digest(); self.seal(d)`,
-    // so it can never fail and tests nothing.
 
     // Modifying epoch should change the digest (basic collision resistance).
     if input.epoch < u32::MAX {

--- a/crates/testing/test-utils/src/consensus.rs
+++ b/crates/testing/test-utils/src/consensus.rs
@@ -3,7 +3,7 @@
 use crate::CommitteeFixture;
 use indexmap::IndexMap;
 use rayls_infrastructure_types::{
-    now, test_chain_spec_arc, AuthorityIdentifier, Batch, BlockHash, Certificate,
+    now, test_chain_spec_arc, AuthorityIdentifier, B256Map, Batch, BlockHash, Certificate,
     CertificateDigest, Database, Hash as _, HeaderBuilder, Round, WorkerId,
 };
 use std::{
@@ -60,14 +60,14 @@ where
 pub fn create_signed_certificates_for_rounds<DB>(
     range: RangeInclusive<Round>,
     fixture: &CommitteeFixture<DB>,
-) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>, HashMap<BlockHash, Batch>)
+) -> (VecDeque<Certificate>, BTreeSet<CertificateDigest>, B256Map<Batch>)
 where
     DB: Database,
 {
     let ids: Vec<_> = fixture.authorities().map(|a| a.id()).collect();
     let mut certificates = VecDeque::new();
     let mut next_parents = BTreeSet::new();
-    let mut batches = HashMap::new();
+    let mut batches = B256Map::default();
     // use genesis for initial parents
     let mut parents: BTreeSet<_> = fixture.genesis().collect();
 


### PR DESCRIPTION
## Summary

- Cut allocation and hashing on the hot paths: `Batch.transactions` carries `Bytes` so a batch cloned through seal, quorum, and ordering refcounts its payloads instead of deep-copying up to 2MB; the consensus-cert, executed-batch, and pending-parent maps key on the digest byte hasher instead of SipHash; certificates are sized with `bcs::serialized_size` instead of being encoded twice; batch-existence checks probe the key without decoding the value; `validate_batch` takes `&SealedBatch`.
- Cut per-peer overhead: the quorum waiter awaits each peer's ack directly in its `FuturesUnordered` instead of spawning a task per peer; the certifier, fetcher, and worker seal loops reuse a pinned timer and drop per-iteration allocations; kad record puts are budgeted to ten per source per rolling minute and deduplicated before the signature verify.
- Keep backpressure honest: the proposer throttles only proposing (digests, parents, and ticks keep draining) and reads the suspended-certificate count from the certificate manager's typed watch rather than a metrics gauge; the engine stops admitting consensus output at queue capacity so execution lag propagates back to consensus instead of being absorbed as memory.

Stack 8/9 of the txpool in-flight tracker and observer-forwarder series.

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [x] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [x] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None on the wire: `Vec<Bytes>` and `Vec<Vec<u8>>` bcs-encode identically (ULEB128 length + raw bytes), so the batch encoding and every stored digest stay byte-identical; the container is a node-local choice. Behavior: a peer exceeding ten kad puts per minute has the excess dropped before verification; the recently-validated dedup set is bounded to a one-minute window.

## Test plan

- [x] `batch_encoding_golden_bytes` pins the `Batch` wire encoding; `tx_payload_bcs_identical_for_vec_u8_and_bytes` cross-decodes the two containers.
- [x] `test_kad_put_budget_drops_flood`, `test_kad_put_stale_duplicate_deduped_before_signature_verify`.
- [x] `make check` on the stack tip; CI on this branch.

