### PR TITLE
feat: add db timeout for origins_after_round (like after_rounds)

### DIFF
--- a/crates/consensus/primary/src/certificate_fetcher.rs
+++ b/crates/consensus/primary/src/certificate_fetcher.rs
@@ -12,7 +12,7 @@ use rand::{rngs::ThreadRng, seq::SliceRandom};
 use rayls_consensus_primary_metrics::PrimaryMetrics;
 use rayls_infrastructure_config::ConsensusConfig;
 use rayls_infrastructure_network_types::FetchCertificatesResponse;
-use rayls_infrastructure_storage::CertificateStore;
+use rayls_infrastructure_storage::{CertificateStore, ReadTimeout};
 use rayls_infrastructure_types::{
     validate_received_certificate, AuthorityIdentifier, BlsPublicKey, Certificate, Committee,
     Database, Epoch, Hash as _, Noticer, RaylsReceiver, RaylsSender, Round, TaskManager,
@@ -390,7 +390,7 @@ impl<DB: Database> CertificateFetcher<DB> {
             written_rounds.insert(authority.id(), BTreeSet::new());
         }
         // NOTE: origins_after_round() is inclusive.
-        match self.certificate_store.origins_after_round(gc_round + 1) {
+        match self.certificate_store.origins_after_round(gc_round + 1, ReadTimeout::Exempt) {
             Ok(origins) => {
                 for (round, origins) in origins {
                     for origin in origins {

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -404,7 +404,7 @@ async fn test_certificate_store_after_round() {
 
     // WHEN get rounds per origin.
     let rounds = store
-        .origins_after_round(round_cutoff, rayls_infrastructure_types::ReadTimeout::Enforced)
+        .origins_after_round(round_cutoff, ReadTimeout::Enforced)
         .expect("Error returned while reading origins_after_round");
     assert_eq!(rounds.len(), (total_rounds - round_cutoff + 1) as usize);
     for origins in rounds.values() {

--- a/crates/consensus/primary/tests/it/storage_tests.rs
+++ b/crates/consensus/primary/tests/it/storage_tests.rs
@@ -404,7 +404,7 @@ async fn test_certificate_store_after_round() {
 
     // WHEN get rounds per origin.
     let rounds = store
-        .origins_after_round(round_cutoff)
+        .origins_after_round(round_cutoff, rayls_infrastructure_types::ReadTimeout::Enforced)
         .expect("Error returned while reading origins_after_round");
     assert_eq!(rounds.len(), (total_rounds - round_cutoff + 1) as usize);
     for origins in rounds.values() {

--- a/crates/infrastructure/storage/src/stores/certificate_store.rs
+++ b/crates/infrastructure/storage/src/stores/certificate_store.rs
@@ -81,9 +81,13 @@ pub trait CertificateStore {
     fn after_round(&self, round: Round, timeout: ReadTimeout) -> StoreResult<Vec<Certificate>>;
 
     /// Retrieves origins with certificates in each round >= the provided round.
+    ///
+    /// `timeout` controls whether this scan is subject to the read-transaction
+    /// timeout; recovery-path callers pass [`ReadTimeout::Exempt`].
     fn origins_after_round(
         &self,
         round: Round,
+        timeout: ReadTimeout,
     ) -> StoreResult<BTreeMap<Round, Vec<AuthorityIdentifier>>>;
 
     /// Retrieves the certificates of the last round and the round before that
@@ -286,10 +290,17 @@ impl<DB: Database> CertificateStore for DB {
     fn origins_after_round(
         &self,
         round: Round,
+        timeout: ReadTimeout,
     ) -> StoreResult<BTreeMap<Round, Vec<AuthorityIdentifier>>> {
         // Collect results within a properly scoped read transaction
         // to ensure MDBX can reclaim dirty pages after the iterator completes
         self.with_read_txn(|txn| {
+            if timeout == ReadTimeout::Exempt {
+                // Bounded recovery scan: opt out of the read-txn cap so a transient I/O
+                // stall can't force-reset the txn mid-recovery and silently truncate the
+                // origin set, causing the cert_fetcher to re-fetch certs it already has.
+                txn.disable_long_read_safety();
+            }
             // Skip to a row at or before the requested round.
             let iter = if round > 0 {
                 txn.skip_to::<CertificateDigestByRound>(&(


### PR DESCRIPTION
## Summary

- Add `ReadTimeout` parameter to `CertificateStore::origins_after_round()` so recovery-path callers can opt out of the read-transaction timeout cap.
- Pass `ReadTimeout::Exempt` in the `CertificateFetcher` garbage-collection scan to prevent transient I/O stalls from silently truncating the origin set and triggering redundant cert re-fetches.
- Update the `origins_after_round` integration test to explicitly pass `ReadTimeout::Enforced`.

Closes #

## Surface areas touched

- [x] Consensus protocol (primary / worker / network / state-sync)
- [x] Infrastructure (types / storage / config / network-cli)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [ ] Tests only

## Breaking / compatibility

The `CertificateStore::origins_after_round()` trait signature gains a `ReadTimeout` parameter. Any downstream implementors of `CertificateStore` must add the parameter. Internal callers are updated in this PR.

## Test plan

- [x] `cargo test -p rayls-consensus-primary -p rayls-infrastructure-storage --no-fail-fast` — 111 unit + 17 integration + 157 storage tests passed (2 ignored, 1 ignored in consensus).
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy -p rayls-consensus-primary -p rayls-infrastructure-storage -- -D warnings` — no errors in changed files (pre-existing `type_complexity` warnings in `mem_db.rs` are unrelated).
