### PR TITLE
feat: handle db errors

### DIFF
--- a/crates/consensus/network/src/kad.rs
+++ b/crates/consensus/network/src/kad.rs
@@ -569,13 +569,13 @@ mod test {
         let rec = test_record(false);
         let rec2 = test_record(false);
         let rec3 = test_record(false);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
 
         assert!(kad_store.get(&rec.key).is_none());
         assert_eq!(kad_store.records().count(), 0);
         kad_store.put(rec.clone()).expect("put record");
         kad_store_worker.put(rec.clone()).expect("put record");
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
         test_rec(&rec, &kad_store);
         test_rec(&rec, &kad_store_worker);
         assert_eq!(kad_store.num_records, 1);
@@ -584,14 +584,14 @@ mod test {
         assert_eq!(kad_store_worker.records().count(), 1);
 
         kad_store.remove(&rec.key);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
         test_rec(&rec, &kad_store_worker);
         assert_eq!(kad_store.records().count(), 0);
         assert_eq!(kad_store.num_records, 0);
         assert_eq!(kad_store_worker.records().count(), 1);
         assert_eq!(kad_store_worker.num_records, 1);
         kad_store_worker.remove(&rec.key);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
         assert!(kad_store_worker.get(&rec.key).is_none());
         assert!(kad_store.get(&rec.key).is_none());
         assert_eq!(kad_store.records().count(), 0);
@@ -601,7 +601,7 @@ mod test {
         kad_store_worker.put(rec.clone()).expect("put record");
         kad_store.put(rec2.clone()).expect("put record");
         kad_store.put(rec3.clone()).expect("put record");
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
 
         assert_eq!(kad_store.num_records, 3);
         assert_eq!(kad_store_worker.num_records, 1);
@@ -691,13 +691,13 @@ mod test {
         kad_store.remove_provider(&provider_rec1_1.key, &provider_rec1_1.provider);
         assert_eq!(kad_store.num_providers, 3);
         kad_store.remove_provider(&provider_rec1_2.key, &provider_rec1_2.provider);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
 
         assert_eq!(kad_store.num_providers, 2);
         assert_eq!(kad_store.provided().count(), 0);
         assert_eq!(kad_store.providers(&provider_rec1.key).len(), 0);
         kad_store.remove_provider(&provider_rec2.key, &provider_rec2.provider);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
 
         assert_eq!(kad_store.num_providers, 1);
         assert_eq!(kad_store.providers(&provider_rec2.key).len(), 0);
@@ -716,11 +716,11 @@ mod test {
 
         // Bogus remove, mismatches key and provider.
         kad_store.remove_provider(&provider_rec3.key, &provider_rec2.provider);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
 
         assert_eq!(kad_store.num_providers, 1);
         kad_store.remove_provider(&provider_rec3.key, &provider_rec3.provider);
-        kad_store.db.sync_persist();
+        kad_store.db.sync_persist().expect("persist");
 
         assert_eq!(kad_store.num_providers, 0);
         kad_store_worker.remove_provider(&provider_rec3.key, &provider_rec2.provider);

--- a/crates/infrastructure/storage/src/cold/archiver.rs
+++ b/crates/infrastructure/storage/src/cold/archiver.rs
@@ -100,6 +100,10 @@ impl<DB: Database> ColdArchiver<DB> {
 
         let seal_elapsed = seal_started.elapsed();
         let finalize_started = std::time::Instant::now();
+        // eyre::Report::new preserves the ColdError type in the chain; seal_due_epochs
+        // uses downcast_ref::<ColdError>() to distinguish WriteFailed (fatal) from
+        // Corruption (retriable). Do not use eyre::eyre!("...: {e}") here — that would
+        // stringify the error and lose the concrete type.
         let finalized = finalize_sealed(&self.hot, &sealed, &should_cancel, PRUNE_YIELD)
             .map_err(|e| eyre::Report::new(e).wrap_err("cold finalize failed"))?;
         // Reporting a cancelled finalize as sealed would let the caller close the epoch out and

--- a/crates/infrastructure/storage/src/cold/archiver.rs
+++ b/crates/infrastructure/storage/src/cold/archiver.rs
@@ -101,7 +101,7 @@ impl<DB: Database> ColdArchiver<DB> {
         let seal_elapsed = seal_started.elapsed();
         let finalize_started = std::time::Instant::now();
         let finalized = finalize_sealed(&self.hot, &sealed, &should_cancel, PRUNE_YIELD)
-            .map_err(|e| eyre::eyre!("cold finalize failed: {e}"))?;
+            .map_err(|e| eyre::Report::new(e).wrap_err("cold finalize failed"))?;
         // Reporting a cancelled finalize as sealed would let the caller close the epoch out and
         // skip the retry that sweeps its leftover hot rows.
         let Finalized::Complete(_) = finalized else {

--- a/crates/infrastructure/storage/src/cold/mod.rs
+++ b/crates/infrastructure/storage/src/cold/mod.rs
@@ -48,6 +48,12 @@ pub enum ColdError {
     /// A jar or index is internally inconsistent and cannot be reconciled.
     #[error("cold store corruption: {0}")]
     Corruption(String),
+
+    /// The hot tier rejected a write or its durability barrier (persist) failed, so rows the
+    /// archival just moved may not be durable. A fatal condition for the node: the hot cache
+    /// pins the failed rows until restart, so callers must fault rather than retry indefinitely.
+    #[error("hot-tier write not durable: {0}")]
+    WriteFailed(String),
 }
 
 /// Location of an archived batch within the cold tier.

--- a/crates/infrastructure/storage/src/cold/probe.rs
+++ b/crates/infrastructure/storage/src/cold/probe.rs
@@ -34,6 +34,8 @@ pub(crate) struct ProbeDb {
     inner: MemDatabase,
     /// Stands in for the MDBX faults a read can hit (txn open error, map resized, poisoned dbi).
     read_fault: bool,
+    /// Stands in for a hot tier rejecting writes outright (e.g. its map is full).
+    write_fault: bool,
     /// Read transactions opened so far, shared across clones.
     read_txns: Arc<AtomicUsize>,
     /// Full reverse scans requested so far, shared across clones.
@@ -48,6 +50,7 @@ impl ProbeDb {
         let mut db = Self {
             inner: MemDatabase::new(),
             read_fault: false,
+            write_fault: false,
             read_txns: Arc::new(AtomicUsize::new(0)),
             reverse_iters: Arc::new(AtomicUsize::new(0)),
             write_starts: Arc::new(Mutex::new(Vec::new())),
@@ -60,6 +63,11 @@ impl ProbeDb {
     /// Builds a probe whose every `read_txn` fails.
     pub(crate) fn failing_reads() -> Self {
         Self { read_fault: true, ..Self::new() }
+    }
+
+    /// Builds a probe whose every `write_txn` fails: a hot tier rejecting writes outright.
+    pub(crate) fn failing_writes() -> Self {
+        Self { write_fault: true, ..Self::new() }
     }
 
     /// Returns how many read transactions have been opened.
@@ -98,6 +106,9 @@ impl Database for ProbeDb {
     }
 
     fn write_txn(&self) -> eyre::Result<Self::TXMut<'_>> {
+        if self.write_fault {
+            eyre::bail!("hot tier rejecting writes");
+        }
         self.write_starts.lock().push(TxnStart {
             locations: self.inner.iter::<ColdBatchLocations>().count(),
             high_water_mark: self

--- a/crates/infrastructure/storage/src/cold/producer.rs
+++ b/crates/infrastructure/storage/src/cold/producer.rs
@@ -462,10 +462,13 @@ pub(super) fn commit_index<DB: Database>(
             }
             Ok(())
         })
-        .map_err(to_cold)?;
+        // A txn-closure failure is a hot-tier fault (mem-cache mutation or a dead writer thread),
+        // not corruption: it must take the fatal path, not retry forever. The underlying MDBX
+        // write failure of these ops surfaces via the sync_persist below instead.
+        .map_err(to_write_failed)?;
     }
     // Every location must be applied before the prune removes the rows they address.
-    db.sync_persist();
+    db.sync_persist().map_err(to_write_failed)?;
     Ok(())
 }
 
@@ -480,8 +483,9 @@ pub(super) fn advance_high_water_mark<DB: Database>(db: &DB, epoch: Epoch) -> Co
     db.with_write_txn(|txn| {
         txn.insert::<ColdArchiveHighWaterMark>(&ARCHIVE_HIGH_WATER_MARK_KEY, &epoch)
     })
-    .map_err(to_cold)?;
-    db.sync_persist();
+    // Same hot-tier fault classification as `commit_index`; see the comment there.
+    .map_err(to_write_failed)?;
+    db.sync_persist().map_err(to_write_failed)?;
     high_water_mark_gauge().set(epoch as i64);
     Ok(())
 }
@@ -518,18 +522,21 @@ pub(super) fn delete_archived_rows<DB: Database>(
     // zero yield (boot, migration, reconcile) nothing shares the writer, and every `sync_persist`
     // would cost its full polling quantum per chunk for nothing. Deletes queued at a crash just
     // leave more hot leftovers for reconcile's last-block probe to sweep.
-    let pace = |db: &DB| {
+    let pace = |db: &DB| -> ColdResult<()> {
         if !yield_between.is_zero() {
-            db.sync_persist();
+            db.sync_persist().map_err(to_write_failed)?;
             std::thread::sleep(yield_between);
         }
+        Ok(())
     };
     for chunk in digests.chunks(WRITE_BATCH_ROWS) {
         if should_cancel() {
             return Ok(None);
         }
-        db.with_write_txn(|txn| txn.evict_persistent_batch::<Batches>(chunk)).map_err(to_cold)?;
-        pace(db);
+        db.with_write_txn(|txn| txn.evict_persistent_batch::<Batches>(chunk))
+            // Hot-tier fault, not corruption; see `commit_index`.
+            .map_err(to_write_failed)?;
+        pace(db)?;
     }
     // Chunk the dense range directly instead of materializing every block number up front; only
     // one chunk's numbers are ever held at a time.
@@ -541,8 +548,9 @@ pub(super) fn delete_archived_rows<DB: Database>(
         let chunk_end = chunk_start.saturating_add(WRITE_BATCH_ROWS as u64 - 1).min(*numbers.end());
         let chunk: Vec<u64> = (chunk_start..=chunk_end).collect();
         db.with_write_txn(|txn| txn.evict_persistent_batch::<ConsensusBlocks>(&chunk))
-            .map_err(to_cold)?;
-        pace(db);
+            // Hot-tier fault, not corruption; see `commit_index`.
+            .map_err(to_write_failed)?;
+        pace(db)?;
         match chunk_end.checked_add(1) {
             Some(next) if next <= *numbers.end() => chunk_start = next,
             _ => break,
@@ -554,4 +562,10 @@ pub(super) fn delete_archived_rows<DB: Database>(
 /// Converts an `eyre` error from the `Database`/`DbTx` trait boundary into a [`ColdError`].
 pub(super) fn to_cold(err: eyre::Report) -> ColdError {
     ColdError::Corruption(err.to_string())
+}
+
+/// Converts a hot-tier durability-barrier failure into a [`ColdError::WriteFailed`], the variant
+/// the seal actor treats as fatal for the node (unlike corruption, which is retried).
+pub(super) fn to_write_failed(err: eyre::Report) -> ColdError {
+    ColdError::WriteFailed(err.to_string())
 }

--- a/crates/infrastructure/storage/src/cold/tests/archive.rs
+++ b/crates/infrastructure/storage/src/cold/tests/archive.rs
@@ -34,7 +34,7 @@ fn test_archive_keeps_hot_bounded_and_serves_cold() {
     // through the full stack (cold outermost).
     archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, None).expect("archive");
     // Flush the layered write queue so the archive's deletes land in the bare MDBX we probe.
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // (a) Boundedness: archived epochs leave the hot tables, the recent epoch stays.
     assert_eq!(
@@ -120,7 +120,7 @@ fn archived_batch_serves_via_read_txn_and_get() {
     let cutoff: Epoch = EPOCHS - 1;
     archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, None).expect("archive");
     // Flush the layered write queue so the archive's deletes land in the bare hot tier.
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // An archived (below-cutoff) batch: pruned from hot, present only in cold.
     let archived = fixtures.iter().find(|f| f.epoch < cutoff).expect("an archived fixture");
@@ -157,7 +157,7 @@ fn archive_due_floors_cutoff_by_el_anchor() {
     // An anchor inside epoch 1 proves epoch 0 is fully executed: exactly epoch 0 seals while
     // consensus alone (current epoch 3) would allow more.
     let stats = archiver.archive_due(1, None).expect("bitten pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(stats.epochs_sealed, 1, "only the epoch below the floored cutoff seals");
 
     let mdbx = hot.inner();
@@ -180,7 +180,7 @@ fn archive_due_floors_cutoff_by_el_anchor() {
 
     // Advancing the anchor into epoch 2 unlocks exactly the next epoch.
     let stats = archiver.archive_due(2, None).expect("advanced pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(stats.epochs_sealed, 1, "the anchor advance unlocks one more epoch");
     let epoch2 = 2 * BLOCKS_PER_EPOCH..3 * BLOCKS_PER_EPOCH;
     assert_eq!(count_hot_rows::<ConsensusBlocks, _>(mdbx, |n| epoch1.contains(n)), 0);
@@ -214,7 +214,7 @@ fn seal_due_seals_prior_epoch_during_live_epoch() {
     let outcome = archiver.seal_due(1, || false).expect("drained pass");
     assert_eq!(outcome, SealOutcome::Drained, "the live epoch must stay hot");
 
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(
         count_hot_rows::<ConsensusBlocks, _>(hot.inner(), |n| *n < BLOCKS_PER_EPOCH),
         0,
@@ -243,19 +243,19 @@ fn archive_below_epoch_caps_epochs_per_pass() {
     // A cap of one seals exactly one epoch; without the cap this single pass would seal both.
     let first = archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, Some(1))
         .expect("first capped pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(first.epochs_sealed, 1, "a cap of one seals exactly one epoch");
 
     // The next pass resumes past the high-water mark and seals the next eligible epoch.
     let second = archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, Some(1))
         .expect("second capped pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(second.epochs_sealed, 1, "the resumable high-water mark advances the capped passes");
 
     // The backlog is now drained; a further (uncapped) pass seals nothing.
     let third = archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, None)
         .expect("drained pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(third.epochs_sealed, 0, "nothing remains after the backlog drained");
 
     // The capped passes together moved the whole eligible backlog out of hot, served via cold.
@@ -433,7 +433,7 @@ fn validate_real_db_archive() {
         Err(e) => panic!("archive failed (finding, not a test bug): {e}"),
     };
     let elapsed = started.elapsed();
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // Post-archive: count hot blocks still below the cutoff (should reach 0) and size each jar dir.
     let hot_blocks_below_after = hot

--- a/crates/infrastructure/storage/src/cold/tests/finalize.rs
+++ b/crates/infrastructure/storage/src/cold/tests/finalize.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 use super::*;
 use crate::cold::{
     probe::ProbeDb,
-    producer::{commit_index, finalize_sealed, Finalized, SealedJars},
+    producer::{
+        advance_high_water_mark, commit_index, delete_archived_rows, finalize_sealed, Finalized,
+        SealedJars,
+    },
 };
 
 /// Builds `count` staged locations for `epoch`, in the row order a seal would append them.
@@ -70,4 +73,30 @@ fn high_water_mark_advances_only_after_a_completed_prune() {
         Some(EPOCH),
         "a completed finalize marks the epoch archived"
     );
+}
+
+/// A hot tier rejecting the write txn outright (e.g. its map is full) must surface as the fatal
+/// `WriteFailed` variant, not as retryable `Corruption`: the producer's txn-closure failures are
+/// hot-tier faults, and callers shut the node down gracefully on them rather than retrying forever.
+#[test]
+fn rejected_hot_tier_writes_surface_as_write_failed() {
+    let locations = vec![(BlockHash::repeat_byte(0xAA), ColdLocation { epoch: 0, row: 0 })];
+
+    let err = commit_index(&ProbeDb::failing_writes(), &locations)
+        .expect_err("a rejected hot-tier txn must surface");
+    assert!(matches!(err, ColdError::WriteFailed(_)), "commit_index: got {err:?}");
+
+    let err = advance_high_water_mark(&ProbeDb::failing_writes(), 0)
+        .expect_err("a rejected hot-tier txn must surface");
+    assert!(matches!(err, ColdError::WriteFailed(_)), "advance_high_water_mark: got {err:?}");
+
+    let err = delete_archived_rows(
+        &ProbeDb::failing_writes(),
+        0..=0,
+        &locations,
+        &|| false,
+        Duration::ZERO,
+    )
+    .expect_err("a rejected hot-tier txn must surface");
+    assert!(matches!(err, ColdError::WriteFailed(_)), "delete_archived_rows: got {err:?}");
 }

--- a/crates/infrastructure/storage/src/cold/tests/layered.rs
+++ b/crates/infrastructure/storage/src/cold/tests/layered.rs
@@ -200,7 +200,7 @@ fn layered_iter_spans_cold_jars_and_hot_tail() {
     // Three epochs archive into three jars; the recent epoch stays hot.
     let cutoff: Epoch = EPOCHS - 1;
     archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, None).expect("archive");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let scanned: Vec<(u64, Vec<u8>)> =
         db.iter::<ConsensusBlocks>().map(|(n, h)| (n, encode(&h))).collect();
@@ -217,7 +217,7 @@ fn archived_db(tmp: &TempDir, fixtures: &[Fixture]) -> (TestDb, HotDb) {
     seed_hot(&hot, fixtures);
     let cutoff: Epoch = EPOCHS - 1;
     archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, None).expect("archive");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     (db, hot)
 }
 
@@ -274,7 +274,7 @@ fn scan_created_before_archival_drains_complete() {
 
     // First pass archives epoch 0 only, so the scan starts over two populated tiers.
     archive_below_epoch(&hot, db.cold().expect("cold attached"), 1, None).expect("first pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let mut scan = db.iter::<ConsensusBlocks>();
     // Drain a prefix, leaving the scan parked before rows the next pass moves to cold.
@@ -284,7 +284,7 @@ fn scan_created_before_archival_drains_complete() {
     // Mid-scan, the second pass archives epochs 1 and 2 and prunes them from hot.
     archive_below_epoch(&hot, db.cold().expect("cold attached"), EPOCHS - 1, None)
         .expect("second pass");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let total = EPOCHS as u64 * BLOCKS_PER_EPOCH;
     let tail: Vec<u64> = scan.map(|(n, _)| n).collect();
@@ -423,7 +423,7 @@ fn reverse_skip_to_steps_instead_of_scanning() {
         db.insert::<ConsensusBlocks>(&n, &header_for(n, 0, BlockHash::repeat_byte(0xDD)))
             .expect("insert");
     }
-    db.sync_persist();
+    db.sync_persist().expect("persist");
 
     let walked: Vec<u64> =
         db.reverse_skip_to::<ConsensusBlocks>(&5).expect("walk back").map(|(n, _)| n).collect();

--- a/crates/infrastructure/storage/src/cold/tests/mod.rs
+++ b/crates/infrastructure/storage/src/cold/tests/mod.rs
@@ -148,7 +148,7 @@ fn seed_hot(hot: &HotDb, fixtures: &[Fixture]) {
         Ok(())
     })
     .expect("seed hot");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 }
 
 /// Counts the rows of a table in the bare MDBX whose key satisfies `keep`.
@@ -184,5 +184,5 @@ fn seed_chunk_blocks(hot: &HotDb, blocks: &[(u64, Vec<BlockHash>)], batches: &[(
         Ok(())
     })
     .expect("seed hot");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 }

--- a/crates/infrastructure/storage/src/cold/tests/reconcile.rs
+++ b/crates/infrastructure/storage/src/cold/tests/reconcile.rs
@@ -38,7 +38,7 @@ fn test_reconcile_heals_interrupted_archive() {
             Ok(())
         })
         .expect("simulate crash window");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
 
         // Sanity: the jars are durable, so no row is absent from both tiers even pre-reconcile.
         let sealed: BTreeSet<Epoch> =
@@ -54,7 +54,7 @@ fn test_reconcile_heals_interrupted_archive() {
     let (db, hot) = open_test_db(&tmp);
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
     // Flush so any reconcile hot deletes land in the bare MDBX we probe for boundedness.
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // The auxiliary index and high-water mark are rebuilt from the self-describing jars.
     let high_water_mark = db
@@ -148,7 +148,7 @@ fn reconcile_preserves_epoch_torn_between_jar_commits() {
             Ok(())
         })
         .expect("carve crash window");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
         // Drop the process state; phase 2 reopens from disk to model a real reboot.
     }
 
@@ -168,7 +168,7 @@ fn reconcile_preserves_epoch_torn_between_jar_commits() {
     );
 
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // The torn epoch's rows must still resolve. With the fix they stay hot (reconcile skips the
     // epoch); against the bug both reads are None because reconcile evicted the hot rows with no
@@ -220,7 +220,7 @@ fn reconcile_rebuilds_shared_digest_to_correct_row() {
             Ok(())
         })
         .expect("seed hot");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
     };
 
     // Phase 1: archive into durable jars, then roll back the post-jar hot txn to model a crash
@@ -242,13 +242,13 @@ fn reconcile_rebuilds_shared_digest_to_correct_row() {
             Ok(())
         })
         .expect("simulate crash window");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
     }
 
     // Phase 2: reopen and reconcile, then both batches must read back through cold.
     let (db, hot) = open_test_db(&tmp);
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let got_shared = db
         .get::<Batches>(&shared)
@@ -297,7 +297,7 @@ fn reconcile_rebuilds_cross_epoch_shared_digest_from_the_jar() {
             Ok(())
         })
         .expect("seed hot");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
 
         // Archive one epoch at a time, flushing between: epoch 1's seal must observe `shared`
         // already gone from hot, which is what makes it skip the row.
@@ -310,7 +310,7 @@ fn reconcile_rebuilds_cross_epoch_shared_digest_from_the_jar() {
             )
             .expect("seal")
             .expect("one epoch below the cutoff");
-            hot.sync_persist();
+            hot.sync_persist().expect("persist");
         }
 
         // Roll back the index and high-water mark, the crash window boot reconcile rebuilds from.
@@ -321,12 +321,12 @@ fn reconcile_rebuilds_cross_epoch_shared_digest_from_the_jar() {
             Ok(())
         })
         .expect("simulate crash window");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
     }
 
     let (db, hot) = open_test_db(&tmp);
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // Against the drift, `shared` is re-pointed at epoch 1 row 0 (which holds `only_later`) and
     // `only_later` at a row epoch 1's jar does not have.
@@ -365,7 +365,7 @@ fn reconcile_rebuilds_rows_independently_of_the_batches_start_key() {
         Ok(())
     })
     .expect("seed hot");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // Seal epoch 0 by hand so the batches jar is rooted at a non-zero sentinel; the seal path
     // always passes 0, which is exactly what would hide a start-key-based row mapping.
@@ -387,7 +387,7 @@ fn reconcile_rebuilds_rows_independently_of_the_batches_start_key() {
     db.cold().expect("cold attached").consensus_blocks().commit().expect("commit blocks");
 
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     for (row, (digest, batch)) in digests.iter().zip(&batches).enumerate() {
         assert_eq!(
@@ -415,7 +415,7 @@ fn reconcile_rejects_a_high_water_mark_the_jars_do_not_cover() {
         seed_hot(&hot, &fixtures);
         archive_below_epoch(&hot, db.cold().expect("cold attached"), cutoff, None)
             .expect("archive");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
     }
     std::fs::remove_dir_all(tmp.path().join("cold")).expect("restore without the cold directory");
 
@@ -437,8 +437,8 @@ fn reconcile_rejects_a_high_water_mark_the_jars_do_not_cover() {
 }
 
 /// The durable residue of a seal whose index txn was lost while its hot prune landed (the layered
-/// writer surfaces a failed commit only through `sync_persist`, which logs and continues): jars
-/// durable, hot rows pruned, auxiliary index and high-water mark absent. Boot reconcile must
+/// writer surfaces a failed commit only through `sync_persist`; callers must treat it as fatal):
+/// jars durable, hot rows pruned, auxiliary index and high-water mark absent. Boot reconcile must
 /// rebuild the index from the jars so every archived row still serves.
 #[test]
 fn reconcile_restores_pruned_but_unindexed_epochs() {
@@ -462,12 +462,12 @@ fn reconcile_restores_pruned_but_unindexed_epochs() {
             Ok(())
         })
         .expect("carve residue");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
     }
 
     let (db, hot) = open_test_db(&tmp);
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let high_water_mark = db
         .get::<ColdArchiveHighWaterMark>(&ARCHIVE_HIGH_WATER_MARK_KEY)
@@ -514,12 +514,12 @@ fn reconcile_skips_epochs_at_or_below_the_high_water_mark() {
             Ok(())
         })
         .expect("carve crash window");
-        hot.sync_persist();
+        hot.sync_persist().expect("persist");
     }
 
     let (db, hot) = open_test_db(&tmp);
     reconcile(&hot, db.cold().expect("cold attached")).expect("reconcile");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let mdbx = hot.inner();
     let numbers: BTreeSet<u64> =
@@ -597,7 +597,7 @@ fn finalize_never_gaps_reads_through_fall_through() {
 
     // The finalize completed the migration: hot rows pruned, every row serves from cold. A
     // zero-yield finalize queues its deletes without draining, so flush before the raw probe.
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(count_hot_rows::<ConsensusBlocks, _>(hot.inner(), |_| true), 0, "hot pruned");
     for (number, _) in &blocks {
         assert!(db.get::<ConsensusBlocks>(number).expect("read").is_some(), "cold serves");
@@ -625,7 +625,7 @@ fn paced_prune_cancelled_after_seal_heals_on_reconcile() {
         Ok(())
     })
     .expect("seed markers");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     let archiver = ColdArchiver::new(hot.clone(), db.cold().expect("cold attached").clone());
     // Cancel the instant epoch 0's jar is committed: the seal completes and the high-water mark
@@ -638,7 +638,7 @@ fn paced_prune_cancelled_after_seal_heals_on_reconcile() {
         SealOutcome::Cancelled,
         "a pass whose prune was cancelled has not archived the epoch"
     );
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // The high-water mark did NOT advance, so the epoch stays above it and reconcile revisits it;
     // its rows are in cold either way, so serving is unaffected.
@@ -655,7 +655,7 @@ fn paced_prune_cancelled_after_seal_heals_on_reconcile() {
 
     // Reconcile sweeps the leftover hot rows, completing the prune idempotently.
     archiver.reconcile().expect("heal");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(
         count_hot_rows::<ConsensusBlocks, _>(hot.inner(), |n| *n <= 2),
         0,
@@ -688,7 +688,7 @@ fn reconcile_sweeps_partially_paced_pruned_epoch() {
         Ok(())
     })
     .expect("seed");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // Seal + index, then cancel the paced prune right before its SECOND block chunk: the digests
     // and blocks 0..=4095 are deleted and committed, block 4096 (the epoch's last) stays hot.
@@ -710,7 +710,7 @@ fn reconcile_sweeps_partially_paced_pruned_epoch() {
         matches!(finalized, Finalized::Cancelled),
         "a prune stopped before its last batch has not finished archiving the epoch"
     );
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // The partial-archive state a shutdown leaves: index committed, first block gone, last block
     // still hot, and the high-water mark un-advanced so the epoch is still due.
@@ -723,7 +723,7 @@ fn reconcile_sweeps_partially_paced_pruned_epoch() {
 
     // Reconcile must sweep the leftover tail; probing only the first block would skip it.
     reconcile(&hot, db.cold().expect("cold attached")).expect("heal");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!(
         count_hot_rows::<ConsensusBlocks, _>(hot.inner(), |n| *n < BLOCKS),
         0,

--- a/crates/infrastructure/storage/src/cold/tests/seal.rs
+++ b/crates/infrastructure/storage/src/cold/tests/seal.rs
@@ -43,7 +43,7 @@ fn seal_layout(layout: &[(u64, BlockHash)], chunk_bytes: usize) -> (TempDir, Tes
     crate::cold::producer::seal_next_epoch(&hot, db.cold().expect("cold attached"), 1, chunk_bytes)
         .expect("seal epoch")
         .expect("one epoch below the cutoff");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     (tmp, db)
 }
 
@@ -126,12 +126,12 @@ fn chunked_seal_retry_after_late_chunk_failure_reseals_cleanly() {
     // Heal the cause and retry: begin_epoch must recover the partially-appended jars.
     hot.with_write_txn(|txn| txn.insert::<Batches>(&DIGEST_C, &batch_for(2, 0)))
         .expect("insert missing batch");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     let stats =
         crate::cold::producer::seal_next_epoch(&hot, db.cold().expect("cold attached"), 1, 0)
             .expect("retried seal")
             .expect("epoch sealed on retry");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!((stats.blocks_archived, stats.batches_archived, stats.epochs_sealed), (3, 3, 1));
 
     // The resealed epoch serves every row and the hot rows are pruned.
@@ -188,7 +188,7 @@ fn cancelled_seal_leaves_jars_uncommitted_and_reseals_whole() {
         crate::cold::producer::seal_next_epoch(&hot, db.cold().expect("cold attached"), 1, 0)
             .expect("retried seal")
             .expect("epoch sealed on retry");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert_eq!((stats.blocks_archived, stats.batches_archived, stats.epochs_sealed), (3, 3, 1));
 
     // ...and its jars are byte-identical to a never-cancelled seal of the same layout.
@@ -216,7 +216,7 @@ fn seal_due_fully_archives_and_matches_fused() {
         background.seal_due(Epoch::MAX, || false).expect("archive pass"),
         SealOutcome::Sealed(_)
     ) {}
-    hot_bg.sync_persist();
+    hot_bg.sync_persist().expect("persist");
 
     let tmp_fused = TempDir::new().unwrap();
     let (db_fused, hot_fused) = open_test_db(&tmp_fused);
@@ -225,7 +225,7 @@ fn seal_due_fully_archives_and_matches_fused() {
         ColdArchiver::new(hot_fused.clone(), db_fused.cold().expect("cold attached").clone());
     let stats = fused.archive_due(Epoch::MAX, None).expect("fused archive");
     assert_eq!(stats.epochs_sealed, 3);
-    hot_fused.sync_persist();
+    hot_fused.sync_persist().expect("persist");
 
     assert_eq!(
         dir_files(&tmp_bg.path().join("cold")),
@@ -281,7 +281,7 @@ fn short_jar_is_never_reopened_by_a_later_pass() {
         Ok(())
     })
     .expect("seed hot");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // Seal a jar covering only the first SHORT blocks of epoch 0.
     db.cold().expect("cold attached").consensus_blocks().begin_epoch(0, 0).expect("begin blocks");
@@ -314,7 +314,7 @@ fn short_jar_is_never_reopened_by_a_later_pass() {
         Ok(())
     })
     .expect("finalize the short jar");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
     assert!(
         db.get::<ConsensusBlocks>(&0).expect("read").is_some(),
         "cold must serve before the pass"
@@ -367,7 +367,7 @@ fn archive_rejects_non_contiguous_consensus_blocks() {
         Ok(())
     })
     .expect("seed hot");
-    hot.sync_persist();
+    hot.sync_persist().expect("persist");
 
     // Archiving epoch 0 (cutoff 1) must reject the gap rather than seal a misaligned jar.
     let result = archive_below_epoch(&hot, db.cold().expect("cold attached"), 1, None);

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -9,7 +9,7 @@ use std::{
     sync::{
         atomic::{AtomicUsize, Ordering as AtomicOrdering},
         mpsc::{self, Receiver, Sender},
-        Arc,
+        Arc, OnceLock,
     },
     thread::JoinHandle,
     time::{Duration, Instant},
@@ -582,6 +582,9 @@ impl<'a, DB: Database> DbTx for LayeredDbTxMut<'a, DB> {
 
 impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     fn insert<T: Table>(&mut self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         // The txn producer already holds the mem write guard for its whole lifetime, so the
         // mutation, the in-flight increment and the enqueue are one critical section by
         // construction.
@@ -592,6 +595,9 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     }
 
     fn remove<T: Table>(&mut self, key: &T::Key) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         self.mem_db.remove::<T>(key)?;
         let rm = Box::new(KeyRemove::<T> { key: key.clone() });
         self.tx.send(DBMessage::Remove(rm)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
@@ -599,6 +605,9 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     }
 
     fn evict_persistent_batch<T: Table>(&mut self, keys: &[T::Key]) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         if keys.is_empty() {
             return Ok(());
         }
@@ -613,6 +622,9 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     }
 
     fn clear_table<T: Table>(&mut self) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         let keys = self.mem_db.raw_keys::<T>();
         self.mem_db.clear_table::<T>()?;
         let clr = Box::new(ClearTable::<T> { _marker: PhantomData, keys });
@@ -621,6 +633,9 @@ impl<'a, DB: Database> DbTxMut for LayeredDbTxMut<'a, DB> {
     }
 
     fn commit(self) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         self.mem_db.commit()?;
         self.tx.send(DBMessage::CommitTxn).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
         Ok(())
@@ -670,21 +685,25 @@ const PERSIST_SLOW_WARN: Duration = Duration::from_secs(1);
 
 /// A [`DBMessage`] sender that tracks the writer queue's depth: every enqueue bumps a shared
 /// counter `db_run` decrements as it drains, feeding the depth gauge and the
-/// [`QUEUE_HIGH_WATER_MARK`] pacing.
+/// [`QUEUE_HIGH_WATER_MARK`] pacing. It also carries the poison latch: once the writer observes
+/// a fatal failure, every producer write path fails fast and nothing further is applied.
 struct QueueSender<DB: Database> {
     tx: Sender<DBMessage<DB>>,
     depth: Arc<AtomicUsize>,
+    /// The first fatal writer failure, if any. Once set the DB is poisoned: the writer applies
+    /// nothing further and every write attempt fails fast with this error.
+    fatal: Arc<OnceLock<String>>,
 }
 
 impl<DB: Database> Clone for QueueSender<DB> {
     fn clone(&self) -> Self {
-        Self { tx: self.tx.clone(), depth: Arc::clone(&self.depth) }
+        Self { tx: self.tx.clone(), depth: Arc::clone(&self.depth), fatal: Arc::clone(&self.fatal) }
     }
 }
 
 impl<DB: Database> Debug for QueueSender<DB> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "QueueSender(depth: {})", self.depth())
+        write!(f, "QueueSender(depth: {}, poisoned: {})", self.depth(), self.fatal.get().is_some())
     }
 }
 
@@ -707,6 +726,18 @@ impl<DB: Database> QueueSender<DB> {
     fn depth(&self) -> usize {
         self.depth.load(AtomicOrdering::Relaxed)
     }
+
+    /// The first fatal writer failure, if any: once set, no further writes are applied and every
+    /// producer write path fails fast.
+    fn fatal(&self) -> Option<&String> {
+        self.fatal.get()
+    }
+}
+
+/// Builds the fail-fast error every write path returns once the DB is poisoned, carrying the
+/// original writer failure.
+fn poisoned_error(fatal: Option<&String>) -> Option<eyre::Error> {
+    fatal.map(|e| eyre::eyre!("consensus DB poisoned: no further writes will be attempted: {e}"))
 }
 
 /// Registers a metric on the process scrape registry, falling back to a private unscraped one on
@@ -763,12 +794,24 @@ fn evict_and_log(mem_db: &MemDatabase, heap: &mut EvictionHeap, max_size: usize,
     }
 }
 
+/// The background writer loop.
+///
+/// A write/commit failure POISONS the DB: the failure is latched (first failure wins), the
+/// optional node fatal-error channel is signaled, and from then on this loop never touches the
+/// database again — it discards every `StartTxn`/`CommitTxn`/`Insert`/`Remove`/`Clear` message,
+/// rejects each `CaughtUp` barrier with the stored error, and waits for `Shutdown`. Producers
+/// independently fail fast on the same latch, so the node winds down instead of continuing to
+/// write into a failing tier. The failed rows stay pinned in mem (their in-flight counts never
+/// settle) and die with the process; the cache rebuilds from the durable tier on the next start.
+/// Only `compact` failures stay advisory.
 fn db_run<DB: Database>(
     db: DB,
     mem_db: MemDatabase,
     rx: Receiver<DBMessage<DB>>,
     depth: Arc<AtomicUsize>,
     max_size: usize,
+    fatal: Arc<OnceLock<String>>,
+    fatal_signal: Arc<OnceLock<tokio::sync::watch::Sender<Option<String>>>>,
 ) {
     let mut txn = None;
     let mut last_compact = Instant::now();
@@ -778,8 +821,14 @@ fn db_run<DB: Database>(
 
     let mut eviction_heap: EvictionHeap = BinaryHeap::new();
     let mut committed_ops: Vec<DeferredOp<DB>> = Vec::with_capacity(1000);
-    // last write/commit failure since the previous CaughtUp, reported by the next persist
-    let mut pending_write_error: Option<String> = None;
+    // Latch the first fatal failure, then signal the node's fatal-error channel (when wired) so
+    // the wind-down starts immediately; both `send` results are advisory and ignored.
+    let trip = |msg: String| {
+        let _ = fatal.set(msg.clone());
+        if let Some(signal) = fatal_signal.get() {
+            let _ = signal.send(Some(msg));
+        }
+    };
     if let Err(e) = db.compact() {
         tracing::error!(target: "layered_db_runner", "DB ERROR compacting DB on startup (background): {e}");
     }
@@ -793,6 +842,23 @@ fn db_run<DB: Database>(
             last_lag_warn = Some(Instant::now());
             tracing::warn!(target: "storage", depth = queued, "layered DB writer queue backlog");
         }
+        // Poisoned: the DB is no longer writable. Apply nothing further (no DB access at all,
+        // including eviction and compact), reject the barriers with the stored error, and wait
+        // for shutdown so the producer-side fail-fast and the node wind-down run to completion.
+        if let Some(err) = fatal.get() {
+            match msg {
+                DBMessage::CaughtUp(tx) => {
+                    let _ = tx.send(Err(err.clone()));
+                }
+                DBMessage::Shutdown => break,
+                DBMessage::StartTxn
+                | DBMessage::CommitTxn
+                | DBMessage::Insert(_)
+                | DBMessage::Remove(_)
+                | DBMessage::Clear(_) => {}
+            }
+            continue;
+        }
         match msg {
             DBMessage::StartTxn => {
                 if let Some((_txn, count)) = &mut txn {
@@ -801,7 +867,8 @@ fn db_run<DB: Database>(
                     match db.write_txn() {
                         Ok(ntxn) => txn = Some((ntxn, 1)),
                         Err(e) => {
-                            tracing::error!(target: "layered_db_runner", "DB ERROR getting write txn (background): {e}")
+                            tracing::error!(target: "layered_db_runner", "DB ERROR getting write txn (background); the DB is poisoned: {e}");
+                            trip(format!("write_txn: {e}"));
                         }
                     }
                 }
@@ -821,13 +888,15 @@ fn db_run<DB: Database>(
                                     txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
                                 );
                             }
-                            // The txn's rows stay in mem with their in-flight counts, so a failed
-                            // commit is retained (not lost, not evictable) and surfaced via
-                            // persist.
+                            // Poison the DB: nothing further is applied, producers fail fast, and
+                            // the next barrier rejects with this error. The txn's rows stay in mem
+                            // with their in-flight counts (retained, not lost, not evictable); the
+                            // counts never settle, the pinned rows die with the process, and the
+                            // cache rebuilds from the durable tier on the next start.
                             Err(e) => {
                                 committed_ops.clear();
-                                tracing::error!(target: "layered_db_runner", "consensus DB commit failed: {e}");
-                                pending_write_error = Some(format!("commit: {e}"));
+                                tracing::error!(target: "layered_db_runner", "consensus DB commit failed; the DB is poisoned: {e}");
+                                trip(format!("commit: {e}"));
                             }
                         }
                     } else {
@@ -839,15 +908,15 @@ fn db_run<DB: Database>(
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = ins.insert_txn(txn) {
                         // keep the failed row in mem (not evictable) so it is not lost
-                        tracing::error!(target: "layered_db_runner", "DB TXN Insert: {e}");
-                        pending_write_error = Some(format!("insert: {e}"));
+                        tracing::error!(target: "layered_db_runner", "DB TXN Insert failed; the DB is poisoned: {e}");
+                        trip(format!("insert: {e}"));
                     } else {
                         committed_ops.push(DeferredOp::Insert(ins));
                     }
                 } else if let Err(e) = ins.insert(&db) {
                     // keep the failed row in mem (with its in-flight count, so not evictable)
-                    tracing::error!(target: "layered_db_runner", "DB Insert: {e}");
-                    pending_write_error = Some(format!("insert: {e}"));
+                    tracing::error!(target: "layered_db_runner", "DB Insert failed; the DB is poisoned: {e}");
+                    trip(format!("insert: {e}"));
                 } else {
                     ins.on_applied(&mem_db, &mut eviction_heap);
                     evict_and_log(
@@ -861,14 +930,14 @@ fn db_run<DB: Database>(
             DBMessage::Remove(rm) => {
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = rm.remove_txn(txn, &mem_db) {
-                        tracing::error!(target: "layered_db_runner", "DB TXN Remove: {e}");
-                        pending_write_error = Some(format!("remove: {e}"));
+                        tracing::error!(target: "layered_db_runner", "DB TXN Remove failed; the DB is poisoned: {e}");
+                        trip(format!("remove: {e}"));
                     } else {
                         committed_ops.push(DeferredOp::Remove(rm));
                     }
                 } else if let Err(e) = rm.remove(&db, &mem_db) {
-                    tracing::error!(target: "layered_db_runner", "DB Remove: {e}");
-                    pending_write_error = Some(format!("remove: {e}"));
+                    tracing::error!(target: "layered_db_runner", "DB Remove failed; the DB is poisoned: {e}");
+                    trip(format!("remove: {e}"));
                 } else {
                     rm.on_applied(&mem_db, &mut eviction_heap);
                     evict_and_log(
@@ -882,14 +951,14 @@ fn db_run<DB: Database>(
             DBMessage::Clear(clr) => {
                 if let Some((txn, _)) = &mut txn {
                     if let Err(e) = clr.clear_table_txn(txn, &mem_db) {
-                        tracing::error!("DB TXN Clear table: {e}");
-                        pending_write_error = Some(format!("clear: {e}"));
+                        tracing::error!(target: "layered_db_runner", "DB TXN Clear table failed; the DB is poisoned: {e}");
+                        trip(format!("clear: {e}"));
                     } else {
                         committed_ops.push(DeferredOp::Clear(clr));
                     }
                 } else if let Err(e) = clr.clear_table(&db, &mem_db) {
-                    tracing::error!("DB Clear: {e}");
-                    pending_write_error = Some(format!("clear: {e}"));
+                    tracing::error!(target: "layered_db_runner", "DB Clear table failed; the DB is poisoned: {e}");
+                    trip(format!("clear: {e}"));
                 } else {
                     clr.on_applied(&mem_db, &mut eviction_heap);
                     evict_and_log(
@@ -902,6 +971,8 @@ fn db_run<DB: Database>(
             }
             // NOTE: proves prior messages were applied, not that an open shared txn committed.
             // Safe at shutdown because consensus writers are torn down before persist runs.
+            // A poisoned DB never reaches this arm: its barriers are rejected above with the
+            // stored error, so a successful reply here means every write so far landed.
             DBMessage::CaughtUp(tx) => {
                 evict_and_log(
                     &mem_db,
@@ -909,11 +980,7 @@ fn db_run<DB: Database>(
                     max_size,
                     txn.as_ref().map(|(_, count)| *count).unwrap_or(0),
                 );
-                let reply: Result<(), String> = match pending_write_error.take() {
-                    Some(e) => Err(e),
-                    None => Ok(()),
-                };
-                let _ = tx.send(reply);
+                let _ = tx.send(Ok(()));
             }
             DBMessage::Shutdown => break,
         }
@@ -939,12 +1006,20 @@ fn db_run<DB: Database>(
 }
 
 /// In-memory cache layer over a persistent database with background writes.
+///
+/// A fatal writer failure poisons the DB: the writer applies nothing further, every write
+/// attempt fails fast with the stored error, and (when [`Self::with_fatal_signal`] is set) the
+/// node's fatal-error channel is signaled so the process winds down instead of continuing to
+/// write into a failing tier. Reads keep serving from the mem cache and the durable tier.
 #[derive(Clone, Debug)]
 pub struct LayeredDatabase<DB: Database> {
     mem_db: MemDatabase,
     db: DB,
     tx: QueueSender<DB>,
     thread: Option<Arc<JoinHandle<()>>>,
+    /// Slot for the node's fatal-error channel, shared with the writer thread: `with_fatal_signal`
+    /// sets it, `db_run` signals it on the first fatal failure.
+    fatal_signal: Arc<OnceLock<tokio::sync::watch::Sender<Option<String>>>>,
     /// The cold tier point reads fall through to on a hot miss, when attached.
     #[cfg(feature = "cold-storage")]
     cold: Option<Arc<ColdStore>>,
@@ -977,7 +1052,8 @@ impl<DB: Database> LayeredDatabase<DB> {
     }
 
     /// Opens the layered DB with a custom eviction policy: small caches in tests, the default in
-    /// production.
+    /// production. The DB starts unpoisoned; a fatal writer failure latches the poison
+    /// (see [`Self::with_fatal_signal`] and [`db_run`]).
     pub fn open_with_config(db: DB, config: CacheConfig) -> Self {
         // This channel must always remain unbounded. This is necessary for the atomicity
         // guarantee (mem mutation + enqueue in one critical section). It is safe today because
@@ -987,21 +1063,43 @@ impl<DB: Database> LayeredDatabase<DB> {
         // process the ops — a classic deadlock.
         let (tx, rx) = mpsc::channel();
         let depth = Arc::new(AtomicUsize::new(0));
+        let fatal = Arc::new(OnceLock::new());
+        let fatal_signal = Arc::new(OnceLock::new());
         let db_cloned = db.clone();
         let mem_db = MemDatabase::new();
         let mem_db_clone = mem_db.clone();
         let queue_depth = Arc::clone(&depth);
+        let fatal_for_thread = Arc::clone(&fatal);
+        let signal_for_thread = Arc::clone(&fatal_signal);
         let thread = Some(Arc::new(std::thread::spawn(move || {
-            db_run(db_cloned, mem_db_clone, rx, queue_depth, config.max_size)
+            db_run(
+                db_cloned,
+                mem_db_clone,
+                rx,
+                queue_depth,
+                config.max_size,
+                fatal_for_thread,
+                signal_for_thread,
+            )
         })));
         Self {
             mem_db,
             db,
-            tx: QueueSender { tx, depth },
+            tx: QueueSender { tx, depth, fatal },
             thread,
+            fatal_signal,
             #[cfg(feature = "cold-storage")]
             cold: None,
         }
+    }
+
+    /// Wires the node's fatal-error channel: when the background writer observes a fatal write
+    /// failure it signals this channel with the stored error, requesting the node wind-down
+    /// (see [`db_run`]). Call before starting writes; the first failure signals it once, and
+    /// every barrier and write attempt then rejects with the stored error.
+    pub fn with_fatal_signal(self, signal: tokio::sync::watch::Sender<Option<String>>) -> Self {
+        let _ = self.fatal_signal.set(signal);
+        self
     }
 
     /// Attaches the cold tier point reads fall through to on a hot miss.
@@ -1188,6 +1286,9 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
 
     /// Write transactions overlap and commit when the last one completes.
     fn write_txn(&self) -> eyre::Result<Self::TXMut<'_>> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         self.tx.send(DBMessage::StartTxn).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))?;
         Ok(LayeredDbTxMut {
             mem_db: self.mem_db.write_txn()?,
@@ -1236,6 +1337,11 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn insert<T: Table>(&self, key: &T::Key, value: &T::Value) -> eyre::Result<()> {
+        // Checked before the mem mutation: `insert_queued` has no rollback, so a poisoned DB
+        // must not touch the cache at all.
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         // The mem mutation, the in-flight increment and the enqueue share one critical section:
         // channel order equals mem order, so a zero in-flight count is a sound "no queued ops".
         self.mem_db.insert_queued::<T>(key, value, || {
@@ -1245,6 +1351,9 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn remove<T: Table>(&self, key: &T::Key) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         self.mem_db.remove_queued::<T>(key, || {
             let rm = Box::new(KeyRemove::<T> { key: key.clone() });
             self.tx.send(DBMessage::Remove(rm)).map_err(|_| eyre::eyre!("DB thread gone, FATAL!"))
@@ -1252,6 +1361,9 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn clear_table<T: Table>(&self) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         // The clear tombstones every row and bumps each in-flight count under the same lock that
         // captures the key set for the writer, so no tombstone is evicted before the clear lands.
         self.mem_db.clear_table_queued::<T>(|keys| {
@@ -1348,11 +1460,17 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
     }
 
     fn persist(&self) -> impl Future<Output = eyre::Result<()>> + Send {
+        // A poisoned DB fails immediately with the stored error (the writer would reject the
+        // barrier with the same error anyway).
+        let poisoned = poisoned_error(self.tx.fatal());
         let (tx, rx) = oneshot::channel();
         let depth_at_send = self.tx.depth();
         let started = Instant::now();
         let send_result = self.tx.send(DBMessage::CaughtUp(tx));
         async move {
+            if let Some(e) = poisoned {
+                return Err(e);
+            }
             match send_result {
                 Ok(()) => match rx.await {
                     Ok(Ok(())) => {
@@ -1378,7 +1496,17 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
 
     /// Blocks the calling thread until the writer has applied all queued messages; never call it
     /// on an async runtime worker.
-    fn sync_persist(&self) {
+    ///
+    /// Returns any write/commit failure the writer observed since the previous barrier, so a
+    /// caller cannot mistake a failed flush for durability. Callers must treat the error as
+    /// fatal (fault the node): a failed flush poisons the DB — the writer applies nothing
+    /// further, every write method returns the stored error immediately, and the failed rows
+    /// stay pinned in the mem cache (in-flight counts never settle) until a restart rebuilds
+    /// it, so an ignored error leaks them unboundedly.
+    fn sync_persist(&self) -> eyre::Result<()> {
+        if let Some(e) = poisoned_error(self.tx.fatal()) {
+            return Err(e);
+        }
         let (tx, mut rx) = oneshot::channel();
         let depth_at_send = self.tx.depth();
         let started = Instant::now();
@@ -1391,18 +1519,21 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
             loop {
                 match rx.try_recv() {
                     Err(TryRecvError::Empty) => std::thread::sleep(Duration::from_millis(100)),
-                    Err(TryRecvError::Closed) => break,
+                    Err(TryRecvError::Closed) => {
+                        return Err(eyre::eyre!("consensus DB sync_persist: reply dropped"));
+                    }
                     Ok(Ok(())) => {
                         log_persist_latency(started.elapsed(), depth_at_send);
-                        break;
+                        return Ok(());
                     }
                     Ok(Err(e)) => {
                         tracing::error!(target: "storage", "consensus DB sync_persist: write failed: {e}");
-                        break;
+                        return Err(eyre::eyre!("consensus DB sync_persist: {e}"));
                     }
                 }
             }
         }
+        r.map(|_| ())
     }
 }
 
@@ -1569,8 +1700,8 @@ impl<DB: Database> Debug for DBMessage<DB> {
 #[cfg(test)]
 mod test {
     use super::{
-        CacheConfig, DBMessage, EvictionHeap, InsertTrait, LayeredDatabase, QUEUE_HIGH_WATER_MARK,
-        QUEUE_PACE_SLEEP,
+        CacheConfig, DBMessage, EvictionHeap, InsertTrait, KeyValueInsert, LayeredDatabase,
+        QUEUE_HIGH_WATER_MARK, QUEUE_PACE_SLEEP,
     };
     #[cfg(feature = "redb")]
     use crate::redb::ReDB;
@@ -1741,7 +1872,7 @@ mod test {
         db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
         db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
         db.insert::<TestTable>(&3, &"three".to_string()).expect("insert");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
         // Key 1 settled first and was evicted: it is now live only in the persistent tier.
         assert_eq!(db.mem_db.mem_size(), 2, "key 1 must be evicted");
         assert!(!db.mem_db.contains_key::<TestTable>(&1).unwrap());
@@ -1768,12 +1899,12 @@ mod test {
         assert_eq!(db.get::<TestTable>(&4).unwrap(), Some("four".to_string()));
 
         inner.release_clear();
-        db.sync_persist();
+        db.sync_persist().expect("persist");
         assert_eq!(db.get::<TestTable>(&1).unwrap(), None, "clear must land");
         assert!(!db.mem_db.is_clearing::<TestTable>(), "pending-clear flag must settle");
 
         db.insert::<TestTable>(&5, &"five".to_string()).expect("insert");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
         assert_eq!(db.get::<TestTable>(&5).unwrap(), Some("five".to_string()));
     }
 
@@ -1792,11 +1923,11 @@ mod test {
             Ok(())
         })
         .expect("seed");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         // An empty batch is a no-op: nothing is removed.
         db.with_write_txn(|txn| txn.evict_persistent_batch::<TestTable>(&[])).expect("empty batch");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
         for i in 0..10u64 {
             assert!(db.contains_key::<TestTable>(&i).unwrap(), "empty batch removed key {i}");
         }
@@ -1804,7 +1935,7 @@ mod test {
         let evicted = [1u64, 3, 5, 7];
         db.with_write_txn(|txn| txn.evict_persistent_batch::<TestTable>(&evicted))
             .expect("batch evict");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         for i in 0..10u64 {
             let present = db.contains_key::<TestTable>(&i).unwrap();
@@ -1840,6 +1971,148 @@ mod test {
         assert!(
             db.persist().await.is_err(),
             "persist must surface the write failure instead of reporting success"
+        );
+    }
+
+    /// The blocking sibling of `test_failed_write_is_surfaced_by_persist`: `sync_persist` must
+    /// also surface a failed commit, so blocking callers (cold archival) cannot mistake a failed
+    /// flush for durability and proceed to prune rows the index never durably landed.
+    #[test]
+    fn test_failed_commit_is_surfaced_by_sync_persist() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let cfg = MdbxConfig::default().with_max_db_size(1024 * 1024).with_growth_step(256 * 1024);
+        let mdbx = MdbxDatabase::open_with_config(temp_dir.path(), cfg).expect("open mdbx");
+        mdbx.open_table::<TestTable>().expect("open mdbx table");
+        let db = LayeredDatabase::open(mdbx);
+        db.open_table::<TestTable>().expect("open layered table");
+
+        // Queue far more data than the map can hold so the background writer hits MAP_FULL.
+        let big = "x".repeat(4096);
+        let _ = db.with_write_txn(|txn| {
+            for i in 0..4_000u64 {
+                txn.insert::<TestTable>(&i, &big)?;
+            }
+            Ok(())
+        });
+
+        assert!(
+            db.sync_persist().is_err(),
+            "sync_persist must surface the failed commit instead of reporting success"
+        );
+    }
+
+    /// A layered MDBX whose map is sized so the background writer hits MAP_FULL, as on a full
+    /// disk: the first failing write poisons the DB.
+    fn open_poisonable_mdbx(path: &Path) -> LayeredDatabase<MdbxDatabase> {
+        let cfg = MdbxConfig::default().with_max_db_size(1024 * 1024).with_growth_step(256 * 1024);
+        let mdbx = MdbxDatabase::open_with_config(path, cfg).expect("open mdbx");
+        mdbx.open_table::<TestTable>().expect("open mdbx table");
+        let db = LayeredDatabase::open(mdbx);
+        db.open_table::<TestTable>().expect("open layered table");
+        db
+    }
+
+    /// Queue far more data than the map can hold so the background writer's next commit fails and
+    /// poisons the DB. The failure is only observable at the next durability barrier.
+    fn queue_poisoning_writes(db: &LayeredDatabase<MdbxDatabase>) {
+        let big = "x".repeat(4096);
+        let _ = db.with_write_txn(|txn| {
+            for i in 0..4_000u64 {
+                txn.insert::<TestTable>(&i, &big)?;
+            }
+            Ok(())
+        });
+    }
+
+    fn assert_poisoned(err: &eyre::Error, what: &str) {
+        assert!(
+            err.to_string().contains("poisoned"),
+            "{what} on a poisoned DB must fail fast with the poison reason: {err}"
+        );
+    }
+
+    /// Once a write failure has been observed, every write path fails fast with the stored error
+    /// and the DB stays poisoned for its lifetime: nothing is retried, queued, or applied.
+    #[tokio::test]
+    async fn test_poisoned_db_fails_further_writes_fast() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let db = open_poisonable_mdbx(temp_dir.path());
+        queue_poisoning_writes(&db);
+        assert!(db.persist().await.is_err(), "persist must surface the write failure");
+
+        let big = "x".repeat(4096);
+        let err = db.insert::<TestTable>(&7, &big).expect_err("insert must fail fast");
+        assert_poisoned(&err, "insert");
+        let err = db.remove::<TestTable>(&7).expect_err("remove must fail fast");
+        assert_poisoned(&err, "remove");
+        let err = db.clear_table::<TestTable>().expect_err("clear_table must fail fast");
+        assert_poisoned(&err, "clear_table");
+        let err = db.write_txn().map(|_| ()).expect_err("write_txn must fail fast");
+        assert_poisoned(&err, "write_txn");
+        let err = db.persist().await.expect_err("persist must fail fast");
+        assert_poisoned(&err, "persist");
+        let err = db.sync_persist().expect_err("sync_persist must fail fast");
+        assert_poisoned(&err, "sync_persist");
+    }
+
+    /// After the poison latches, the writer applies nothing further — not even a message a
+    /// producer enqueued before it could fail fast — and reads keep serving from the cache and
+    /// the durable tier.
+    #[test]
+    fn test_poisoned_writer_applies_nothing_further() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let db = open_poisonable_mdbx(temp_dir.path());
+
+        // A row that lands before the failure, so reads have something to serve afterwards.
+        // Key 9000 sits outside the poisoning batch's range (0..4000), so the batch cannot
+        // clobber it in the mem cache.
+        db.insert::<TestTable>(&9000, &"pre-failure".to_string()).expect("pre-failure insert");
+        db.sync_persist().expect("pre-failure persist");
+
+        queue_poisoning_writes(&db);
+        assert!(db.sync_persist().is_err(), "sync_persist must surface the write failure");
+
+        // A message enqueued directly, as if by a producer that slipped past the fail-fast check:
+        // the poisoned writer must discard it, not apply it.
+        let ins = Box::new(KeyValueInsert::<TestTable> { key: 99, value: "late".to_string() });
+        db.tx.send(DBMessage::Insert(ins)).expect("the poisoned writer still drains messages");
+
+        // The depth gauge is decremented per message the writer takes off the queue (applied or
+        // discarded), so zero means the writer has drained past the late insert.
+        let deadline = Instant::now() + std::time::Duration::from_secs(5);
+        while db.tx.depth() > 0 {
+            assert!(
+                Instant::now() < deadline,
+                "the writer did not drain the queue after the poison"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+
+        assert!(
+            db.db.get::<TestTable>(&99).expect("durable read").is_none(),
+            "a message enqueued after the poison must not be applied to the durable tier"
+        );
+        assert_eq!(
+            db.get::<TestTable>(&9000).expect("cache read").as_deref(),
+            Some("pre-failure"),
+            "reads must keep serving after the poison"
+        );
+    }
+
+    /// `with_fatal_signal` wires the node's wind-down channel: the first fatal writer failure
+    /// signals it with the stored error, so the process stops instead of writing further.
+    #[tokio::test]
+    async fn test_fatal_signal_fires_on_writer_failure() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let (signal, rx) = tokio::sync::watch::channel(None);
+        let db = open_poisonable_mdbx(temp_dir.path()).with_fatal_signal(signal);
+
+        queue_poisoning_writes(&db);
+        assert!(db.persist().await.is_err(), "persist must surface the write failure");
+
+        assert!(
+            rx.borrow().is_some(),
+            "the node fatal-error channel must be signaled on the first fatal failure"
         );
     }
 
@@ -1934,7 +2207,7 @@ mod test {
         for i in 0..10u64 {
             db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
         }
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         assert_eq!(db.mem_db.mem_size(), 3, "cache must be trimmed to max_size");
         // The newest rows survive hot; older ones fall through to the persistent tier.
@@ -1995,7 +2268,7 @@ mod test {
             "K1's tombstone must survive while queued"
         );
         drop(release2);
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         // The remove applied, so K1's settled tombstone is now evictable; only K2 stays hot.
         assert_eq!(db.mem_db.mem_size(), 1, "settled rows must be trimmed to max_size");
@@ -2020,7 +2293,7 @@ mod test {
         db.remove::<TestTable>(&999).expect("remove never-inserted key");
         db.insert::<TestTable>(&1, &"one".to_string()).expect("insert");
         db.insert::<TestTable>(&2, &"two".to_string()).expect("insert");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         assert_eq!(db.get::<TestTable>(&999).unwrap(), None);
         assert!(!db.mem_db.is_tombstoned::<TestTable>(&999), "stray tombstone must be evicted");
@@ -2041,7 +2314,7 @@ mod test {
         db.insert::<TestTable>(&3, &"three".to_string()).expect("insert");
         db.clear_table::<TestTable>().expect("clear");
         db.insert::<TestTable>(&4, &"four".to_string()).expect("insert");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         assert_eq!(db.get::<TestTable>(&1).unwrap(), None);
         assert_eq!(db.get::<TestTable>(&2).unwrap(), None);
@@ -2062,7 +2335,7 @@ mod test {
         for i in 1..=3u64 {
             db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
         }
-        db.sync_persist();
+        db.sync_persist().expect("persist");
         // 1 settled first and was evicted; 2 and 3 are hot.
         assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap());
         assert!(db.mem_db.contains_key::<TestTable>(&3).unwrap());
@@ -2073,7 +2346,7 @@ mod test {
 
         // Overflow the cache: without the read bump, key 2 (settled first) would be evicted.
         db.insert::<TestTable>(&4, &"v4".to_string()).expect("insert");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         assert_eq!(db.mem_db.mem_size(), 2);
         assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "read key must stay hot");
@@ -2098,7 +2371,7 @@ mod test {
         db.insert::<TestTable>(&1, &"v3".to_string()).expect("reinsert");
         db.insert::<TestTable>(&2, &"v2".to_string()).expect("insert");
         db.insert::<TestTable>(&3, &"v3".to_string()).expect("insert");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         assert_eq!(db.get::<TestTable>(&1).unwrap(), Some("v3".to_string()));
         assert_eq!(db.mem_db.mem_size(), 1, "no in-flight leak: the row is evictable");
@@ -2267,7 +2540,7 @@ mod test {
             txn.insert::<TestTable>(&key, &val).expect("Failed to insert");
         }
         txn.commit().unwrap();
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         // Verify all items are accessible via the layered iterator
         let count = db.iter::<TestTable>().count();

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -823,10 +823,19 @@ fn db_run<DB: Database>(
     let mut committed_ops: Vec<DeferredOp<DB>> = Vec::with_capacity(1000);
     // Latch the first fatal failure, then signal the node's fatal-error channel (when wired) so
     // the wind-down starts immediately; both `send` results are advisory and ignored.
+    // The watch preserves the first error (root cause): a later `WriteFailed` from cold archival
+    // must not overwrite the original writer failure that `core.rs` logs.
     let trip = |msg: String| {
         let _ = fatal.set(msg.clone());
         if let Some(signal) = fatal_signal.get() {
-            let _ = signal.send(Some(msg));
+            let _ = signal.send_if_modified(|cur| {
+                if cur.is_none() {
+                    *cur = Some(msg.clone());
+                    true
+                } else {
+                    false
+                }
+            });
         }
     };
     if let Err(e) = db.compact() {

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1545,7 +1545,7 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
                 }
             }
         }
-        r.map(|_| ())
+        r
     }
 }
 

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -1461,18 +1461,21 @@ impl<DB: Database> Database for LayeredDatabase<DB> {
 
     fn persist(&self) -> impl Future<Output = eyre::Result<()>> + Send {
         // A poisoned DB fails immediately with the stored error (the writer would reject the
-        // barrier with the same error anyway).
+        // barrier with the same error anyway) — without enqueuing a CaughtUp, so a loop
+        // retrying persist() on a poisoned DB does not spam the writer queue (see
+        // sync_persist() which also short-circuits before send).
+        let tx = self.tx.clone();
         let poisoned = poisoned_error(self.tx.fatal());
-        let (tx, rx) = oneshot::channel();
-        let depth_at_send = self.tx.depth();
-        let started = Instant::now();
-        let send_result = self.tx.send(DBMessage::CaughtUp(tx));
         async move {
             if let Some(e) = poisoned {
                 return Err(e);
             }
+            let (ca_tx, ca_rx) = oneshot::channel();
+            let depth_at_send = tx.depth();
+            let started = Instant::now();
+            let send_result = tx.send(DBMessage::CaughtUp(ca_tx));
             match send_result {
-                Ok(()) => match rx.await {
+                Ok(()) => match ca_rx.await {
                     Ok(Ok(())) => {
                         log_persist_latency(started.elapsed(), depth_at_send);
                         Ok(())

--- a/crates/infrastructure/storage/src/lib.rs
+++ b/crates/infrastructure/storage/src/lib.rs
@@ -321,7 +321,7 @@ mod test {
             Ok(())
         })
         .unwrap();
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         println!("DBBENCH [{name}] insert {max}: {}", start.elapsed().as_secs_f64());
         let startc = std::time::Instant::now();
@@ -450,7 +450,7 @@ mod test {
         db.insert::<TestTable>(&123, &"123".to_string()).expect("Failed to insert");
         db.insert::<TestTable>(&456, &"456".to_string()).expect("Failed to insert");
         db.insert::<TestTable>(&789, &"789".to_string()).expect("Failed to insert");
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
 
         // Skip all smaller
         let key_vals: Vec<_> = db.skip_to::<TestTable>(&456).expect("Seek failed").collect();
@@ -474,7 +474,7 @@ mod test {
         txn.insert::<TestTable>(&456, &"456".to_string()).expect("Failed to insert");
         txn.insert::<TestTable>(&789, &"789".to_string()).expect("Failed to insert");
         txn.commit().unwrap();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
 
         // Skip to the one before the end
         let key_val = db.record_prior_to::<TestTable>(&999).expect("Seek failed");
@@ -493,9 +493,9 @@ mod test {
             }
         }
         txn.commit().unwrap();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
-                           // Skip prior to will return an iterator starting with an "unexpected" key if the sought one
-                           // is not in the table
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
+                                             // Skip prior to will return an iterator starting with an "unexpected" key if the sought one
+                                             // is not in the table
         let val = db.record_prior_to::<TestTable>(&50).map(|(k, _)| k).unwrap();
         assert_eq!(49, val);
     }
@@ -566,12 +566,12 @@ mod test {
             txn.insert::<TestTable>(&key, &val).expect("Failed to batch insert");
         }
         txn.commit().unwrap();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
 
         // Check we have multiple entries
         assert!(db.iter::<TestTable>().count() > 1);
         let _ = db.clear_table::<TestTable>();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
         assert_eq!(db.iter::<TestTable>().count(), 0);
         // Clear again to ensure safety when clearing empty map
         let _ = db.clear_table::<TestTable>();
@@ -580,7 +580,7 @@ mod test {
         let _ = db.insert::<TestTable>(&1, &"e".to_string());
         assert_eq!(db.iter::<TestTable>().count(), 1);
         let _ = db.clear_table::<TestTable>();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
         assert_eq!(db.iter::<TestTable>().count(), 0);
     }
 
@@ -602,7 +602,7 @@ mod test {
 
         // Clear again to ensure empty works after clearing
         let _ = db.clear_table::<TestTable>();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
         assert_eq!(db.iter::<TestTable>().count(), 0);
         assert!(db.is_empty::<TestTable>());
     }
@@ -640,9 +640,9 @@ mod test {
             txn.remove::<TestTable>(&key).expect("Failed to batch remove");
         }
         txn.commit().unwrap();
-        db.sync_persist(); // Either a no-op or a chance for write ops to catch up.
-                           // Rayls: Asserting against fetched items, due to chaining of in memory and persistent db,
-                           // resulting in double iter size.
+        db.sync_persist().expect("persist"); // Either a no-op or a chance for write ops to catch up.
+                                             // Rayls: Asserting against fetched items, due to chaining of in memory and persistent db,
+                                             // resulting in double iter size.
         for (k, _) in (0..101).map(|i| (i, i.to_string())).take(50) {
             let val = db.get::<TestTable>(&k).expect("Failed to get removed key");
             assert_eq!(None, val);

--- a/crates/infrastructure/storage/src/mdbx/database.rs
+++ b/crates/infrastructure/storage/src/mdbx/database.rs
@@ -1208,7 +1208,7 @@ mod test {
             for n in 0..8u64 {
                 db.insert::<TestTable>(&n, &format!("row-{n}")).expect("insert");
             }
-            db.sync_persist();
+            db.sync_persist().expect("persist");
         }
 
         let stats = compact_in_place(temp_dir.path(), &cfg).expect("compact after stack drop");

--- a/crates/infrastructure/types/src/database_traits.rs
+++ b/crates/infrastructure/types/src/database_traits.rs
@@ -244,9 +244,20 @@ pub trait Database: Send + Sync + Clone + Unpin + 'static {
     /// Wait for enqueued background writes to commit, returning an error if any failed.
     ///
     /// A successful result means committed, not fsync'd to disk; deferred-sync backends sync later.
+    ///
+    /// In a layered DB, a failure poisons the DB: every write method then fails fast with the
+    /// stored error and the background writer applies nothing further.
     fn persist(&self) -> impl Future<Output = eyre::Result<()>> + Send {
         std::future::ready(Ok(()))
     }
-    /// Sync version of persist- useful for test not for prod code.
-    fn sync_persist(&self) {}
+    /// Blocking variant of `persist`, for callers that cannot await.
+    ///
+    /// Returns any write/commit failure the background writer observed since the previous
+    /// barrier. Callers must treat an error as fatal (fault the node): a failed flush poisons a
+    /// layered DB (every write then fails fast and the writer applies nothing further), and the
+    /// failed rows stay pinned in its mem cache until a restart rebuilds it, so an ignored
+    /// error leaks them unboundedly.
+    fn sync_persist(&self) -> eyre::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
@@ -14,14 +14,14 @@ use prometheus::{
     Histogram, IntCounter, Registry,
 };
 use rayls_infrastructure_storage::{
-    cold_archiver_for, ColdArchiver, ColdArchiverType, DatabaseType, SealOutcome,
+    cold::ColdError, cold_archiver_for, ColdArchiver, ColdArchiverType, DatabaseType, SealOutcome,
 };
 use rayls_infrastructure_types::{
     ConsensusHeader, Database, Epoch, Notifier, TaskKind, TaskManager,
 };
 use reth_db::lockfile::StorageLock;
 use tokio::sync::{oneshot, watch};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 /// Acquires the process-exclusivity lock on the consensus-DB directory: the cold tier assumes a
 /// single archiver process (a concurrent writer could truncate a torn jar under a reconcile).
@@ -123,6 +123,7 @@ impl ColdArchival {
         task_manager: &TaskManager,
         mut anchor_rx: watch::Receiver<ConsensusHeader>,
         shutdown: Notifier,
+        fatal_db_error: watch::Sender<Option<String>>,
     ) {
         let Some(archiver) = self.archiver.clone() else { return };
         let noticer = shutdown.subscribe();
@@ -140,11 +141,19 @@ impl ColdArchival {
                         // no sooner than the cooldown (see [`FAILED_PASS_COOLDOWN`]). A pass the
                         // shutdown flag stopped is not a failure, so it must not arm the cooldown:
                         // a later non-teardown cancel source would otherwise stall archival.
-                        if seal_due_epochs(&archiver, anchor_epoch, &shutdown).await {
+                        if seal_due_epochs(&archiver, anchor_epoch, &shutdown, &fatal_db_error)
+                            .await
+                        {
                             sealed_for = Some(anchor_epoch);
                         } else if !shutdown.was_notified() {
                             retry_at = tokio::time::Instant::now() + FAILED_PASS_COOLDOWN;
                         }
+                    }
+                    // A write error was signaled: the node is winding down gracefully (run()'
+                    // handles the ordered teardown), so this actor must NOT arm the retry
+                    // cooldown and keep sealing into a failing tier.
+                    if fatal_db_error.borrow().is_some() {
+                        return;
                     }
                     tokio::select! {
                         biased;
@@ -235,10 +244,13 @@ impl ColdArchiveMetrics {
 ///
 /// Returns whether the backlog below the cutoff was drained; a spawn failure, a failed pass, a
 /// panicked pass and a cancelled pass all return `false`, leaving the epoch due for a retry.
+/// A hot-tier write failure instead signals `fatal_db_error` and returns `false`: the node winds
+/// down gracefully (keeping the durable tier), and the actor exits without retrying.
 async fn seal_due_epochs<DB: Database>(
     archiver: &Arc<ColdArchiver<DB>>,
     el_anchor_epoch: Epoch,
     shutdown: &Notifier,
+    fatal_db_error: &watch::Sender<Option<String>>,
 ) -> bool {
     loop {
         // Checked before each pass, not only at a chunk seam: a shutdown landing on a completed
@@ -292,6 +304,24 @@ async fn seal_due_epochs<DB: Database>(
             Ok(Ok(SealOutcome::Cancelled)) => return false,
             Ok(Err(e)) => {
                 metrics.cold_archive_failures.inc();
+                // A hot-tier durability failure is fatal, but the node shuts down GRACEFULLY
+                // rather than panicking: the durable tier is the last known valid data, and
+                // losing the mem cache and any uncommitted mdbx transaction is acceptable.
+                // Signal the epoch manager (run() requests the ordered wind-down and exits
+                // non-zero) and stop retrying — retrying the same epoch only pins more rows in
+                // the failing cache, and the process exit discards them anyway. Any other pass
+                // failure (corruption, contiguity) stays retriable after the cooldown.
+                if e.downcast_ref::<ColdError>()
+                    .is_some_and(|err| matches!(err, ColdError::WriteFailed(_)))
+                {
+                    error!(
+                        target: "epoch-manager",
+                        ?e,
+                        "cold epoch archive: hot-tier write not durable, requesting graceful node shutdown"
+                    );
+                    let _ = fatal_db_error.send(Some(format!("{e:?}")));
+                    return false;
+                }
                 warn!(target: "epoch-manager", "cold epoch archive failed: {e}");
                 return false;
             }
@@ -334,7 +364,9 @@ fn lower_current_thread_priority() {}
 mod tests {
     use super::*;
     use rayls_infrastructure_storage::{
-        cold_archiver_for, open_db,
+        cold_archiver_for,
+        mdbx::MdbxConfig,
+        open_db, open_db_with_consensus_config,
         tables::{Batches, ColdBatchLocations, ConsensusBlocks},
         DatabaseType,
     };
@@ -368,7 +400,7 @@ mod tests {
             Ok(())
         })
         .expect("seed");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         let archiver = cold_archiver_for(&db).expect("mdbx stack has a cold tier");
         let shutdown = Notifier::new();
@@ -381,6 +413,7 @@ mod tests {
             &task_manager,
             anchor_rx,
             shutdown.clone(),
+            watch::channel(None).0,
         );
 
         // Wake the actor and wait until a blocking pass is provably in flight: the pass's
@@ -464,13 +497,18 @@ mod tests {
             Ok(())
         })
         .expect("seed");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         let shutdown = Notifier::new();
         let mut task_manager = TaskManager::new("seal-actor-retry-test");
         task_manager.set_join_wait(500);
         let (anchor_tx, anchor_rx) = watch::channel(ConsensusHeader::default());
-        ColdArchival::new(&db).spawn_actor(&task_manager, anchor_rx, shutdown.clone());
+        ColdArchival::new(&db).spawn_actor(
+            &task_manager,
+            anchor_rx,
+            shutdown.clone(),
+            watch::channel(None).0,
+        );
 
         let failures = || ColdArchiveMetrics::get().cold_archive_failures.get();
         let before = failures();
@@ -486,7 +524,7 @@ mod tests {
             txn.insert::<ConsensusBlocks>(&1, &header_with_batch(1, 0, digest))
         })
         .expect("repair the gap");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
         anchor_tx.send_replace(header_for(5, 2));
         for _ in 0..1_000 {
             tokio::task::yield_now().await;
@@ -517,6 +555,59 @@ mod tests {
             .expect("probe aux index")
     }
 
+    /// A hot-tier durability failure must signal the fatal channel (the epoch manager then winds
+    /// the node down gracefully, keeping the durable tier) instead of panicking: losing the mem
+    /// cache and any uncommitted mdbx transaction is acceptable.
+    #[tokio::test]
+    async fn write_failure_signals_fatal_shutdown_not_a_panic() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = MdbxConfig::default().with_max_db_size(1024 * 1024).with_growth_step(256 * 1024);
+        let db = open_db_with_consensus_config(tmp.path(), &cfg);
+
+        // Seed one small due epoch (blocks 0-2 in epoch 0) plus marker epochs making it due.
+        db.with_write_txn(|txn| {
+            for number in 0..3u64 {
+                let digest = digest_for(number);
+                txn.insert::<Batches>(&digest, &batch_for(number))?;
+                txn.insert::<ConsensusBlocks>(&number, &header_with_batch(number, 0, digest))?;
+            }
+            txn.insert::<ConsensusBlocks>(&3, &header_for(3, 1))?;
+            txn.insert::<ConsensusBlocks>(&4, &header_for(4, 2))?;
+            Ok(())
+        })
+        .expect("seed");
+        db.sync_persist().expect("persist");
+
+        // Overflow the map: the writer's commit of this oversized txn fails with MAP_FULL and
+        // poisons the DB. Queueing may itself fail mid-batch — once the writer trips, the
+        // producer's in-flight inserts fail fast — but the DB is poisoned either way. The junk
+        // never commits, so the seal's reads stay clean; the archival pass then fails on the
+        // poisoned DB and surfaces the failure as a `WriteFailed`.
+        let big = Batch { transactions: vec![vec![0u8; 4096]], ..Default::default() };
+        match db.with_write_txn(|txn| {
+            for i in 0..4_000u64 {
+                txn.insert::<Batches>(&digest_for(10_000 + i), &big)?;
+            }
+            Ok(())
+        }) {
+            Ok(()) => {}
+            Err(e) => assert!(
+                e.to_string().contains("poisoned"),
+                "a mid-batch queueing failure must be the poison, got: {e}"
+            ),
+        }
+
+        let archiver = cold_archiver_for(&db).expect("mdbx stack has a cold tier");
+        let shutdown = Notifier::new();
+        let (fatal_tx, fatal_rx) = watch::channel(None);
+        let drained = seal_due_epochs(&archiver, 3, &shutdown, &fatal_tx).await;
+        assert!(!drained, "a failed pass must not report its epoch drained");
+        assert!(
+            fatal_rx.borrow().is_some(),
+            "a hot-tier durability failure must signal the graceful node shutdown, not panic"
+        );
+    }
+
     /// A failed archive chunk must surface as an error (the CLI's exit code), never be swallowed
     /// into a success: a gapped epoch fails the seal's contiguity check mid-drain.
     #[tokio::test]
@@ -531,7 +622,7 @@ mod tests {
             Ok(())
         })
         .expect("seed");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         let archival = ColdArchival::new(&db);
         let result = archival.migrate_backlog(2).await;

--- a/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/cold_archive.rs
@@ -118,6 +118,10 @@ impl ColdArchival {
     /// `shutdown` doubles as the cancel flag at chunk seams. The actor is [`TaskKind::Drainable`]
     /// so teardown joins its blocking pass rather than aborting mid-pass and detaching a thread
     /// that still holds a database handle.
+    ///
+    /// `fatal_db_error` is a `watch` that is overwritten on `send`; both the writer thread
+    /// (`layered_db::trip`) and this actor may signal it, but `send_if_modified` preserves the
+    /// first (root-cause) error so `core.rs` logs the original failure.
     pub(crate) fn spawn_actor(
         &self,
         task_manager: &TaskManager,
@@ -319,7 +323,17 @@ async fn seal_due_epochs<DB: Database>(
                         ?e,
                         "cold epoch archive: hot-tier write not durable, requesting graceful node shutdown"
                     );
-                    let _ = fatal_db_error.send(Some(format!("{e:?}")));
+                    // Preserve the first fatal signal (root cause). The writer thread's `trip()`
+                    // may have already sent the original `write_txn`/`commit` failure; `watch`
+                    // overwrites on `send`, so only set if still `None`.
+                    let _ = fatal_db_error.send_if_modified(|cur| {
+                        if cur.is_none() {
+                            *cur = Some(format!("{e:?}"));
+                            true
+                        } else {
+                            false
+                        }
+                    });
                     return false;
                 }
                 warn!(target: "epoch-manager", "cold epoch archive failed: {e}");

--- a/crates/middleware/orchestrator/src/epoch_manager/core.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/core.rs
@@ -375,7 +375,10 @@ where
                 }
 
                 // A hot-tier write/durability failure (cold archival). Same ordered wind-down,
-                // surfaced as an error instead of a panic.
+                // surfaced as an error instead of a panic. `fatal_db_error` preserves the first
+                // (root-cause) signal via `send_if_modified` in both `db_run::trip` and
+                // `cold_archive::seal_due_epochs`, so `borrow()` is the original writer failure,
+                // not a secondary archival error.
                 _ = fatal_db_error.changed() => {
                     let msg = fatal_db_error.borrow().clone().unwrap_or_default();
                     error!(

--- a/crates/middleware/orchestrator/src/epoch_manager/core.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/core.rs
@@ -48,6 +48,10 @@ where
         rayls_datadir: P,
         passphrase: String,
         consensus_db: DB,
+        // Fired once if the consensus DB rejects a hot-tier write or its durability barrier (by
+        // the DB's own writer, or cold archival): the node winds down gracefully (keeping the
+        // durable state) instead of panicking.
+        fatal_db_error: watch::Sender<Option<String>>,
         #[cfg(feature = "cold-storage")] cold_archival: ColdArchival,
     ) -> eyre::Result<Self> {
         // create key config for lifetime of the app
@@ -78,6 +82,7 @@ where
             key_config,
             node_shutdown,
             sigterm_trigger: Notifier::new(),
+            fatal_db_error,
             reth_db,
             consensus_db,
             consensus_bus,
@@ -204,6 +209,7 @@ where
                 &node_task_manager,
                 self.consensus_bus.executed_anchor().subscribe(),
                 self.node_shutdown.clone(),
+                self.fatal_db_error.clone(),
             );
         }
 
@@ -332,6 +338,12 @@ where
         // strictly happen-before the close: the engine polls rx_shutdown before its input, so it
         // sees shutdown_requested=true and exits Ok. Cheap mpsc clone, held for run()'s lifetime.
         let engine_input_keepalive = to_engine.clone();
+        // A consensus-DB write error is fatal WITHOUT a panic: the durable state is the last
+        // known valid data, and the mem cache plus any uncommitted mdbx transaction are safe
+        // to lose. The select arm below requests the same ordered wind-down the crash path
+        // uses, then surfaces the error (non-zero exit) so a supervisor can restart and
+        // rebuild the cache.
+        let fatal_db_error = self.fatal_db_error.subscribe();
         let outcome = AssertUnwindSafe(async {
             let epochs = self.run_epochs(&engine, network_config, to_engine, gas_accumulator);
             tokio::pin!(epochs);
@@ -342,6 +354,9 @@ where
             // `node_shutdown` below.
             let node_join = node_task_manager.join(node_shutdown.clone());
             tokio::pin!(node_join);
+
+            let fatal_db_error = fatal_db_error;
+            tokio::pin!(fatal_db_error);
 
             tokio::select! {
                 // run_epochs returned on its own: a graceful loop break after sigterm_trigger
@@ -357,6 +372,19 @@ where
                         Ok(()) => epoch_result,
                         Err(e) => epoch_result.and(Err(eyre!("Node task shutdown: {e}"))),
                     }
+                }
+
+                // A hot-tier write/durability failure (cold archival). Same ordered wind-down,
+                // surfaced as an error instead of a panic.
+                _ = fatal_db_error.changed() => {
+                    let msg = fatal_db_error.borrow().clone().unwrap_or_default();
+                    error!(
+                        target: "epoch-manager",
+                        "consensus DB write error: {msg}"
+                    );
+                    sigterm_trigger.notify();
+                    let epoch_result = epochs.await;
+                    epoch_result.and(Err(eyre!("consensus DB write error: {msg}")))
                 }
             }
         })
@@ -391,6 +419,9 @@ where
 
         // Flush both layers, each under catch_unwind so a panic in one still runs the other.
         // Consensus goes first so a crash between them leaves consensus >= execution (replayable).
+        // A flush failure here is logged, not faulted: the process is exiting, so the layered
+        // cache's failed rows die with it (no unbounded pinning), and consensus >= execution
+        // replays the unflushed tail on restart.
         let consensus_flush = AssertUnwindSafe(self.consensus_db.persist()).catch_unwind().await;
         match consensus_flush {
             Ok(Ok(())) => info!(target: "engine", "shutdown consensus DB flush complete"),

--- a/crates/middleware/orchestrator/src/epoch_manager/types.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/types.rs
@@ -12,6 +12,7 @@ use rayls_execution_evm::reth_env::RethDb;
 use super::cold_archive::ColdArchival;
 use rayls_infrastructure_config::KeyConfig;
 use rayls_infrastructure_types::{EpochRecord, Notifier};
+use tokio::sync::watch;
 
 use crate::engine::RaylsBuilder;
 
@@ -49,6 +50,12 @@ pub(crate) struct EpochManager<P, DB> {
     /// directly (engine, network, vote collector), so the epoch teardown stays ordered.
     /// `node_shutdown` is fired only afterward, for the node-level drain + flush.
     pub(super) sigterm_trigger: Notifier,
+    /// One-shot channel for a consensus-DB write/durability error observed by the background
+    /// archival (a [`ColdError::WriteFailed`]). The node treats it as fatal: `run()` responds
+    /// with the graceful ordered shutdown (same as a node-task crash, but without a panic) and
+    /// exits non-zero, keeping the last known durable data. Losing the mem cache and any
+    /// uncommitted mdbx transaction is acceptable, so nothing is retried once this fires.
+    pub(super) fatal_db_error: watch::Sender<Option<String>>,
     /// Reth DB, keep for entire execution.
     pub(super) reth_db: RethDb,
     /// Consensus DB, keep for entire execution.

--- a/crates/middleware/orchestrator/src/epoch_manager/utils.rs
+++ b/crates/middleware/orchestrator/src/epoch_manager/utils.rs
@@ -13,6 +13,7 @@ use rayls_infrastructure_types::{
 #[cfg(not(feature = "dev-single-node-setup"))]
 use rayls_infrastructure_types::MIN_RAYLS_PROTOCOL_BASE_FEE;
 use std::collections::BTreeMap;
+use tokio::sync::watch;
 use tracing::info;
 
 /// Number of recent EVM blocks scanned to recover the restart execution anchor.
@@ -141,14 +142,23 @@ pub fn catchup_accumulator<DB: Database>(
 }
 
 /// Create a consensus DB that lives for program lifetime.
+///
+/// When `fatal_db_error` is provided it is wired into the DB: the background writer signals it
+/// with the stored error on the first fatal write failure, so the node winds down gracefully
+/// instead of continuing to write into a failing tier.
 pub(crate) fn open_consensus_db<P: RaylsDirs + 'static>(
     rayls_datadir: &P,
     consensus_db_config: &MdbxConfig,
+    fatal_db_error: Option<watch::Sender<Option<String>>>,
 ) -> eyre::Result<DatabaseType> {
     let consensus_db_path = rayls_datadir.consensus_db_path();
 
     let _ = std::fs::create_dir_all(&consensus_db_path);
     let db = open_db_with_consensus_config(&consensus_db_path, consensus_db_config);
+    let db = match fatal_db_error {
+        Some(signal) => db.with_fatal_signal(signal),
+        None => db,
+    };
 
     info!(target: "epoch-manager", ?consensus_db_path, "opened consensus storage");
 

--- a/crates/middleware/orchestrator/src/lib.rs
+++ b/crates/middleware/orchestrator/src/lib.rs
@@ -50,7 +50,12 @@ where
         .build()?;
 
     let res = runtime.block_on(async move {
-        let consensus_db = open_consensus_db(&rayls_datadir, &builder.consensus_db_config)?;
+        let (fatal_db_error, _fatal_db_error_rx) = tokio::sync::watch::channel(None);
+        let consensus_db = open_consensus_db(
+            &rayls_datadir,
+            &builder.consensus_db_config,
+            Some(fatal_db_error.clone()),
+        )?;
         // One aggregate owns cold archival end to end; inert on backends without a cold tier.
         #[cfg(feature = "cold-storage")]
         let cold_archival = epoch_manager::ColdArchival::new(&consensus_db);
@@ -59,6 +64,7 @@ where
             rayls_datadir,
             passphrase,
             consensus_db,
+            fatal_db_error,
             #[cfg(feature = "cold-storage")]
             cold_archival,
         )?;
@@ -113,7 +119,9 @@ where
         .build()?;
 
     let migrated = runtime.block_on(async {
-        let consensus_db = open_consensus_db(&rayls_datadir, &builder.consensus_db_config)?;
+        // No node is running, so there is no fatal-error channel to signal: a failed pass is the
+        // error returned here (fail-closed, nonzero exit).
+        let consensus_db = open_consensus_db(&rayls_datadir, &builder.consensus_db_config, None)?;
         let archival = epoch_manager::ColdArchival::new(&consensus_db);
         if !archival.is_active() {
             info!(target: "epoch-manager", "database stack has no cold tier; nothing to migrate");

--- a/crates/middleware/processor/tests/it/batch_ordering_restart.rs
+++ b/crates/middleware/processor/tests/it/batch_ordering_restart.rs
@@ -120,7 +120,7 @@ impl BatchOrderingHarness {
 
         self.execution_node = None;
         if let Some(store) = self.ordering_store.take() {
-            store.sync_persist();
+            store.sync_persist().expect("persist");
             drop(store);
         }
         tokio::task::yield_now().await;

--- a/crates/middleware/processor/tests/it/history_recovery.rs
+++ b/crates/middleware/processor/tests/it/history_recovery.rs
@@ -113,7 +113,7 @@ impl ConsensusHistoryFixture {
             })
             .expect("bulk write txn for scattered blocks");
         self.next_block_num = start_block_num + count;
-        self.db.sync_persist();
+        self.db.sync_persist().expect("persist");
         seqs
     }
 

--- a/crates/middleware/rewards/src/lib.rs
+++ b/crates/middleware/rewards/src/lib.rs
@@ -384,7 +384,7 @@ mod tests {
             Ok(())
         })
         .expect("seed");
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         let counter = ConsensusRewardsCounter::new(db.clone());
         counter.set_committee(committee);
@@ -396,7 +396,7 @@ mod tests {
         let archiver = cold_archiver_for(&db).expect("mdbx stack has a cold tier");
         assert_eq!(archiver.seal_due(1, || false).expect("seal"), SealOutcome::Sealed(0));
         assert_eq!(archiver.seal_due(1, || false).expect("drained"), SealOutcome::Drained);
-        db.sync_persist();
+        db.sync_persist().expect("persist");
 
         let after = counter.tally(1, 6).expect("post-archival tally");
         assert_eq!(after, before, "the closing epoch's tally must survive archival at the floor");


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

- Poison the consensus layered DB on first background writer failure (`write_txn`/`insert`/`remove`/`clear`/`commit`): latch `OnceLock<String>` in `QueueSender`, discard further `Insert`/`Remove`/`Clear` messages, reject `CaughtUp` barriers with the stored error, and signal the node via `watch::Sender<Option<String>>`. Producers fail fast via `poisoned_error` before touching `MemDatabase` (`crates/infrastructure/storage/src/layered_db.rs`, `crates/infrastructure/types/src/database_traits.rs`).
- Treat hot-tier durability failures as node-fatal `ColdError::WriteFailed` (not retriable `Corruption`) and propagate via `sync_persist().map_err(to_write_failed)?` (`crates/infrastructure/storage/src/cold/producer.rs`, `crates/infrastructure/storage/src/cold/mod.rs`). `ColdArchiver::seal_due` surfaces it as `WriteFailed`; `epoch_manager/cold_archive.rs` `seal_due_epochs` signals `fatal_db_error` and exits without retry cooldown.
- Wire the signal end-to-end: `open_consensus_db(..., Option<watch::Sender>)` + `LayeredDatabase::with_fatal_signal` (`crates/infrastructure/storage/src/layered_db.rs`, `crates/middleware/orchestrator/src/epoch_manager/utils.rs`), `EpochManager` stores `fatal_db_error` (`types.rs`/`core.rs:46,379`) and adds a `select!` arm that requests the same ordered wind-down as a node-task crash (`sigterm_trigger.notify()` → `controlled_shutdown` → engine drain → `consensus_db.persist()` flush) and exits non-zero. CLI `cold-migrate` remains fail-closed (`None`).

Closes #

## Surface areas touched

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [x] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. `Database::sync_persist` now returns `eyre::Result<()>` (was `()`); all in-tree callers updated to `expect`/`?` in tests. Wire is additive: DB starts unpoisoned, first failure latches poison; reads keep serving from `mem` + durable tier. Node now exits non-zero on hot-tier write failure instead of continuing into a failing tier (supervisor restart rebuilds `MemDatabase` from durable tier, uncommitted `mdbx` txn lost).

## Test plan

- [x] `cargo test -p rayls-infrastructure-storage --lib layered_db::test::{test_failed_write_is_surfaced_by_persist,test_failed_commit_is_surfaced_by_sync_persist,test_poisoned_db_fails_further_writes_fast,test_poisoned_writer_applies_nothing_further,test_fatal_signal_fires_on_writer_failure}` — MAP_FULL poison, fail-fast, barrier rejection, `watch` signal, post-poison discard.
- [x] `cargo test -p rayls-infrastructure-storage --lib cold::tests::{finalize::rejected_hot_tier_writes_surface_as_write_failed, seal::*, archive::*, reconcile::*}` — `ProbeDb::failing_writes` → `ColdError::WriteFailed`, cold-archive actor `write_failure_signals_fatal_shutdown_not_a_panic`.
- [x] `cargo test --workspace` (or at least `cargo test -p rayls-middleware-orchestrator --lib epoch_manager::cold_archive::tests`) — actor still joins cancelled `cold-seal` thread before DB teardown, retry cooldown not armed after `fatal_db_error`.
- [x] CI: `cargo fmt --check`, `cargo clippy -- -D warnings` green on push.
