### PR TITLE
chore: pin rust fmt nightly version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,10 +48,13 @@ jobs:
       # rustfmt.toml uses nightly-only options (wrap_comments, comment_width,
       # format_code_in_doc_comments, doc_comment_code_block_width), so the check
       # must run on nightly rustfmt — stable would silently ignore them.
+      # The nightly is date-pinned because unstable-option behavior drifts
+      # between nightlies (keep in sync with the Makefile fmt target and
+      # rustfmt.toml); bump the pin together with a reformat commit.
       - name: Install nightly rustfmt
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-06-24
           components: rustfmt
 
       # --check fails (non-zero exit) if any file is not formatted per rustfmt.toml

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,7 +59,7 @@ jobs:
 
       # --check fails (non-zero exit) if any file is not formatted per rustfmt.toml
       - name: Check formatting
-        run: cargo +nightly fmt --all --check
+        run: cargo +nightly-2026-06-24 fmt --all --check
 
   # ===========================================================================
   # TESTS - Rust workspace tests, across feature sets

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ BASE_DIR:=$(shell basename $(ROOT_DIR))
 # Default tag is latest if not specified
 TAG ?= latest
 
+# Date-pinned nightly for rustfmt — unstable-option behavior drifts between
+# nightlies, so fmt must match CI (.github/workflows/pr.yaml fmt job).
+# Install with: rustup toolchain install $(FMT_NIGHTLY) --profile minimal --component rustfmt
+FMT_NIGHTLY := nightly-2026-06-24
+
 help:
 	@echo ;
 	@echo "make attest" ;
@@ -33,7 +38,7 @@ help:
 	@echo "    :::> Test restart integration tests." ;
 	@echo ;
 	@echo "make fmt" ;
-	@echo "    :::> cargo +nightly fmt" ;
+	@echo "    :::> cargo +$(FMT_NIGHTLY) fmt (date-pinned to match the CI fmt check)" ;
 	@echo ;
 	@echo "make clippy" ;
 	@echo "    :::> Cargo +nightly clippy for all features with fix enabled." ;
@@ -86,9 +91,9 @@ test-faucet:
 test-restarts:
 	cargo test test_restarts -- --ignored ;
 
-# format using +nightly toolchain
+# format using the pinned nightly toolchain (same as the CI fmt check)
 fmt:
-	cargo +nightly fmt ;
+	cargo +$(FMT_NIGHTLY) fmt ;
 
 # clippy formatter + try to fix problems
 clippy:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cd axyl
 cargo build --release
 ```
 
-The toolchain is pinned to Rust 1.91 via [`rust-toolchain.toml`](./rust-toolchain.toml). `make pr` runs the same fmt + clippy + test gate as CI (fmt and clippy require a nightly toolchain); `make test` runs the test suite alone.
+The toolchain is pinned to Rust 1.91 via [`rust-toolchain.toml`](./rust-toolchain.toml). `make pr` runs the same fmt + clippy + test gate as CI (fmt and clippy require a nightly toolchain; fmt is date-pinned via the `FMT_NIGHTLY` variable in the [`Makefile`](./Makefile) to match the CI check); `make test` runs the test suite alone.
 
 Documentation lives in [`doc/`](doc/):
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,8 @@
+# This config uses nightly-only options whose behavior drifts between nightlies,
+# so formatting is pinned to nightly-2026-06-24 (see the Makefile FMT_NIGHTLY
+# variable and the fmt job in .github/workflows/pr.yaml). Bump all pins together
+# with a reformat commit.
+
 # Reorder imports alphabetically
 reorder_imports = true # stable
 # Merge imports into a single use statement.


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

- Pinned Rust nightly to a version

Closes #

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [X] CI / build (`.github/workflows/`, `Makefile`)
- [X] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

<!-- Does this require a node restart, a network upgrade, a hardfork activation block, a contract migration, a config change, or any client coordination? If yes, describe. If no, write "None". -->

None.

## Test plan

<!-- What did you do to convince yourself this works? Commands, scenarios, or links to CI output. -->

- [ ]
- [ ]
