### PR TITLE
fix: chain-id in e2e test

### DIFF
--- a/crates/testing/chaos-framework/src/cluster.rs
+++ b/crates/testing/chaos-framework/src/cluster.rs
@@ -372,6 +372,8 @@ fn e2e_tests_config_local_testnet(
         "1000",
         "--min-header-delay-ms",
         "500",
+        "--chain-id",
+        "487",
     ]);
     create_committee_command.args.execute(shared_genesis_dir.clone())?;
 

--- a/crates/testing/chaos-framework/src/fault/tx_spam.rs
+++ b/crates/testing/chaos-framework/src/fault/tx_spam.rs
@@ -56,7 +56,7 @@ pub fn spam_invalid_signatures(rpc_url: &str, count: usize) -> eyre::Result<Spam
 
 /// Generate and submit transactions with wrong chain ID.
 ///
-/// These should be rejected because chain ID doesn't match CHAIN_ID (0x7e1).
+/// These should be rejected because chain ID doesn't match the cluster's CHAIN_ID.
 pub fn spam_wrong_chain_id(rpc_url: &str, count: usize) -> eyre::Result<SpamResult> {
     info!(target: "chaos", count, "spamming wrong chain ID transactions");
     let mut result = SpamResult { submitted: 0, accepted: 0, rejected: 0 };
@@ -65,7 +65,7 @@ pub fn spam_wrong_chain_id(rpc_url: &str, count: usize) -> eyre::Result<SpamResu
     let to_account = rpc::address_from_word("spam-wrong-chain");
 
     for i in 0..count {
-        // Sign with wrong chain ID (0x1 = mainnet Ethereum instead of 0x7e1).
+        // Sign with wrong chain ID (0x1 = mainnet Ethereum instead of CHAIN_ID).
         result.submitted += 1;
         match send_tx_with_chain_id(rpc_url, &key, to_account, 1, i as u128) {
             Ok(_) => result.accepted += 1,

--- a/crates/testing/chaos-framework/src/lib.rs
+++ b/crates/testing/chaos-framework/src/lib.rs
@@ -15,5 +15,5 @@ pub mod rpc;
 pub mod scenario;
 pub mod verify;
 
-/// Axyl chain ID (0x7e1 = 2017).
-pub const CHAIN_ID: u64 = 0x7e1;
+/// Chain ID of the chaos cluster: the `local` network profile (487 = 0x1e7).
+pub const CHAIN_ID: u64 = rayls_infrastructure_types::RaylsNetwork::Local.chain_id();

--- a/crates/testing/chaos-framework/src/node.rs
+++ b/crates/testing/chaos-framework/src/node.rs
@@ -203,7 +203,9 @@ fn spawn_validator_process(
         .arg("--http.port")
         .arg(format!("{rpc_port}"))
         // v1 (plain) storage is no longer supported -- the node refuses to start without this
-        .arg("--storage.v2");
+        .arg("--storage.v2")
+        .arg("--network")
+        .arg("local");
 
     command.spawn().expect("failed to spawn validator process")
 }
@@ -235,7 +237,9 @@ fn spawn_observer_process(
         .arg("--http.port")
         .arg(format!("{rpc_port}"))
         // v1 (plain) storage is no longer supported -- the node refuses to start without this
-        .arg("--storage.v2");
+        .arg("--storage.v2")
+        .arg("--network")
+        .arg("local");
 
     command.spawn().expect("failed to spawn observer process")
 }

--- a/crates/testing/e2e-tests/src/lib.rs
+++ b/crates/testing/e2e-tests/src/lib.rs
@@ -164,8 +164,15 @@ pub fn spawn_local_testnet(
             faucet_contract_address,
         ]);
         #[cfg(not(feature = "faucet"))]
-        let command =
-            NodeCommand::parse_from(["rl", "--http", "--storage.v2", "--network", "local", "--instance", &instance]);
+        let command = NodeCommand::parse_from([
+            "rl",
+            "--http",
+            "--storage.v2",
+            "--network",
+            "local",
+            "--instance",
+            &instance,
+        ]);
 
         std::thread::spawn(|| {
             let err = command.execute(

--- a/crates/testing/e2e-tests/src/lib.rs
+++ b/crates/testing/e2e-tests/src/lib.rs
@@ -95,6 +95,8 @@ pub fn config_local_testnet(
         "1000",
         "--min-header-delay-ms",
         "500",
+        "--chain-id",
+        "487",
     ]);
     create_committee_command.args.execute(shared_genesis_dir.clone())?;
     // If provided optional accounts then hack them into genesis now...
@@ -153,6 +155,8 @@ pub fn spawn_local_testnet(
             "rl",
             "--http",
             "--storage.v2",
+            "--network",
+            "local",
             "--instance",
             &instance,
             "--google-kms",
@@ -161,7 +165,7 @@ pub fn spawn_local_testnet(
         ]);
         #[cfg(not(feature = "faucet"))]
         let command =
-            NodeCommand::parse_from(["rl", "--http", "--storage.v2", "--instance", &instance]);
+            NodeCommand::parse_from(["rl", "--http", "--storage.v2", "--network", "local", "--instance", &instance]);
 
         std::thread::spawn(|| {
             let err = command.execute(

--- a/crates/testing/e2e-tests/tests/it/epochs.rs
+++ b/crates/testing/e2e-tests/tests/it/epochs.rs
@@ -574,6 +574,8 @@ fn config_committee(
         "1000",
         "--min-header-delay-ms",
         "500",
+        "--chain-id",
+        "487",
     ]);
     create_committee_command.args.execute(shared_genesis_dir.to_path_buf())?;
 

--- a/crates/testing/e2e-tests/tests/it/restarts.rs
+++ b/crates/testing/e2e-tests/tests/it/restarts.rs
@@ -14,7 +14,7 @@ use nix::{
     unistd::Pid,
 };
 use rayls_infrastructure_types::{
-    get_available_tcp_port, keccak256, test_utils::init_test_tracing, Address,
+    get_available_tcp_port, keccak256, test_utils::init_test_tracing, Address, RaylsNetwork,
     MIN_RAYLS_PROTOCOL_BASE_FEE,
 };
 use secp256k1::{Keypair, Secp256k1, SecretKey};
@@ -953,8 +953,10 @@ fn send_rls(
     //const_hex::decode_to_slice(to_account, &mut to_addr[..])?;
     to_addr.copy_from_slice(to_account.as_slice());
     let (from_account, _, _) = decode_key(key)?;
+    // Must match the `--chain-id` passed to the genesis ceremony and the `--network local`
+    // the nodes boot with, or the RPC rejects the tx with "invalid chain ID".
     let new_transaction = LegacyTransaction {
-        chain: 0x7e1,
+        chain: RaylsNetwork::Local.chain_id(),
         nonce,
         to: Some(to_addr),
         value: amount,

--- a/crates/testing/e2e-tests/tests/it/restarts.rs
+++ b/crates/testing/e2e-tests/tests/it/restarts.rs
@@ -733,7 +733,9 @@ fn start_validator(
         .arg("--http.port")
         .arg(format!("{rpc_port}"))
         // v1 (plain) storage is no longer supported -- the node refuses to start without this
-        .arg("--storage.v2");
+        .arg("--storage.v2")
+        .arg("--network")
+        .arg("local");
 
     #[cfg(feature = "faucet")]
     command


### PR DESCRIPTION
<!--
Thanks for contributing to Axyl. A few notes before you file:

- Keep the PR focused. Smaller PRs review faster and revert cleanly.
- If the change is security-sensitive, see SECURITY.md instead.
- The CI runs `cargo fmt --check`, `cargo clippy`, and the workspace tests on every push.
-->

## Summary

<!-- 1–3 bullets describing what this PR changes and why. Link to the issue it closes or references. -->

- Fixes chain-id mismatch in e2e and chaos test fixtures after internal chain-id constant changed from 2017 to 487. Three locations generate genesis via `GenesisArgs` without specifying `--chain-id`, producing a genesis with chain-id 2017 that fails the datadir chain-id verification at node boot.
- Adds `--chain-id 487` to all three `GenesisArgs` CLI invocations and `--network local` to all node startup commands that use the generated datadirs, ensuring genesis and expected chain-id are consistent.

Closes #

## Surface areas touched

<!-- Tick everything that materially changes in this PR. Anything ticked here is a signal for release notes and reviewer routing. Leave unticked if untouched. -->

- [ ] Consensus protocol (primary / worker / network / state-sync)
- [ ] Execution / EVM
- [ ] JSON-RPC (`eth_*`, `rayls_*`, faucet)
- [ ] Middleware (orchestrator / processor / bridge)
- [ ] Infrastructure (types / storage / config / network-cli)
- [ ] On-chain contracts (`rayls-contracts/`)
- [ ] Operations (`etc/`, scripts, Docker, compose)
- [ ] CI / build (`.github/workflows/`, `Makefile`)
- [ ] Documentation only (`doc/`, in-crate READMEs, root docs)
- [x] Tests only

## Breaking / compatibility

<!-- Does this require a node restart, a network upgrade, a hardfork activation block, a contract migration, a config change, or any client coordination? If yes, describe. If no, write "None". -->

None.

## Test plan

<!-- What did you do to convince yourself this works? Commands, scenarios, or links to CI output. -->

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --all-features` — passes (no errors)
- [x] `cargo test -p e2e-tests --test it epochs::test_epoch_boundary -- --ignored --exact --test-threads 1` — passes
- [x] `cargo test -p e2e-tests --test it genesis_tests::test_genesis_with_precompiles` — passes
- [x] `cargo test -p e2e-tests --test it genesis_tests::test_precompile_genesis_accounts` — passes
- [x] `cargo check -p chaos-framework` — compiles