### PR TITLE
feat: reduce lock on mem db eviction

### DIFF
--- a/crates/consensus/primary/src/state_sync/mod.rs
+++ b/crates/consensus/primary/src/state_sync/mod.rs
@@ -55,11 +55,14 @@ where
 
         // preserve round knowledge from CvvInactive to avoid TooOld after rejoin
         let current_round = *consensus_bus.primary_round_updates().borrow();
+        // seed the gc round from the primed channel (primed by identify_node_mode before this
+        // runs) so the cert parent-check gate never runs with gc=0 and suspends the history
+        let gc_round = *consensus_bus.gc_round_updates().borrow();
 
         let certificate_validator = CertificateValidator::new(
             config,
             consensus_bus,
-            AtomicRound::new(0),
+            AtomicRound::new(gc_round),
             AtomicRound::new(highest_process_round),
             AtomicRound::new(current_round),
             task_spawner,

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -786,7 +786,15 @@ fn log_persist_latency(elapsed: Duration, depth: usize) {
 /// the number of rows evicted, plus the open write transactions observed at that moment.
 /// Eviction only runs once no producer txn is open, so `open_txns` is normally 0 except at a
 /// `CaughtUp` barrier.
-fn evict_and_log(mem_db: &MemDatabase, heap: &mut EvictionHeap, max_size: usize, open_txns: usize) {
+fn evict_and_log(
+    mem_db: &MemDatabase,
+    heap: &mut EvictionHeap,
+    max_size: usize,
+    has_open_txn: bool,
+) {
+    if has_open_txn {
+        return;
+    }
     let EvictionStats { before, after, evicted, eviction_time } =
         mem_db.evict_if_needed(heap, max_size);
     if evicted > 0 {
@@ -796,7 +804,7 @@ fn evict_and_log(mem_db: &MemDatabase, heap: &mut EvictionHeap, max_size: usize,
             after,
             evicted,
             eviction_time = ?eviction_time,
-            open_txns,
+            has_open_txn,
             "mem cache evicted"
         );
     }

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -783,9 +783,9 @@ fn log_persist_latency(elapsed: Duration, depth: usize) {
 }
 
 /// Runs one eviction pass and logs its outcome at `info`: the cache size before and after and
-/// the number of rows evicted, plus the open write transactions observed at that moment.
-/// Eviction only runs once no producer txn is open, so `open_txns` is normally 0 except at a
-/// `CaughtUp` barrier.
+/// the number of rows evicted, plus whether a write transaction was open at that moment.
+/// Eviction runs only when the writer owns no write txn: while a txn is open, its producer holds
+/// the mem write lock, so the writer must not try to take that lock from the background thread.
 fn evict_and_log(
     mem_db: &MemDatabase,
     heap: &mut EvictionHeap,

--- a/crates/infrastructure/storage/src/layered_db.rs
+++ b/crates/infrastructure/storage/src/layered_db.rs
@@ -783,26 +783,20 @@ fn log_persist_latency(elapsed: Duration, depth: usize) {
 }
 
 /// Runs one eviction pass and logs its outcome at `info`: the cache size before and after and
-/// the number of rows evicted, plus whether a write transaction was open at that moment.
-/// Eviction runs only when the writer owns no write txn: while a txn is open, its producer holds
-/// the mem write lock, so the writer must not try to take that lock from the background thread.
-fn evict_and_log(
-    mem_db: &MemDatabase,
-    heap: &mut EvictionHeap,
-    max_size: usize,
-    has_open_txn: bool,
-) {
-    if has_open_txn {
-        return;
-    }
-    let EvictionStats { before, after, evicted } = mem_db.evict_if_needed(heap, max_size);
+/// the number of rows evicted, plus the open write transactions observed at that moment.
+/// Eviction only runs once no producer txn is open, so `open_txns` is normally 0 except at a
+/// `CaughtUp` barrier.
+fn evict_and_log(mem_db: &MemDatabase, heap: &mut EvictionHeap, max_size: usize, open_txns: usize) {
+    let EvictionStats { before, after, evicted, eviction_time } =
+        mem_db.evict_if_needed(heap, max_size);
     if evicted > 0 {
         tracing::debug!(
             target: "storage",
             before,
             after,
             evicted,
-            has_open_txn,
+            eviction_time = ?eviction_time,
+            open_txns,
             "mem cache evicted"
         );
     }
@@ -2194,7 +2188,11 @@ mod test {
     }
 
     /// Insert a burst of keys into a tiny cache and confirm the writer evicts settled keys in
-    /// recency order until the cache fits `max_size`, with the newest rows surviving in mem.
+    /// recency order: after the burst the cache is at or below `max_size`, holds only the newest
+    /// keys (strictly LRU, since keys were inserted in order), and every key stays readable
+    /// through the persistent tier. The exact survivor count depends on how far the producer ran
+    /// ahead of the writer (a pass can evict no faster than ops settle into the heap), so the
+    /// assertions pin the invariants, not a specific size.
     #[test]
     fn eviction_keeps_cache_at_max_size_and_evicts_oldest_settled() {
         let inner = MemDatabase::new();
@@ -2207,8 +2205,8 @@ mod test {
         }
         db.sync_persist().expect("persist");
 
-        assert_eq!(db.mem_db.mem_size(), 3, "cache must be trimmed to max_size");
-        // The newest rows survive hot; older ones fall through to the persistent tier.
+        assert!(db.mem_db.mem_size() <= 3, "cache must be trimmed to max_size after the burst");
+        // Older rows fall through to the persistent tier; every key stays readable.
         for i in 0..10u64 {
             assert_eq!(
                 db.get::<TestTable>(&i).unwrap().as_deref(),
@@ -2216,18 +2214,20 @@ mod test {
                 "every key must still be readable after eviction"
             );
         }
-        for i in 7..10u64 {
+        // Eviction is strictly LRU (keys were inserted in order): the hot set is a suffix —
+        // no older key may be hot while a newer key was evicted.
+        let mut seen_evicted = false;
+        for i in (0..10u64).rev() {
+            let hot = db.mem_db.contains_key::<TestTable>(&i).unwrap();
             assert!(
-                db.mem_db.contains_key::<TestTable>(&i).unwrap(),
-                "newest key {i} must stay hot"
+                !hot || !seen_evicted,
+                "key {i} hot although a newer key was evicted: LRU violated"
             );
+            if !hot {
+                seen_evicted = true;
+            }
         }
-        for i in 0..7u64 {
-            assert!(
-                !db.mem_db.contains_key::<TestTable>(&i).unwrap(),
-                "settled key {i} must be evicted"
-            );
-        }
+        assert!(db.mem_db.contains_key::<TestTable>(&9).unwrap(), "the newest key must stay hot");
     }
 
     /// A tombstone whose remove is still queued must not be evicted, even when the cache is over
@@ -2318,40 +2318,10 @@ mod test {
         assert_eq!(db.get::<TestTable>(&2).unwrap(), None);
         assert_eq!(db.get::<TestTable>(&3).unwrap(), None);
         assert_eq!(db.get::<TestTable>(&4).unwrap(), Some("four".to_string()));
-        assert_eq!(db.mem_db.mem_size(), 2, "cleared tombstones settle and are evicted");
-    }
-
-    /// Reading a hot key refreshes its recency (lock-free, throttled), so it survives eviction over
-    /// a sibling that settled at the same time but was never read since.
-    #[test]
-    fn read_recency_protects_a_hot_key() {
-        let inner = MemDatabase::new();
-        inner.open_table::<TestTable>().expect("open inner table");
-        let db = LayeredDatabase::open_with_config(inner, CacheConfig { max_size: 2 });
-        db.open_table::<TestTable>().expect("open layered table");
-
-        for i in 1..=3u64 {
-            db.insert::<TestTable>(&i, &format!("v{i}")).expect("insert");
-        }
-        db.sync_persist().expect("persist");
-        // 1 settled first and was evicted; 2 and 3 are hot.
-        assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap());
-        assert!(db.mem_db.contains_key::<TestTable>(&3).unwrap());
-
-        // Cross the recency throttle window, then read key 2: its clock bumps.
-        std::thread::sleep(std::time::Duration::from_millis(150));
-        assert_eq!(db.get::<TestTable>(&2).unwrap(), Some("v2".to_string()));
-
-        // Overflow the cache: without the read bump, key 2 (settled first) would be evicted.
-        db.insert::<TestTable>(&4, &"v4".to_string()).expect("insert");
-        db.sync_persist().expect("persist");
-
-        assert_eq!(db.mem_db.mem_size(), 2);
-        assert!(db.mem_db.contains_key::<TestTable>(&2).unwrap(), "read key must stay hot");
-        assert!(db.mem_db.contains_key::<TestTable>(&4).unwrap(), "newest key must stay hot");
-        assert!(
-            !db.mem_db.contains_key::<TestTable>(&3).unwrap(),
-            "unread sibling must be evicted"
+        assert_eq!(
+            db.mem_db.mem_size(),
+            1,
+            "cleared tombstones settle and are evicted down to the target"
         );
     }
 

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -487,7 +487,7 @@ impl MemDatabase {
     /// producers never touch it. Every pop removes one entry, so the loop always terminates.
     ///
     /// Fast path: rows are pushed to the heap exactly when their in-flight count settles to zero
-    /// and entries leave it only through this pass's pops, so `heap.len()` is a lower bound on
+    /// and entries leave it only through this pass's pops, so `heap.len()` is a upper bound on
     /// the settled (evictable) rows. When it is below `max_size / 2` the pass could evict at most
     /// that many rows, so the exclusive store lock is skipped entirely: the writer runs a pass
     /// after every applied op and the heap grows by one per settled op, so any skipped eviction
@@ -498,8 +498,8 @@ impl MemDatabase {
         if heap.len() < max_size >> 1 {
             return EvictionStats::default();
         }
-        let mut store = self.store.write();
         let start = Instant::now();
+        let mut store = self.store.write();
         let mut total: usize = store.values().map(|table| table.rows.len()).sum();
         if total <= max_size {
             return EvictionStats {

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -116,7 +116,7 @@ impl StoreEntry {
 pub(crate) type EvictionHeap = BinaryHeap<Reverse<(u64, &'static str, Vec<u8>)>>;
 
 /// Outcome of one eviction pass, for the layered writer's cache-pressure logs.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct EvictionStats {
     /// Total cached rows (live and tombstoned) when the pass started.
     pub before: usize,
@@ -124,6 +124,8 @@ pub struct EvictionStats {
     pub after: usize,
     /// Rows removed during the pass.
     pub evicted: usize,
+    /// Duration of the eviction pass.
+    pub eviction_time: Duration,
 }
 
 /// One cached table: the rows plus a flag set while the producer's clear is queued but not yet
@@ -477,19 +479,39 @@ impl MemDatabase {
         }
     }
 
-    /// Evicts settled keys (in-flight == 0) in recency order until the cache fits `max_size`.
+    /// Evicts settled keys (in-flight == 0) in recency order until the cache is at or below
+    /// `max_size / 8`, the trim target (see the relaxed bound in the fast path below).
     /// Candidates are validated at pop: a key re-inserted since its settle, or a row cleared
     /// away, is skipped. A key whose recency was refreshed by a read since it settled is
     /// re-pushed with the fresh clock so hot keys survive eviction. The heap stays writer-owned;
     /// producers never touch it. Every pop removes one entry, so the loop always terminates.
+    ///
+    /// Fast path: rows are pushed to the heap exactly when their in-flight count settles to zero
+    /// and entries leave it only through this pass's pops, so `heap.len()` is a lower bound on
+    /// the settled (evictable) rows. When it is below `max_size / 2` the pass could evict at most
+    /// that many rows, so the exclusive store lock is skipped entirely: the writer runs a pass
+    /// after every applied op and the heap grows by one per settled op, so any skipped eviction
+    /// is picked up on the next pass. The cache may therefore transiently exceed `max_size` by
+    /// less than `max_size / 2` settled rows while a writer backlog drains; in-flight rows are
+    /// never evictable, so this is a bounded relaxation of the cap, not a correctness issue.
     pub fn evict_if_needed(&self, heap: &mut EvictionHeap, max_size: usize) -> EvictionStats {
+        if heap.len() < max_size >> 1 {
+            return EvictionStats::default();
+        }
         let mut store = self.store.write();
+        let start = Instant::now();
         let mut total: usize = store.values().map(|table| table.rows.len()).sum();
         if total <= max_size {
-            return EvictionStats { before: total, after: total, evicted: 0 };
+            return EvictionStats {
+                before: total,
+                after: total,
+                evicted: 0,
+                eviction_time: start.elapsed(),
+            };
         }
+        let evict_until = max_size >> 3;
         let mut evicted = 0usize;
-        while total > max_size {
+        while total > evict_until {
             let Some(Reverse((heap_last_used, table, key))) = heap.pop() else { break };
             let Some(table_map) = store.get_mut(table) else { continue };
             let Some(entry) = table_map.rows.get(&key) else { continue };
@@ -508,11 +530,17 @@ impl MemDatabase {
             total -= 1;
             evicted += 1;
         }
-        EvictionStats { before: total + evicted, after: total, evicted }
+        EvictionStats {
+            before: total + evicted,
+            after: total,
+            evicted,
+            eviction_time: start.elapsed(),
+        }
     }
 
-    /// Total rows (live and tombstoned) held in the cache; the writer keeps this at or below the
-    /// configured max size.
+    /// Total rows (live and tombstoned) held in the cache; the writer trims it toward
+    /// `max_size / 8` on each pass, keeping it near the configured max size (see the relaxed
+    /// bound in [`MemDatabase::evict_if_needed`]).
     pub fn mem_size(&self) -> usize {
         self.store.read().values().map(|table| table.rows.len()).sum()
     }
@@ -902,9 +930,12 @@ fn record_prior_to_impl<T: Table>(store: &StoreType, key: &T::Key) -> Option<(T:
 
 #[cfg(test)]
 mod test {
-    use rayls_infrastructure_types::{Database, DbTx, DbTxMut};
+    use rayls_infrastructure_types::{encode_key, Database, DbTx, DbTxMut, Table};
 
-    use crate::{mem_db::MemDatabase, test::*};
+    use crate::{
+        mem_db::{EvictionHeap, EvictionStats, MemDatabase},
+        test::*,
+    };
 
     fn open_db() -> MemDatabase {
         let db = MemDatabase::new();
@@ -1226,6 +1257,80 @@ mod test {
             val_after_commit.unwrap(),
             "fifty".to_string(),
             "Value for key 50 should match reinserted value after commit"
+        );
+    }
+
+    /// The eviction fast path must skip the pass while fewer than `max_size / 2` rows are
+    /// settled — even when the cache is over its cap — and the next pass, once enough ops have
+    /// settled, trims the cache to the target.
+    #[test]
+    fn evict_fast_path_skips_when_few_settled_rows() {
+        let db = open_db();
+        let mut heap = EvictionHeap::new();
+        const MAX: usize = 10;
+
+        let mut txn = db.write_txn().unwrap();
+        for i in 0..12u64 {
+            txn.insert::<TestTable>(&i, &i.to_string()).expect("Failed to insert");
+        }
+        drop(txn);
+        assert_eq!(db.mem_size(), 12, "all rows must be cached, in flight");
+
+        // Settle two rows: heap.len() == 2 < MAX / 2, while the cache (12) exceeds MAX (10).
+        db.on_op_applied(TestTable::NAME, &encode_key(&0u64), &mut heap);
+        db.on_op_applied(TestTable::NAME, &encode_key(&1u64), &mut heap);
+
+        let stats = db.evict_if_needed(&mut heap, MAX);
+        assert_eq!(stats, EvictionStats::default(), "fast path must skip the pass");
+        assert_eq!(db.mem_size(), 12, "no row may be evicted on the fast path");
+
+        // Settle the rest: the heap now exceeds MAX / 2, so the pass runs and trims to MAX / 8.
+        for i in 2..12u64 {
+            db.on_op_applied(TestTable::NAME, &encode_key(&i), &mut heap);
+        }
+        let stats = db.evict_if_needed(&mut heap, MAX);
+        assert!(stats.evicted > 0, "the pass must run once enough rows have settled");
+        assert_eq!(db.mem_size(), MAX >> 3, "the cache must be trimmed to the eviction target");
+    }
+
+    /// Reading a hot key across the recency throttle window refreshes its clock, so an
+    /// eviction pass reorders candidates by recency: the stale heap entry is re-pushed with
+    /// the fresh clock and the unread settled siblings are evicted first, so the read key
+    /// survives down to the target with the newest row.
+    #[test]
+    fn read_recency_protects_a_hot_key() {
+        let db = open_db();
+        let mut heap = EvictionHeap::new();
+        const MAX: usize = 16; // eviction target MAX / 8 = 2
+
+        let mut txn = db.write_txn().unwrap();
+        for i in 1..=17u64 {
+            txn.insert::<TestTable>(&i, &i.to_string()).expect("Failed to insert");
+        }
+        drop(txn);
+        for i in 1..=17u64 {
+            db.on_op_applied(TestTable::NAME, &encode_key(&i), &mut heap);
+        }
+
+        // Cross the recency throttle window, then read key 9: its clock bumps past every
+        // other settle clock.
+        std::thread::sleep(std::time::Duration::from_millis(150));
+        assert_eq!(db.get::<TestTable>(&9).unwrap(), Some("9".to_string()));
+
+        // Overflow the cap (17 > 16): the pass evicts in recency order down to the target.
+        let stats = db.evict_if_needed(&mut heap, MAX);
+        assert!(stats.evicted > 0, "the pass must evict the overflow");
+        assert_eq!(db.mem_size(), 2, "the cache must be trimmed to the target");
+        assert!(db.contains_key::<TestTable>(&9).unwrap(), "read key must stay hot");
+        assert!(db.contains_key::<TestTable>(&17).unwrap(), "newest key must stay hot");
+        assert!(!db.contains_key::<TestTable>(&1).unwrap(), "oldest sibling must be evicted");
+        assert!(
+            !db.contains_key::<TestTable>(&8).unwrap(),
+            "unread sibling below the read key must be evicted"
+        );
+        assert!(
+            !db.contains_key::<TestTable>(&16).unwrap(),
+            "unread sibling above the read key must be evicted"
         );
     }
 }

--- a/crates/infrastructure/storage/src/mem_db.rs
+++ b/crates/infrastructure/storage/src/mem_db.rs
@@ -487,7 +487,7 @@ impl MemDatabase {
     /// producers never touch it. Every pop removes one entry, so the loop always terminates.
     ///
     /// Fast path: rows are pushed to the heap exactly when their in-flight count settles to zero
-    /// and entries leave it only through this pass's pops, so `heap.len()` is a upper bound on
+    /// and entries leave it only through this pass's pops, so `heap.len()` is an upper bound on
     /// the settled (evictable) rows. When it is below `max_size / 2` the pass could evict at most
     /// that many rows, so the exclusive store lock is skipped entirely: the writer runs a pass
     /// after every applied op and the heap grows by one per settled op, so any skipped eviction


### PR DESCRIPTION
## Summary

- Reduce lock contention on the mem-DB eviction path (`crates/infrastructure/storage`): `MemDatabase::evict_if_needed` now has a lock-free fast path that skips the pass — and the exclusive store write lock with it — entirely while the eviction heap holds fewer than `max_size / 2` settled rows, so a skipped eviction is simply picked up on the writer's next pass.
- When a pass does run, it now trims the cache down to `max_size / 8` (a trim target) instead of stopping exactly at `max_size`, batching evictions so fewer passes are needed; `EvictionStats` gains an `eviction_time` field that the layered writer logs for cache-pressure observability.
- In primary state-sync, seed the certificate validator's GC round from the primed `gc_round_updates` channel (set before state-sync runs) instead of hard-coding `0`, so the certificate parent-check gate never runs with `gc=0` and suspends history.

Closes #

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

None. No node restart, network upgrade, hardfork, contract migration, config change, or client coordination is required.

Note: the mem cache cap is now a *soft* bound rather than a hard one. While a writer backlog drains, the cache may transiently exceed `max_size` by less than `max_size / 2` settled rows before the next pass trims it. In-flight rows are never evictable, so this is a bounded relaxation of the cap, not a correctness change; every key remains readable through the persistent tier.

## Test plan

- [x] `cargo fmt --check` — clean on the changed crates.
- [x] `cargo clippy -p rayls-infrastructure-storage -p rayls-consensus-primary --all-targets` — no new warnings from the changed files (remaining warnings are pre-existing in unrelated files).
- [x] `cargo test -p rayls-infrastructure-storage` — 150 passed, 0 failed, 2 ignored. Covers the new fast-path test (`evict_fast_path_skips_when_few_settled_rows`), the relocated/rewritten recency test (`read_recency_protects_a_hot_key`), and updated LRU assertions in `layered_db` (hot set is a suffix, cache ≤ `max_size`, all keys readable post-eviction).
- [x] `cargo test -p rayls-consensus-primary` — 105 + 17 passed, 0 failed, 1 ignored. State-sync suites (`state_sync::cert_flow`, `state_sync::cert_validator`) pass with the GC round now seeded from the channel.
