### PR TITLE
chore: pin rust nightly

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -3,7 +3,7 @@ name: Nightly Fuzz
 # Runs the cargo-fuzz harnesses for Axyl protocol types. Each target runs for a
 # bounded wall-clock budget (libFuzzer -max_total_time). On a crash, the failing
 # input is uploaded as an artifact for local reproduction:
-#   cd crates/testing/fuzz-targets && cargo +nightly fuzz run <target> <artifact>
+#   cd crates/testing/fuzz-targets && cargo +nightly-2026-06-24 fuzz run <target> <artifact>
 #
 # Not part of PR checks: fuzzing is time-boxed exploration, not a pass/fail gate.
 
@@ -43,6 +43,7 @@ env:
   RUST_BACKTRACE: 1
   # Scheduled runs use a longer budget than the manual default.
   FUZZ_SECONDS: ${{ github.event.inputs.max_total_time || '300' }}
+  NIGHTLY: nightly-2026-06-24
 
 jobs:
   fuzz:
@@ -69,12 +70,12 @@ jobs:
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: nightly
+          toolchain: ${{ env.NIGHTLY }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: nightly-fuzz
+          shared-key: nightly-fuzz-${{ env.NIGHTLY }}
           workspaces: crates/testing/fuzz-targets/fuzz
           cache-on-failure: true
 
@@ -94,7 +95,7 @@ jobs:
           github.event.inputs.target == matrix.target
         working-directory: crates/testing/fuzz-targets
         run: |
-          cargo +nightly fuzz run ${{ matrix.target }} -- \
+          cargo +"$NIGHTLY" fuzz run ${{ matrix.target }} -- \
             -max_total_time=${{ env.FUZZ_SECONDS }} -print_final_stats=1
 
       - name: Upload crash artifacts

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,9 +48,7 @@ jobs:
       # rustfmt.toml uses nightly-only options (wrap_comments, comment_width,
       # format_code_in_doc_comments, doc_comment_code_block_width), so the check
       # must run on nightly rustfmt — stable would silently ignore them.
-      # The nightly is date-pinned because unstable-option behavior drifts
-      # between nightlies (keep in sync with the Makefile fmt target and
-      # rustfmt.toml); bump the pin together with a reformat commit.
+      # The nightly is date-pinned.
       - name: Install nightly rustfmt
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,12 @@ BASE_DIR:=$(shell basename $(ROOT_DIR))
 # Default tag is latest if not specified
 TAG ?= latest
 
-# Date-pinned nightly for rustfmt — unstable-option behavior drifts between
-# nightlies, so fmt must match CI (.github/workflows/pr.yaml fmt job).
-# Install with: rustup toolchain install $(FMT_NIGHTLY) --profile minimal --component rustfmt
-FMT_NIGHTLY := nightly-2026-06-24
+# Date-pinned nightly for every nightly-only tool (rustfmt, clippy --fix, udeps).
+# Unstable-option behavior drifts between nightlies, so this must match CI: the
+# fmt job in .github/workflows/pr.yaml and nightly-fuzz.yml, plus rustfmt.toml
+# and etc/test/test-and-attest.sh. Bump every pin together (reformat commit).
+# Install with: rustup toolchain install $(NIGHTLY) --profile minimal --component rustfmt,clippy
+NIGHTLY := nightly-2026-06-24
 
 help:
 	@echo ;
@@ -22,7 +24,7 @@ help:
 	@echo "make udeps" ;
 	@echo "    :::> Check unused dependencies in the entire project by package." ;
 	@echo "    :::> Dev needs 'cargo-udeps' installed." ;
-	@echo "    :::> Dev also needs rust nightly and protobuf (on mac). ";
+	@echo "    :::> Dev also needs rust $(NIGHTLY) and protobuf (on mac). ";
 	@echo "    :::> To install run: 'cargo install cargo-udeps --locked'." ;
 	@echo ;
 	@echo "make check" ;
@@ -38,10 +40,10 @@ help:
 	@echo "    :::> Test restart integration tests." ;
 	@echo ;
 	@echo "make fmt" ;
-	@echo "    :::> cargo +$(FMT_NIGHTLY) fmt (date-pinned to match the CI fmt check)" ;
+	@echo "    :::> cargo +$(NIGHTLY) fmt (date-pinned to match the CI fmt check)" ;
 	@echo ;
 	@echo "make clippy" ;
-	@echo "    :::> Cargo +nightly clippy for all features with fix enabled." ;
+	@echo "    :::> cargo +$(NIGHTLY) clippy for all features with fix enabled." ;
 	@echo ;
 	@echo "make docker-login" ;
 	@echo "    :::> Setup docker registry using gcloud artifacts." ;
@@ -74,7 +76,7 @@ attest:
 
 # check for unused dependencies
 udeps:
-	find . -type f -name Cargo.toml -exec sed -rne 's/^name = "(.*)"/\1/p' {} + | xargs -I {} sh -c "echo '\n\n{}:' && cargo +nightly udeps --package {}" ;
+	find . -type f -name Cargo.toml -exec sed -rne 's/^name = "(.*)"/\1/p' {} + | xargs -I {} sh -c "echo '\n\n{}:' && cargo +$(NIGHTLY) udeps --package {}" ;
 
 check:
 	cargo check --workspace --all-features --all-targets ;
@@ -93,11 +95,11 @@ test-restarts:
 
 # format using the pinned nightly toolchain (same as the CI fmt check)
 fmt:
-	cargo +$(FMT_NIGHTLY) fmt ;
+	cargo +$(NIGHTLY) fmt ;
 
-# clippy formatter + try to fix problems
+# clippy on the pinned nightly + try to fix problems
 clippy:
-	cargo +nightly clippy --workspace --all-features --fix ;
+	cargo +$(NIGHTLY) clippy --workspace --all-features --fix ;
 
 # login to gcloud artifact registry for managing docker images
 docker-login:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cd axyl
 cargo build --release
 ```
 
-The toolchain is pinned to Rust 1.91 via [`rust-toolchain.toml`](./rust-toolchain.toml). `make pr` runs the same fmt + clippy + test gate as CI (fmt and clippy require a nightly toolchain; fmt is date-pinned via the `FMT_NIGHTLY` variable in the [`Makefile`](./Makefile) to match the CI check); `make test` runs the test suite alone.
+The toolchain is pinned to Rust 1.91 via [`rust-toolchain.toml`](./rust-toolchain.toml). `make pr` runs the same fmt + clippy + test gate as CI (fmt and clippy run on the date-pinned nightly set by the `NIGHTLY` variable in the [`Makefile`](./Makefile) — the same nightly CI uses for the fmt check and fuzzing); `make test` runs the test suite alone.
 
 Documentation lives in [`doc/`](doc/):
 

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/batch_digest.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/batch_digest.rs
@@ -6,7 +6,7 @@
 //! - Two identical batches always produce the same digest (determinism)
 //! - Modifying any field changes the digest (collision resistance sanity check)
 //!
-//! Run: cargo +nightly fuzz run batch_digest
+//! Run: cargo +nightly-2026-06-24 fuzz run batch_digest
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/bcs_roundtrip.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/bcs_roundtrip.rs
@@ -5,7 +5,7 @@
 //! This catches inconsistencies in serde implementations that could
 //! cause validators to disagree on certificate/batch digests.
 //!
-//! Run: `cargo +nightly fuzz run bcs_roundtrip -- -max_total_time=300`
+//! Run: `cargo +nightly-2026-06-24 fuzz run bcs_roundtrip -- -max_total_time=300`
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/certificate_signed_by.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/certificate_signed_by.rs
@@ -12,7 +12,7 @@
 //! value of this target is panic-safety: `signed_by` must never crash on
 //! malformed bitmaps with out-of-range indices, gaps, or duplicates.
 //!
-//! Run: cargo +nightly fuzz run certificate_signed_by
+//! Run: cargo +nightly-2026-06-24 fuzz run certificate_signed_by
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/difficulty_field_encoding.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/difficulty_field_encoding.rs
@@ -19,7 +19,7 @@
 //! XOR section was removed: XORing two values derived from `difficulty` and then
 //! recovering them is a pure tautology that cannot fail.
 //!
-//! Run: cargo +nightly fuzz run difficulty_field_encoding
+//! Run: cargo +nightly-2026-06-24 fuzz run difficulty_field_encoding
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/header_digest_integrity.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/header_digest_integrity.rs
@@ -8,7 +8,7 @@
 //! This is critical because Header digests are certificate references in the
 //! DAG. A collision or inconsistency breaks consensus.
 //!
-//! Run: cargo +nightly fuzz run header_digest_integrity
+//! Run: cargo +nightly-2026-06-24 fuzz run header_digest_integrity
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/header_nonce_roundtrip.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/header_nonce_roundtrip.rs
@@ -8,7 +8,7 @@
 //! - the high 32 bits recover `epoch` and the low 32 bits recover `round`
 //!   (this is exactly what `RethEnv::deconstruct_nonce()` does on the EL side)
 //!
-//! Run: cargo +nightly fuzz run header_nonce_roundtrip
+//! Run: cargo +nightly-2026-06-24 fuzz run header_nonce_roundtrip
 
 #![no_main]
 use indexmap::IndexMap;

--- a/crates/testing/fuzz-targets/fuzz/fuzz_targets/quorum_threshold.rs
+++ b/crates/testing/fuzz-targets/fuzz/fuzz_targets/quorum_threshold.rs
@@ -13,7 +13,7 @@
 //! - Result is always > committee_members / 2 (majority)
 //! - Result is always <= committee_members (can't require more than exist)
 //!
-//! Run: cargo +nightly fuzz run quorum_threshold
+//! Run: cargo +nightly-2026-06-24 fuzz run quorum_threshold
 
 #![no_main]
 use libfuzzer_sys::fuzz_target;

--- a/docs/test-inventory.md
+++ b/docs/test-inventory.md
@@ -100,7 +100,7 @@ Network-fault scenarios require root / `CAP_NET_ADMIN` (they use `tc`/`netem` an
 
 ## 3. Fuzz targets (`fuzz-targets`) — 7
 
-`crates/testing/fuzz-targets/fuzz/fuzz_targets/`. Run with `cargo +nightly fuzz run <name>`.
+`crates/testing/fuzz-targets/fuzz/fuzz_targets/`. Run with `cargo +nightly-2026-06-24 fuzz run <name>` (the date-pinned nightly shared with the fmt check, see the Makefile `NIGHTLY` variable).
 
 | Target | Fuzzes |
 |---|---|

--- a/etc/test/test-and-attest.sh
+++ b/etc/test/test-and-attest.sh
@@ -61,8 +61,12 @@ if [ -n "$MODIFIED_TRACKED_FILES" ]; then
     exit 1
 fi
 
+# Date-pinned nightly for fmt/clippy — keep in sync with the Makefile NIGHTLY
+# variable and the fmt job in .github/workflows/pr.yaml.
+NIGHTLY="nightly-2026-06-24"
+
 # check cargo fmt first
-cargo +nightly-2025-11-04 fmt -- --check
+cargo +"${NIGHTLY}" fmt -- --check
 
 echo "fmt passed"
 
@@ -70,9 +74,9 @@ echo "fmt passed"
 # check clippy
 #
 # default features
-cargo +nightly-2025-11-04 clippy --workspace -- -D warnings
+cargo +"${NIGHTLY}" clippy --workspace -- -D warnings
 # all features
-cargo +nightly-2025-11-04 clippy --workspace --all-features -- -D warnings
+cargo +"${NIGHTLY}" clippy --workspace --all-features -- -D warnings
 
 echo "clippy for workspace: default and all features passed"
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 # This config uses nightly-only options whose behavior drifts between nightlies,
-# so formatting is pinned to nightly-2026-06-24 (see the Makefile FMT_NIGHTLY
+# so formatting is pinned to nightly-2026-06-24 (see the Makefile NIGHTLY
 # variable and the fmt job in .github/workflows/pr.yaml). Bump all pins together
 # with a reformat commit.
 


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

- Pin Rust Nightly version to eliminate drifts

Closes #

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [X] CI / build (`.github/workflows/`, `Makefile`)
- [X] Documentation only (`doc/`, in-crate READMEs, root docs)
- [X] Tests only
