### PR TITLE
fix: don't seal ahead until the epoch's first batch has executed

### DIFF
--- a/crates/consensus/worker/src/batch-builder/src/lib.rs
+++ b/crates/consensus/worker/src/batch-builder/src/lib.rs
@@ -48,7 +48,9 @@ const IN_FLIGHT_TTL: Duration = Duration::from_secs(60);
 
 /// The most batches the builder may seal ahead of its own execution watermark while the epoch is
 /// active. Keeps the in-flight prefix within the per-authority parking budget, so a lagging batch
-/// cannot strand its successors.
+/// cannot strand its successors. Collapses to one batch until the epoch's first batch has executed
+/// (so a head whose header is rejected at a lagged boundary leaves no tail to execute out of
+/// order) and again within the quiesce window before the boundary; see `check_build_budget`.
 pub const MAX_SEAL_AHEAD: u64 = 4;
 const _: () = assert!(MAX_SEAL_AHEAD * 4 <= MAX_PARKED_PER_AUTHORITY as u64);
 
@@ -285,7 +287,17 @@ impl BatchBuilder {
         match pipeline {
             PipelineState::Clean(clean) => PipelineState::Clean(clean),
             PipelineState::Accumulating(acc) => {
-                if acc.can_start_build(executed_seq, self.config.epoch_boundary).is_err() {
+                if let Err(reason) = acc.can_start_build(executed_seq, self.config.epoch_boundary) {
+                    // Debug, not info: the gate is re-checked on every tick and candidate event
+                    // while it refuses. The reason tells the epoch-start throttle and a full
+                    // budget apart from an unexplained stall.
+                    debug!(
+                        target: "worker::batch_builder",
+                        ?reason,
+                        seq,
+                        executed_seq,
+                        "accumulating: seal-ahead gate refused to start a build"
+                    );
                     return PipelineState::Accumulating(acc);
                 }
                 interval.reset();
@@ -293,7 +305,16 @@ impl BatchBuilder {
                 PipelineState::AwaitingQuorum(acc.start_building(rx))
             }
             PipelineState::BacklogDraining(backlog) => {
-                if backlog.can_start_build(executed_seq, self.config.epoch_boundary).is_err() {
+                if let Err(reason) =
+                    backlog.can_start_build(executed_seq, self.config.epoch_boundary)
+                {
+                    debug!(
+                        target: "worker::batch_builder",
+                        ?reason,
+                        seq,
+                        executed_seq,
+                        "backlog draining: seal-ahead gate refused to start a build"
+                    );
                     return PipelineState::BacklogDraining(backlog);
                 }
                 interval.reset();

--- a/crates/consensus/worker/src/batch-builder/src/pipeline.rs
+++ b/crates/consensus/worker/src/batch-builder/src/pipeline.rs
@@ -97,6 +97,10 @@ pub enum GateRejectionReason {
     EpochBoundaryReached,
     /// The seal-ahead budget is already full; wait for execution to catch up.
     BudgetExhausted,
+    /// The builder's first batch of this epoch has not executed yet, so only that one batch may be
+    /// outstanding: sealing ahead of an unexecuted head is what lets a tail execute out of order
+    /// when the head's header is rejected at a lagged boundary.
+    EpochStartThrottled,
 }
 
 /// The resolution of a spawned build-and-seal task.
@@ -436,7 +440,19 @@ impl PipelineState {
     }
 }
 
-/// Refuses a build past the boundary or once the phase's seal-ahead budget is full.
+/// Refuses a build past the boundary, once the phase's seal-ahead budget is full, or while the
+/// epoch's first batch is still unexecuted.
+///
+/// The epoch-start rule: until execution has reached `start_seq` (this builder's first seq of the
+/// epoch), at most one batch may be outstanding. Execution forgets every authority's seq frame at
+/// the boundary and accepts whatever batch an authority commits first in the new epoch. If this
+/// builder has sealed ahead and its head batch's header is rejected as wrong-epoch - this node
+/// lagged the boundary - a seal-ahead tail commits first, is accepted in the head's place, and
+/// every one of its txs drops nonce-too-high; the head lands later, the dropped txs re-seal after
+/// their in-flight TTL, and the epoch's early sealing is wasted for minutes. With nothing sealed
+/// ahead of the head there is no tail to reorder. The cost is one commit round-trip of builder
+/// idle time per epoch (and per mid-epoch restart, since `start_seq` resumes at `executed + 1`).
+/// Local pacing only, nothing replicated, so it needs no activation.
 #[inline]
 fn check_build_budget(
     data: &PipelineData,
@@ -453,6 +469,12 @@ fn check_build_budget(
         data.start_seq,
         own_executed_seq,
     );
+
+    let first_of_epoch_executed =
+        own_executed_seq.is_some_and(|executed| executed >= data.start_seq);
+    if !first_of_epoch_executed && in_flight >= 1 {
+        return Err(GateRejectionReason::EpochStartThrottled);
+    }
 
     if in_flight >= phase.max_allowed_ahead() {
         return Err(GateRejectionReason::BudgetExhausted);

--- a/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/build_batches.rs
@@ -608,8 +608,11 @@ async fn test_canonical_notification_updates_pool() {
     assert!(pending.iter().all(|tx| txpool.is_in_flight(tx.hash())));
 }
 
-/// The builder seals up to `MAX_SEAL_AHEAD` batches ahead of its own execution watermark, then
-/// stalls until execution advances, so a lagging proposer cannot outrun the parking budget.
+/// The builder seals its first batch of the epoch and then nothing more until that batch has
+/// executed (the epoch-start throttle, so a head rejected at a lagged boundary leaves no tail to
+/// execute out of order); once it has, the builder seals up to `MAX_SEAL_AHEAD` batches ahead of
+/// its own execution watermark and stalls until execution advances, so a lagging proposer cannot
+/// outrun the parking budget.
 #[tokio::test]
 async fn builder_stalls_at_the_seal_ahead_budget_until_the_watermark_advances() {
     let genesis = test_genesis();
@@ -628,7 +631,9 @@ async fn builder_stalls_at_the_seal_ahead_budget_until_the_watermark_advances() 
     // sequence by exactly one, making the budget observable batch by batch.
     let per_tx_gas = 30_000;
     let mut tx_factory = TransactionFactory::new();
-    for _ in 0..5 {
+    // Six: the head (seq 10), MAX_SEAL_AHEAD ahead of it once it executes (11..=14), and one
+    // more for the slot a further watermark advance reopens (15).
+    for _ in 0..6 {
         let tx = tx_factory.create_eip1559(
             chain.clone(),
             Some(per_tx_gas),
@@ -639,7 +644,7 @@ async fn builder_stalls_at_the_seal_ahead_budget_until_the_watermark_advances() 
         );
         let _ = tx_factory.submit_tx_to_pool(tx, txpool.clone()).await;
     }
-    assert_eq!(txpool.pool_size().pending, 5);
+    assert_eq!(txpool.pool_size().pending, 6);
 
     let (to_worker, mut from_batch_builder) = tokio::sync::mpsc::channel(2);
     // Resume at seq 10 with execution reported through seq 9, so the seal-ahead budget starts
@@ -664,13 +669,30 @@ async fn builder_stalls_at_the_seal_ahead_budget_until_the_watermark_advances() 
     );
     let _builder = tokio::spawn(batch_builder.run());
 
-    // The builder seals exactly MAX_SEAL_AHEAD batches while execution stays at seq 9.
-    for _ in 0..rayls_batch_builder::MAX_SEAL_AHEAD {
-        let (_batch, _sender_nonce_ranges, ack) =
+    // Epoch-start throttle: the head (seq 10) seals, then nothing more while execution is still
+    // at 9 - the Active budget of MAX_SEAL_AHEAD does not apply until the head has executed.
+    let (head, _sender_nonce_ranges, ack) =
+        timeout(Duration::from_secs(5), from_batch_builder.recv())
+            .await
+            .expect("the epoch's head batch seals")
+            .expect("batch channel open");
+    assert_eq!(head.batch.seq, 10);
+    let _ = ack.send(Ok(()));
+    assert!(
+        timeout(Duration::from_millis(500), from_batch_builder.recv()).await.is_err(),
+        "builder must not seal ahead of an unexecuted epoch head"
+    );
+
+    // The head executes: the throttle lifts and the builder seals exactly MAX_SEAL_AHEAD batches
+    // ahead of execution (11..=14).
+    wm_tx.send(Some(10)).unwrap();
+    for expected_seq in 11..=(10 + rayls_batch_builder::MAX_SEAL_AHEAD) {
+        let (batch, _sender_nonce_ranges, ack) =
             timeout(Duration::from_secs(5), from_batch_builder.recv())
                 .await
                 .expect("batch sealed ahead of execution")
                 .expect("batch channel open");
+        assert_eq!(batch.batch.seq, expected_seq);
         let _ = ack.send(Ok(()));
     }
 
@@ -681,12 +703,13 @@ async fn builder_stalls_at_the_seal_ahead_budget_until_the_watermark_advances() 
     );
 
     // Execution advances one sequence, reopening exactly one slot in the budget.
-    wm_tx.send(Some(10)).unwrap();
-    let (_batch, _sender_nonce_ranges, ack) =
+    wm_tx.send(Some(11)).unwrap();
+    let (next, _sender_nonce_ranges, ack) =
         timeout(Duration::from_secs(5), from_batch_builder.recv())
             .await
             .expect("watermark advance unblocks the next batch")
             .expect("batch channel open");
+    assert_eq!(next.batch.seq, 15);
     let _ = ack.send(Ok(()));
 }
 

--- a/crates/consensus/worker/src/batch-builder/tests/it/pipeline_typestate.rs
+++ b/crates/consensus/worker/src/batch-builder/tests/it/pipeline_typestate.rs
@@ -68,6 +68,67 @@ fn can_start_build_refuses_past_the_boundary() {
 }
 
 #[test]
+fn can_start_build_throttles_to_one_batch_until_the_epochs_first_batch_executes() {
+    // The lagged-boundary reorder needs a seal-ahead tail to exist while the head is still
+    // unexecuted. Resume at seq 10 with execution reported through 9 (the previous epoch's last):
+    // the head (10) may seal, but nothing may seal ahead of it until execution reaches it.
+    let far_boundary = u64::MAX;
+
+    // nothing sealed yet: the head itself may start
+    let fresh = BatchPipeline::<Clean>::new(None, 10, 0).on_event();
+    assert_eq!(fresh.can_start_build(Some(9), far_boundary), Ok(()));
+
+    // head sealed (depth 1), execution still at 9: throttled, even though the Active budget is 4
+    let head_out = BatchPipeline::<Clean>::new(Some(10), 10, 0).on_event();
+    assert_eq!(
+        head_out.can_start_build(Some(9), far_boundary),
+        Err(GateRejectionReason::EpochStartThrottled)
+    );
+    // no watermark at all (genesis) is the same: the floor is start_seq - 1, still unexecuted
+    assert_eq!(
+        head_out.can_start_build(None, far_boundary),
+        Err(GateRejectionReason::EpochStartThrottled)
+    );
+
+    // the head executed: the throttle lifts and the ordinary budget applies again
+    assert_eq!(head_out.can_start_build(Some(10), far_boundary), Ok(()));
+    // three ahead of the executed head is under the Active budget of four
+    let three_ahead = BatchPipeline::<Clean>::new(Some(13), 10, 0).on_event();
+    assert_eq!(three_ahead.can_start_build(Some(10), far_boundary), Ok(()));
+    // four ahead fills it, and the reason is now the budget, not the throttle
+    let four_ahead = BatchPipeline::<Clean>::new(Some(14), 10, 0).on_event();
+    assert_eq!(
+        four_ahead.can_start_build(Some(10), far_boundary),
+        Err(GateRejectionReason::BudgetExhausted)
+    );
+}
+
+#[test]
+fn epoch_start_throttle_yields_to_the_boundary_and_quiesce_rules() {
+    // Closed still wins over everything; Quiescing's budget of one coincides with the throttle, so
+    // the reason reported is the throttle's while the head is unexecuted and the budget's after.
+    let boundary = 100;
+    let quiescing_tip = boundary - BOUNDARY_QUIESCE_WINDOW_SECS;
+
+    let at_boundary = BatchPipeline::<Clean>::new(Some(10), 10, boundary).on_event();
+    assert_eq!(
+        at_boundary.can_start_build(Some(9), boundary),
+        Err(GateRejectionReason::EpochBoundaryReached)
+    );
+
+    let quiescing = BatchPipeline::<Clean>::new(Some(10), 10, quiescing_tip).on_event();
+    assert_eq!(
+        quiescing.can_start_build(Some(9), boundary),
+        Err(GateRejectionReason::EpochStartThrottled)
+    );
+    let quiescing_ahead = BatchPipeline::<Clean>::new(Some(11), 10, quiescing_tip).on_event();
+    assert_eq!(
+        quiescing_ahead.can_start_build(Some(10), boundary),
+        Err(GateRejectionReason::BudgetExhausted)
+    );
+}
+
+#[test]
 fn clean_closes_when_the_tip_reaches_the_boundary() {
     let boundary = 100;
     let below = BatchPipeline::<Clean>::new(None, 1, boundary - 1);


### PR DESCRIPTION
## The problem

A validator that lags an epoch boundary re-sealed the same ~14k transactions
every epoch, all of them dropped nonce-too-high, blocks executed with
`txs: 0`, and its pending pool sat at ~25k until a manual replacement tx
was sent for each affected sender. Recovery was intermittent: the stall
cleared on a clean boundary and recurred on the next lagged one (55
`peer rejected header as wrong epoch` events in a few hours).

Execution orders each authority's batches by seq (`last + 1`, park
otherwise), but forgets every authority's frame at the epoch boundary and
accepts whatever batch an authority commits first in the new epoch. The
batch builder meanwhile seals up to `MAX_SEAL_AHEAD` batches ahead of its
own execution watermark from the first second of the epoch. Combine the
two at a lagged boundary:

1. the builder seals A (the head) and immediately B, C, D behind it;
2. A's header is rejected as wrong-epoch and requeued;
3. B's header is accepted first, B reaches execution first, and with the
   frame reset it is accepted in A's place;
4. B's first tx is thousands of nonces above the sender's state, so every
   tx in B (and then C and D) drops nonce-too-high;
5. A lands later; the dropped txs stay pooled, re-seal after the in-flight
   TTL, and the epoch's early sealing is wasted for minutes.

Observed on validator-3 as `stale-seq batch` / `parking out-of-order`
right after each boundary, followed by `tx_dropped_nonce_too_high` with
`report.nonce_too_low=0` and a 23k nonce gap.

## What's changed

- `check_build_budget` gains one rule: until execution has reached the
  builder's first seq of the epoch (`own_executed_seq >= start_seq`), at
  most one batch may be outstanding. Once the head executes, the ordinary
  `Active`/`Quiescing` budget applies unchanged. A rejected head header
  therefore leaves no seal-ahead tail to execute out of order. New
  `GateRejectionReason::EpochStartThrottled` distinguishes it from
  `BudgetExhausted`.
- This mirrors the existing quiesce rule at the epoch end: both collapse
  the budget to one batch while batch order cannot be trusted.
- Local pacing only: it changes when this validator proposes, not how any
  node executes a committed output, so no activation is needed and a single
  node can run it.
- Cost: one commit round-trip of builder idle time per epoch (and per
  mid-epoch restart, since `start_seq` resumes at `executed + 1`); under
  full saturation ≤ ~0.3% of network TPS, otherwise none.
- Tests: two typestate tests (throttle holds at depth 1 with the head
  unexecuted, lifts exactly at `start_seq`, yields to the boundary and
  quiesce rules); the end-to-end seal-ahead test rewritten to the new
  contract and asserting seqs (head 10 → stall → watermark 10 → 11..=14 →
  stall → watermark 11 → 15).